### PR TITLE
feat: split terminal panes with drag-to-resize

### DIFF
--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -6,11 +6,20 @@ import { spawn } from "tauri-pty";
 import type { IPty } from "tauri-pty";
 import "@xterm/xterm/css/xterm.css";
 import "../styles/terminal.css";
+import {
+  SplitPane,
+  collectLeafIds,
+  splitLeaf,
+  removeLeaf,
+  useSplitPaneShortcuts,
+} from "./TerminalSplitPane";
+import type { PaneNode } from "./TerminalSplitPane";
 
 interface TerminalTab {
   id: string;
   label: string;
   cwd: string;
+  paneTree: PaneNode;
 }
 
 interface TerminalPanelProps {
@@ -18,37 +27,52 @@ interface TerminalPanelProps {
   worktreeName: string;
 }
 
-let tabCounter = 0;
+let paneCounter = 0;
+
+function newPaneId(): string {
+  return `pane-${++paneCounter}`;
+}
+
+function makeTab(label: string, cwd: string): TerminalTab {
+  const paneId = newPaneId();
+  return {
+    id: paneId,
+    label,
+    cwd,
+    paneTree: { type: "leaf", id: paneId },
+  };
+}
 
 export function TerminalPanel({ cwd, worktreeName }: TerminalPanelProps) {
   const [tabs, setTabs] = useState<TerminalTab[]>(() => [
-    { id: `tab-${++tabCounter}`, label: worktreeName, cwd },
+    makeTab(worktreeName, cwd),
   ]);
   const [activeTabId, setActiveTabId] = useState(tabs[0].id);
+  const [focusedPaneId, setFocusedPaneId] = useState<string | null>(
+    tabs[0].paneTree.type === "leaf" ? tabs[0].paneTree.id : null,
+  );
 
   // When worktree changes, reset to a single tab for the new cwd
   const prevCwd = useRef(cwd);
   useEffect(() => {
     if (cwd !== prevCwd.current) {
       prevCwd.current = cwd;
-      const newTab = {
-        id: `tab-${++tabCounter}`,
-        label: worktreeName,
-        cwd,
-      };
+      const newTab = makeTab(worktreeName, cwd);
       setTabs([newTab]);
       setActiveTabId(newTab.id);
+      setFocusedPaneId(
+        newTab.paneTree.type === "leaf" ? newTab.paneTree.id : null,
+      );
     }
   }, [cwd, worktreeName]);
 
   const addTab = useCallback(() => {
-    const newTab: TerminalTab = {
-      id: `tab-${++tabCounter}`,
-      label: `Shell ${tabCounter}`,
-      cwd,
-    };
+    const newTab = makeTab(`Shell`, cwd);
     setTabs((prev) => [...prev, newTab]);
     setActiveTabId(newTab.id);
+    setFocusedPaneId(
+      newTab.paneTree.type === "leaf" ? newTab.paneTree.id : null,
+    );
   }, [cwd]);
 
   const closeTab = useCallback(
@@ -65,6 +89,73 @@ export function TerminalPanel({ cwd, worktreeName }: TerminalPanelProps) {
       });
     },
     [activeTabId],
+  );
+
+  const activeTab = tabs.find((t) => t.id === activeTabId);
+
+  const updatePaneTree = useCallback(
+    (newTree: PaneNode) => {
+      setTabs((prev) =>
+        prev.map((t) =>
+          t.id === activeTabId ? { ...t, paneTree: newTree } : t,
+        ),
+      );
+    },
+    [activeTabId],
+  );
+
+  // Split the focused pane
+  const handleSplitH = useCallback(() => {
+    if (!focusedPaneId || !activeTab) return;
+    const newId = newPaneId();
+    const newTree = splitLeaf(
+      activeTab.paneTree,
+      focusedPaneId,
+      "vertical",
+      newId,
+    );
+    updatePaneTree(newTree);
+    setFocusedPaneId(newId);
+  }, [focusedPaneId, activeTab, updatePaneTree]);
+
+  const handleSplitV = useCallback(() => {
+    if (!focusedPaneId || !activeTab) return;
+    const newId = newPaneId();
+    const newTree = splitLeaf(
+      activeTab.paneTree,
+      focusedPaneId,
+      "horizontal",
+      newId,
+    );
+    updatePaneTree(newTree);
+    setFocusedPaneId(newId);
+  }, [focusedPaneId, activeTab, updatePaneTree]);
+
+  // Close the focused pane (remove from tree)
+  const handleClosePane = useCallback(() => {
+    if (!focusedPaneId || !activeTab) return;
+    const leafIds = collectLeafIds(activeTab.paneTree);
+    if (leafIds.length <= 1) return; // Don't close the last pane
+    const newTree = removeLeaf(activeTab.paneTree, focusedPaneId);
+    if (newTree) {
+      updatePaneTree(newTree);
+      const remaining = collectLeafIds(newTree);
+      setFocusedPaneId(remaining[0] ?? null);
+    }
+  }, [focusedPaneId, activeTab, updatePaneTree]);
+
+  useSplitPaneShortcuts(handleSplitH, handleSplitV, handleClosePane);
+
+  const renderLeaf = useCallback(
+    (paneId: string, isFocused: boolean) => (
+      <TerminalInstance
+        key={paneId}
+        cwd={cwd}
+        active={activeTab?.id === activeTabId && isFocused}
+        visible={activeTab?.id === activeTabId}
+      />
+    ),
+    [cwd, activeTab, activeTabId],
   );
 
   return (
@@ -93,14 +184,41 @@ export function TerminalPanel({ cwd, worktreeName }: TerminalPanelProps) {
         <button className="terminal-tab-add" onClick={addTab} title="New tab">
           +
         </button>
+        {activeTab && collectLeafIds(activeTab.paneTree).length < 4 && (
+          <>
+            <button
+              className="terminal-tab-add"
+              onClick={handleSplitV}
+              title="Split vertically (⌘\)"
+            >
+              &#9783;
+            </button>
+            <button
+              className="terminal-tab-add"
+              onClick={handleSplitH}
+              title="Split horizontally (⌘⇧-)"
+            >
+              &#9776;
+            </button>
+          </>
+        )}
       </div>
       <div className="terminal-tab-content">
         {tabs.map((tab) => (
-          <TerminalInstance
+          <div
             key={tab.id}
-            cwd={tab.cwd}
-            active={tab.id === activeTabId}
-          />
+            className={`terminal-instance ${tab.id === activeTabId ? "terminal-instance-active" : ""}`}
+          >
+            {tab.id === activeTabId && activeTab ? (
+              <SplitPane
+                node={activeTab.paneTree}
+                onUpdateNode={updatePaneTree}
+                renderLeaf={renderLeaf}
+                focusedId={focusedPaneId}
+                onFocusLeaf={setFocusedPaneId}
+              />
+            ) : null}
+          </div>
         ))}
       </div>
     </div>
@@ -110,6 +228,7 @@ export function TerminalPanel({ cwd, worktreeName }: TerminalPanelProps) {
 interface TerminalInstanceProps {
   cwd: string;
   active: boolean;
+  visible?: boolean;
 }
 
 async function loadTerminalSettings(): Promise<{
@@ -134,7 +253,11 @@ async function loadTerminalSettings(): Promise<{
   }
 }
 
-function TerminalInstance({ cwd, active }: TerminalInstanceProps) {
+function TerminalInstance({
+  cwd,
+  active,
+  visible = true,
+}: TerminalInstanceProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const termRef = useRef<Terminal | null>(null);
   const ptyRef = useRef<IPty | null>(null);
@@ -256,24 +379,26 @@ function TerminalInstance({ cwd, active }: TerminalInstanceProps) {
     };
   }, [cwd]);
 
-  // Refit when becoming active
+  // Refit when becoming active or visible
   useEffect(() => {
-    if (!active || !fitAddonRef.current) return;
+    if (!visible || !fitAddonRef.current) return;
     const timer = setTimeout(() => {
       try {
         fitAddonRef.current?.fit();
       } catch {
         // ignore
       }
-      termRef.current?.focus();
+      if (active) {
+        termRef.current?.focus();
+      }
     }, 50);
     return () => clearTimeout(timer);
-  }, [active]);
+  }, [active, visible]);
 
   // Refit on window resize
   useEffect(() => {
     const handleResize = () => {
-      if (!active) return;
+      if (!visible) return;
       try {
         fitAddonRef.current?.fit();
       } catch {
@@ -282,13 +407,7 @@ function TerminalInstance({ cwd, active }: TerminalInstanceProps) {
     };
     window.addEventListener("resize", handleResize);
     return () => window.removeEventListener("resize", handleResize);
-  }, [active]);
+  }, [visible]);
 
-  return (
-    <div
-      className={`terminal-instance ${active ? "terminal-instance-active" : ""}`}
-    >
-      <div className="terminal-container" ref={containerRef} />
-    </div>
-  );
+  return <div className="terminal-container" ref={containerRef} />;
 }

--- a/src/components/TerminalSplitPane.tsx
+++ b/src/components/TerminalSplitPane.tsx
@@ -1,0 +1,236 @@
+import { useCallback, useRef, useEffect, type ReactNode } from "react";
+
+export type SplitDirection = "horizontal" | "vertical";
+
+export interface SplitNode {
+  type: "split";
+  direction: SplitDirection;
+  ratio: number; // 0-1, size of first child
+  first: PaneNode;
+  second: PaneNode;
+}
+
+export interface LeafNode {
+  type: "leaf";
+  id: string;
+}
+
+export type PaneNode = SplitNode | LeafNode;
+
+interface SplitPaneProps {
+  node: PaneNode;
+  onUpdateNode: (node: PaneNode) => void;
+  renderLeaf: (id: string, isFocused: boolean) => ReactNode;
+  focusedId: string | null;
+  onFocusLeaf: (id: string) => void;
+}
+
+const MIN_RATIO = 0.15;
+const MAX_RATIO = 0.85;
+
+export function SplitPane({
+  node,
+  onUpdateNode,
+  renderLeaf,
+  focusedId,
+  onFocusLeaf,
+}: SplitPaneProps) {
+  if (node.type === "leaf") {
+    return (
+      <div
+        className={`split-leaf ${focusedId === node.id ? "split-leaf-focused" : ""}`}
+        onClick={() => onFocusLeaf(node.id)}
+      >
+        {renderLeaf(node.id, focusedId === node.id)}
+      </div>
+    );
+  }
+
+  return (
+    <SplitContainer
+      direction={node.direction}
+      ratio={node.ratio}
+      onRatioChange={(ratio) => onUpdateNode({ ...node, ratio })}
+      first={
+        <SplitPane
+          node={node.first}
+          onUpdateNode={(first) => onUpdateNode({ ...node, first })}
+          renderLeaf={renderLeaf}
+          focusedId={focusedId}
+          onFocusLeaf={onFocusLeaf}
+        />
+      }
+      second={
+        <SplitPane
+          node={node.second}
+          onUpdateNode={(second) => onUpdateNode({ ...node, second })}
+          renderLeaf={renderLeaf}
+          focusedId={focusedId}
+          onFocusLeaf={onFocusLeaf}
+        />
+      }
+    />
+  );
+}
+
+interface SplitContainerProps {
+  direction: SplitDirection;
+  ratio: number;
+  onRatioChange: (ratio: number) => void;
+  first: ReactNode;
+  second: ReactNode;
+}
+
+function SplitContainer({
+  direction,
+  ratio,
+  onRatioChange,
+  first,
+  second,
+}: SplitContainerProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const dragging = useRef(false);
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      dragging.current = true;
+      const cursor = direction === "horizontal" ? "col-resize" : "row-resize";
+      document.body.style.cursor = cursor;
+      document.body.style.userSelect = "none";
+
+      const handleMouseMove = (ev: MouseEvent) => {
+        if (!dragging.current || !containerRef.current) return;
+        const rect = containerRef.current.getBoundingClientRect();
+        let newRatio: number;
+        if (direction === "horizontal") {
+          newRatio = (ev.clientX - rect.left) / rect.width;
+        } else {
+          newRatio = (ev.clientY - rect.top) / rect.height;
+        }
+        newRatio = Math.min(MAX_RATIO, Math.max(MIN_RATIO, newRatio));
+        onRatioChange(newRatio);
+      };
+
+      const handleMouseUp = () => {
+        dragging.current = false;
+        document.body.style.cursor = "";
+        document.body.style.userSelect = "";
+        document.removeEventListener("mousemove", handleMouseMove);
+        document.removeEventListener("mouseup", handleMouseUp);
+      };
+
+      document.addEventListener("mousemove", handleMouseMove);
+      document.addEventListener("mouseup", handleMouseUp);
+    },
+    [direction, onRatioChange],
+  );
+
+  const isHorizontal = direction === "horizontal";
+  const firstSize = `${ratio * 100}%`;
+  const secondSize = `${(1 - ratio) * 100}%`;
+
+  return (
+    <div
+      ref={containerRef}
+      className={`split-container ${isHorizontal ? "split-horizontal" : "split-vertical"}`}
+    >
+      <div
+        className="split-pane-child"
+        style={isHorizontal ? { width: firstSize } : { height: firstSize }}
+      >
+        {first}
+      </div>
+      <div
+        className={`split-divider ${isHorizontal ? "split-divider-h" : "split-divider-v"}`}
+        onMouseDown={handleMouseDown}
+      />
+      <div
+        className="split-pane-child"
+        style={isHorizontal ? { width: secondSize } : { height: secondSize }}
+      >
+        {second}
+      </div>
+    </div>
+  );
+}
+
+// Helper: collect all leaf IDs from a pane tree
+export function collectLeafIds(node: PaneNode): string[] {
+  if (node.type === "leaf") return [node.id];
+  return [...collectLeafIds(node.first), ...collectLeafIds(node.second)];
+}
+
+// Helper: split a leaf node into two
+export function splitLeaf(
+  root: PaneNode,
+  leafId: string,
+  direction: SplitDirection,
+  newLeafId: string,
+): PaneNode {
+  if (root.type === "leaf") {
+    if (root.id === leafId) {
+      return {
+        type: "split",
+        direction,
+        ratio: 0.5,
+        first: root,
+        second: { type: "leaf", id: newLeafId },
+      };
+    }
+    return root;
+  }
+  return {
+    ...root,
+    first: splitLeaf(root.first, leafId, direction, newLeafId),
+    second: splitLeaf(root.second, leafId, direction, newLeafId),
+  };
+}
+
+// Helper: remove a leaf and collapse the tree
+export function removeLeaf(root: PaneNode, leafId: string): PaneNode | null {
+  if (root.type === "leaf") {
+    return root.id === leafId ? null : root;
+  }
+
+  const newFirst = removeLeaf(root.first, leafId);
+  const newSecond = removeLeaf(root.second, leafId);
+
+  if (newFirst === null) return newSecond;
+  if (newSecond === null) return newFirst;
+
+  return { ...root, first: newFirst, second: newSecond };
+}
+
+// Hook for split pane keyboard shortcuts
+export function useSplitPaneShortcuts(
+  onSplitH: () => void,
+  onSplitV: () => void,
+  onClosePane?: () => void,
+) {
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      // Cmd+\ or Ctrl+\ = vertical split
+      if ((e.metaKey || e.ctrlKey) && e.key === "\\") {
+        e.preventDefault();
+        onSplitV();
+        return;
+      }
+      // Cmd+Shift+- = horizontal split
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === "-") {
+        e.preventDefault();
+        onSplitH();
+        return;
+      }
+      // Cmd+Shift+W = close focused pane
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === "W") {
+        e.preventDefault();
+        onClosePane?.();
+        return;
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown, true);
+    return () => document.removeEventListener("keydown", handleKeyDown, true);
+  }, [onSplitH, onSplitV, onClosePane]);
+}

--- a/src/styles/terminal.css
+++ b/src/styles/terminal.css
@@ -158,3 +158,66 @@
   scrollbar-width: thin;
   scrollbar-color: var(--border) transparent;
 }
+
+/* ==========================================================
+   Split Panes
+   ========================================================== */
+
+.split-container {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+}
+
+.split-horizontal {
+  flex-direction: row;
+}
+
+.split-vertical {
+  flex-direction: column;
+}
+
+.split-pane-child {
+  overflow: hidden;
+  min-width: 0;
+  min-height: 0;
+}
+
+.split-leaf {
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+}
+
+.split-leaf-focused {
+  box-shadow: inset 0 0 0 1px var(--accent-muted);
+}
+
+/* ── Dividers ── */
+
+.split-divider {
+  flex-shrink: 0;
+  background-color: var(--border-subtle);
+  transition: background-color 0.15s;
+  z-index: 2;
+}
+
+.split-divider:hover {
+  background-color: var(--accent);
+}
+
+.split-divider-h {
+  width: 3px;
+  cursor: col-resize;
+}
+
+.split-divider-v {
+  height: 3px;
+  cursor: row-resize;
+}


### PR DESCRIPTION
## Summary
- Split terminal tabs into multiple panes (vertical and horizontal)
- Recursive pane tree structure supports nested splits
- Drag dividers to resize panes with smooth interaction
- Focused pane highlighted with accent border glow
- Maximum 4 panes per tab to prevent excessive subdivision

## Keyboard Shortcuts
- **Cmd+\\** — Split vertically (side by side)
- **Cmd+Shift+-** — Split horizontally (top/bottom)
- **Cmd+Shift+W** — Close focused pane

## New Files
- `src/components/TerminalSplitPane.tsx` — Split pane tree renderer with drag resize
- Updated `src/components/TerminalPanel.tsx` — Tab-level pane tree management
- Updated `src/styles/terminal.css` — Split container and divider styles

## Test plan
- [ ] Open a terminal, press Cmd+\\ to split vertically
- [ ] Press Cmd+Shift+- to split horizontally
- [ ] Drag dividers to resize panes
- [ ] Click on different panes to focus them (accent border appears)
- [ ] Press Cmd+Shift+W to close focused pane
- [ ] Each pane runs an independent PTY session
- [ ] Split buttons visible in tab bar
- [ ] All CI checks pass