### PR TITLE
feat: command bookmarks and snippets

### DIFF
--- a/src-tauri/src/bookmarks.rs
+++ b/src-tauri/src/bookmarks.rs
@@ -1,0 +1,45 @@
+use crate::db::queries;
+use crate::db::AppDb;
+use tauri::State;
+
+#[tauri::command]
+pub fn create_bookmark(
+    db: State<'_, AppDb>,
+    project_id: Option<i64>,
+    label: String,
+    command: String,
+    tags: String,
+) -> Result<i64, String> {
+    let conn = db.0.lock().map_err(|e| format!("DB lock: {}", e))?;
+    queries::insert_bookmark(&conn, project_id, &label, &command, &tags)
+        .map_err(|e| format!("Failed to create bookmark: {}", e))
+}
+
+#[tauri::command]
+pub fn list_bookmarks(
+    db: State<'_, AppDb>,
+    project_id: Option<i64>,
+) -> Result<Vec<queries::BookmarkRow>, String> {
+    let conn = db.0.lock().map_err(|e| format!("DB lock: {}", e))?;
+    queries::list_bookmarks(&conn, project_id)
+        .map_err(|e| format!("Failed to list bookmarks: {}", e))
+}
+
+#[tauri::command]
+pub fn update_bookmark(
+    db: State<'_, AppDb>,
+    id: i64,
+    label: String,
+    command: String,
+    tags: String,
+) -> Result<(), String> {
+    let conn = db.0.lock().map_err(|e| format!("DB lock: {}", e))?;
+    queries::update_bookmark(&conn, id, &label, &command, &tags)
+        .map_err(|e| format!("Failed to update bookmark: {}", e))
+}
+
+#[tauri::command]
+pub fn delete_bookmark(db: State<'_, AppDb>, id: i64) -> Result<bool, String> {
+    let conn = db.0.lock().map_err(|e| format!("DB lock: {}", e))?;
+    queries::delete_bookmark(&conn, id).map_err(|e| format!("Failed to delete bookmark: {}", e))
+}

--- a/src-tauri/src/db/queries.rs
+++ b/src-tauri/src/db/queries.rs
@@ -790,6 +790,97 @@ pub fn update_env_var(
     Ok(())
 }
 
+// ============================================================
+// Command Bookmarks
+// ============================================================
+
+#[derive(Debug, Serialize)]
+pub struct BookmarkRow {
+    pub id: i64,
+    pub project_id: Option<i64>,
+    pub label: String,
+    pub command: String,
+    pub tags: String,
+    pub created_at: String,
+}
+
+pub fn insert_bookmark(
+    conn: &Connection,
+    project_id: Option<i64>,
+    label: &str,
+    command: &str,
+    tags: &str,
+) -> Result<i64, rusqlite::Error> {
+    conn.execute(
+        "INSERT INTO command_bookmarks (project_id, label, command, tags) VALUES (?1, ?2, ?3, ?4)",
+        params![project_id, label, command, tags],
+    )?;
+    Ok(conn.last_insert_rowid())
+}
+
+pub fn list_bookmarks(
+    conn: &Connection,
+    project_id: Option<i64>,
+) -> Result<Vec<BookmarkRow>, rusqlite::Error> {
+    // Return global bookmarks (project_id IS NULL) plus project-scoped ones
+    if let Some(pid) = project_id {
+        let mut stmt = conn.prepare(
+            "SELECT id, project_id, label, command, tags, created_at
+             FROM command_bookmarks
+             WHERE project_id IS NULL OR project_id = ?1
+             ORDER BY created_at DESC",
+        )?;
+        let rows = stmt.query_map(params![pid], |row| {
+            Ok(BookmarkRow {
+                id: row.get(0)?,
+                project_id: row.get(1)?,
+                label: row.get(2)?,
+                command: row.get(3)?,
+                tags: row.get(4)?,
+                created_at: row.get(5)?,
+            })
+        })?;
+        rows.collect()
+    } else {
+        let mut stmt = conn.prepare(
+            "SELECT id, project_id, label, command, tags, created_at
+             FROM command_bookmarks
+             WHERE project_id IS NULL
+             ORDER BY created_at DESC",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok(BookmarkRow {
+                id: row.get(0)?,
+                project_id: row.get(1)?,
+                label: row.get(2)?,
+                command: row.get(3)?,
+                tags: row.get(4)?,
+                created_at: row.get(5)?,
+            })
+        })?;
+        rows.collect()
+    }
+}
+
+pub fn update_bookmark(
+    conn: &Connection,
+    id: i64,
+    label: &str,
+    command: &str,
+    tags: &str,
+) -> Result<(), rusqlite::Error> {
+    conn.execute(
+        "UPDATE command_bookmarks SET label = ?1, command = ?2, tags = ?3 WHERE id = ?4",
+        params![label, command, tags, id],
+    )?;
+    Ok(())
+}
+
+pub fn delete_bookmark(conn: &Connection, id: i64) -> Result<bool, rusqlite::Error> {
+    let affected = conn.execute("DELETE FROM command_bookmarks WHERE id = ?1", params![id])?;
+    Ok(affected > 0)
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::init_test_db;
@@ -929,6 +1020,42 @@ mod tests {
         // Invalid category should fail
         let result = insert_memory_note(&conn, wid, "bad", "invalid_category");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn bookmark_crud() {
+        let conn = init_test_db();
+        let pid = insert_project(&conn, "test", "/tmp/test", None, None).unwrap();
+
+        // Insert global bookmark
+        let b1 = insert_bookmark(&conn, None, "List files", "ls -la", "fs,util").unwrap();
+        assert!(b1 > 0);
+
+        // Insert project-scoped bookmark
+        let b2 = insert_bookmark(&conn, Some(pid), "Run tests", "npm test", "test,npm").unwrap();
+        assert!(b2 > 0);
+
+        // List with project context: should see both global + project-scoped
+        let all = list_bookmarks(&conn, Some(pid)).unwrap();
+        assert_eq!(all.len(), 2);
+
+        // List without project: only global
+        let global = list_bookmarks(&conn, None).unwrap();
+        assert_eq!(global.len(), 1);
+        assert_eq!(global[0].label, "List files");
+
+        // Update
+        update_bookmark(&conn, b1, "List all files", "ls -lah", "fs,util").unwrap();
+        let updated = list_bookmarks(&conn, None).unwrap();
+        assert_eq!(updated[0].label, "List all files");
+        assert_eq!(updated[0].command, "ls -lah");
+
+        // Delete
+        let deleted = delete_bookmark(&conn, b1).unwrap();
+        assert!(deleted);
+        let remaining = list_bookmarks(&conn, Some(pid)).unwrap();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].label, "Run tests");
     }
 
     #[test]

--- a/src-tauri/src/db/schema.sql
+++ b/src-tauri/src/db/schema.sql
@@ -123,6 +123,15 @@ CREATE TABLE IF NOT EXISTS settings (
     value       TEXT NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS command_bookmarks (
+    id          INTEGER PRIMARY KEY,
+    project_id  INTEGER REFERENCES projects(id) ON DELETE CASCADE,
+    label       TEXT NOT NULL,
+    command     TEXT NOT NULL,
+    tags        TEXT NOT NULL DEFAULT '',
+    created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
 -- ============================================================
 -- Indexes
 -- ============================================================
@@ -142,6 +151,7 @@ CREATE INDEX IF NOT EXISTS idx_network_traffic_process_id ON network_traffic(pro
 CREATE INDEX IF NOT EXISTS idx_network_traffic_timestamp ON network_traffic(timestamp);
 CREATE INDEX IF NOT EXISTS idx_browser_events_timestamp ON browser_events(timestamp);
 CREATE INDEX IF NOT EXISTS idx_browser_events_type ON browser_events(event_type);
+CREATE INDEX IF NOT EXISTS idx_command_bookmarks_project_id ON command_bookmarks(project_id);
 
 -- ============================================================
 -- Ring Buffer Trigger: keep at most 50,000 log rows per process

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod bookmarks;
 pub mod browser;
 pub mod claudemd;
 pub mod db;
@@ -153,6 +154,10 @@ pub fn run() {
             settings::set_setting,
             settings::get_all_settings,
             settings::delete_setting,
+            bookmarks::create_bookmark,
+            bookmarks::list_bookmarks,
+            bookmarks::update_bookmark,
+            bookmarks::delete_bookmark,
         ])
         .setup(|app| {
             let app_handle = app.handle().clone();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { ActiveProjectBadge } from "./components/ActiveProjectBadge";
 import { SettingsTab } from "./components/SettingsTab";
 import { TerminalPanel } from "./components/TerminalPanel";
 import { CommandPalette } from "./components/CommandPalette";
+import { CommandBookmarks } from "./components/CommandBookmarks";
 import { useUiStore } from "./stores/uiStore";
 import {
   useCommandRegistry,
@@ -45,6 +46,7 @@ function AppContent() {
   } = useUiStore();
 
   const [paletteOpen, setPaletteOpen] = useState(false);
+  const [bookmarksOpen, setBookmarksOpen] = useState(false);
   const { register, execute, search } = useCommandRegistry();
 
   // Fetch projects and worktrees for quick switcher commands
@@ -147,6 +149,14 @@ function AppContent() {
           setSelectedWorktreeName(null);
         },
       },
+      {
+        id: "bookmarks:open",
+        label: "Command Bookmarks",
+        category: "Tools",
+        shortcut: "\u2318B",
+        icon: "\u2606",
+        action: () => setBookmarksOpen(true),
+      },
     ];
 
     // Add project switch commands
@@ -195,6 +205,7 @@ function AppContent() {
   const shortcuts = useMemo(
     () => [
       { key: "k", meta: true, action: () => setPaletteOpen((p) => !p) },
+      { key: "b", meta: true, action: () => setBookmarksOpen((p) => !p) },
       {
         key: ",",
         meta: true,
@@ -216,6 +227,7 @@ function AppContent() {
   useGlobalShortcuts(shortcuts);
 
   const handleClosePalette = useCallback(() => setPaletteOpen(false), []);
+  const handleCloseBookmarks = useCallback(() => setBookmarksOpen(false), []);
 
   return (
     <>
@@ -246,6 +258,12 @@ function AppContent() {
         onExecute={execute}
         search={search}
       />
+      {bookmarksOpen && (
+        <CommandBookmarks
+          projectId={selectedProjectId}
+          onClose={handleCloseBookmarks}
+        />
+      )}
     </>
   );
 }

--- a/src/components/CommandBookmarks.tsx
+++ b/src/components/CommandBookmarks.tsx
@@ -1,0 +1,402 @@
+import { useState, useEffect, useCallback } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import "../styles/command-bookmarks.css";
+
+interface Bookmark {
+  id: number;
+  project_id: number | null;
+  label: string;
+  command: string;
+  tags: string;
+  created_at: string;
+}
+
+interface CommandBookmarksProps {
+  projectId: number | null;
+  onInsertCommand?: (command: string) => void;
+  onClose: () => void;
+}
+
+export function CommandBookmarks({
+  projectId,
+  onInsertCommand,
+  onClose,
+}: CommandBookmarksProps) {
+  const [bookmarks, setBookmarks] = useState<Bookmark[]>([]);
+  const [filter, setFilter] = useState("");
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [showForm, setShowForm] = useState(false);
+  const [formLabel, setFormLabel] = useState("");
+  const [formCommand, setFormCommand] = useState("");
+  const [formTags, setFormTags] = useState("");
+  const [formGlobal, setFormGlobal] = useState(true);
+
+  const loadBookmarks = useCallback(async () => {
+    try {
+      const list = await invoke<Bookmark[]>("list_bookmarks", {
+        projectId,
+      });
+      setBookmarks(list);
+    } catch {
+      // ignore
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    loadBookmarks();
+  }, [loadBookmarks]);
+
+  const handleSave = useCallback(async () => {
+    const label = formLabel.trim();
+    const command = formCommand.trim();
+    if (!label || !command) return;
+
+    const tags = formTags.trim();
+    const pid = formGlobal ? null : projectId;
+
+    try {
+      if (editingId !== null) {
+        await invoke("update_bookmark", {
+          id: editingId,
+          label,
+          command,
+          tags,
+        });
+      } else {
+        await invoke("create_bookmark", {
+          projectId: pid,
+          label,
+          command,
+          tags,
+        });
+      }
+      setShowForm(false);
+      setEditingId(null);
+      setFormLabel("");
+      setFormCommand("");
+      setFormTags("");
+      setFormGlobal(true);
+      await loadBookmarks();
+    } catch {
+      // ignore
+    }
+  }, [
+    formLabel,
+    formCommand,
+    formTags,
+    formGlobal,
+    projectId,
+    editingId,
+    loadBookmarks,
+  ]);
+
+  const handleEdit = useCallback((b: Bookmark) => {
+    setEditingId(b.id);
+    setFormLabel(b.label);
+    setFormCommand(b.command);
+    setFormTags(b.tags);
+    setFormGlobal(b.project_id === null);
+    setShowForm(true);
+  }, []);
+
+  const handleDelete = useCallback(
+    async (id: number) => {
+      try {
+        await invoke("delete_bookmark", { id });
+        await loadBookmarks();
+      } catch {
+        // ignore
+      }
+    },
+    [loadBookmarks],
+  );
+
+  const handleInsert = useCallback(
+    (command: string) => {
+      onInsertCommand?.(command);
+      onClose();
+    },
+    [onInsertCommand, onClose],
+  );
+
+  const handleExport = useCallback(() => {
+    const data = JSON.stringify(bookmarks, null, 2);
+    const blob = new Blob([data], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "workroot-bookmarks.json";
+    a.click();
+    URL.revokeObjectURL(url);
+  }, [bookmarks]);
+
+  const handleImport = useCallback(async () => {
+    const input = document.createElement("input");
+    input.type = "file";
+    input.accept = ".json";
+    input.onchange = async () => {
+      const file = input.files?.[0];
+      if (!file) return;
+      try {
+        const text = await file.text();
+        const imported = JSON.parse(text) as Bookmark[];
+        for (const b of imported) {
+          await invoke("create_bookmark", {
+            projectId: b.project_id,
+            label: b.label,
+            command: b.command,
+            tags: b.tags || "",
+          });
+        }
+        await loadBookmarks();
+      } catch {
+        // ignore invalid JSON
+      }
+    };
+    input.click();
+  }, [loadBookmarks]);
+
+  const filtered = filter.trim()
+    ? bookmarks.filter((b) => {
+        const q = filter.toLowerCase();
+        return (
+          b.label.toLowerCase().includes(q) ||
+          b.command.toLowerCase().includes(q) ||
+          b.tags.toLowerCase().includes(q)
+        );
+      })
+    : bookmarks;
+
+  const globalBookmarks = filtered.filter((b) => b.project_id === null);
+  const projectBookmarks = filtered.filter((b) => b.project_id !== null);
+
+  return (
+    <div className="bookmarks-backdrop" onClick={onClose}>
+      <div className="bookmarks-panel" onClick={(e) => e.stopPropagation()}>
+        <div className="bookmarks-header">
+          <h3 className="bookmarks-title">Command Bookmarks</h3>
+          <div className="bookmarks-header-actions">
+            <button
+              className="bookmarks-action-btn"
+              onClick={handleImport}
+              title="Import bookmarks"
+            >
+              Import
+            </button>
+            <button
+              className="bookmarks-action-btn"
+              onClick={handleExport}
+              title="Export bookmarks"
+            >
+              Export
+            </button>
+            <button
+              className="bookmarks-action-btn bookmarks-action-primary"
+              onClick={() => {
+                setEditingId(null);
+                setFormLabel("");
+                setFormCommand("");
+                setFormTags("");
+                setFormGlobal(true);
+                setShowForm(true);
+              }}
+            >
+              + New
+            </button>
+            <button className="bookmarks-close" onClick={onClose}>
+              &times;
+            </button>
+          </div>
+        </div>
+
+        {showForm && (
+          <div className="bookmarks-form">
+            <input
+              className="bookmarks-form-input"
+              type="text"
+              placeholder="Label"
+              value={formLabel}
+              onChange={(e) => setFormLabel(e.target.value)}
+              autoFocus
+            />
+            <textarea
+              className="bookmarks-form-textarea"
+              placeholder="Command (e.g., npm run dev)"
+              value={formCommand}
+              onChange={(e) => setFormCommand(e.target.value)}
+              rows={2}
+            />
+            <input
+              className="bookmarks-form-input"
+              type="text"
+              placeholder="Tags (comma-separated)"
+              value={formTags}
+              onChange={(e) => setFormTags(e.target.value)}
+            />
+            <div className="bookmarks-form-row">
+              <label className="bookmarks-form-label">
+                <input
+                  type="checkbox"
+                  checked={formGlobal}
+                  onChange={(e) => setFormGlobal(e.target.checked)}
+                />
+                <span>Global (available in all projects)</span>
+              </label>
+              <div className="bookmarks-form-actions">
+                <button
+                  className="bookmarks-action-btn"
+                  onClick={() => {
+                    setShowForm(false);
+                    setEditingId(null);
+                  }}
+                >
+                  Cancel
+                </button>
+                <button
+                  className="bookmarks-action-btn bookmarks-action-primary"
+                  onClick={handleSave}
+                >
+                  {editingId !== null ? "Update" : "Save"}
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        <div className="bookmarks-search-wrap">
+          <input
+            className="bookmarks-search"
+            type="text"
+            placeholder="Filter bookmarks..."
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            spellCheck={false}
+          />
+        </div>
+
+        <div className="bookmarks-list">
+          {filtered.length === 0 ? (
+            <div className="bookmarks-empty">
+              {bookmarks.length === 0
+                ? "No bookmarks yet. Click + New to add one."
+                : "No matching bookmarks."}
+            </div>
+          ) : (
+            <>
+              {globalBookmarks.length > 0 && (
+                <div className="bookmarks-group">
+                  <div className="bookmarks-group-label">Global</div>
+                  {globalBookmarks.map((b) => (
+                    <BookmarkItem
+                      key={b.id}
+                      bookmark={b}
+                      onInsert={handleInsert}
+                      onEdit={handleEdit}
+                      onDelete={handleDelete}
+                    />
+                  ))}
+                </div>
+              )}
+              {projectBookmarks.length > 0 && (
+                <div className="bookmarks-group">
+                  <div className="bookmarks-group-label">Project</div>
+                  {projectBookmarks.map((b) => (
+                    <BookmarkItem
+                      key={b.id}
+                      bookmark={b}
+                      onInsert={handleInsert}
+                      onEdit={handleEdit}
+                      onDelete={handleDelete}
+                    />
+                  ))}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function BookmarkItem({
+  bookmark,
+  onInsert,
+  onEdit,
+  onDelete,
+}: {
+  bookmark: Bookmark;
+  onInsert: (cmd: string) => void;
+  onEdit: (b: Bookmark) => void;
+  onDelete: (id: number) => void;
+}) {
+  const tags = bookmark.tags
+    ? bookmark.tags.split(",").filter((t) => t.trim())
+    : [];
+
+  return (
+    <div className="bookmark-item">
+      <div
+        className="bookmark-item-main"
+        onClick={() => onInsert(bookmark.command)}
+        title="Click to insert into terminal"
+      >
+        <div className="bookmark-item-label">{bookmark.label}</div>
+        <code className="bookmark-item-command">{bookmark.command}</code>
+        {tags.length > 0 && (
+          <div className="bookmark-item-tags">
+            {tags.map((t) => (
+              <span key={t.trim()} className="bookmark-tag">
+                {t.trim()}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+      <div className="bookmark-item-actions">
+        <button
+          className="bookmark-btn-icon"
+          onClick={() => onEdit(bookmark)}
+          title="Edit"
+        >
+          <EditIcon />
+        </button>
+        <button
+          className="bookmark-btn-icon bookmark-btn-danger"
+          onClick={() => onDelete(bookmark.id)}
+          title="Delete"
+        >
+          <TrashIcon />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function EditIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+      <path
+        d="M10 2L12 4L5 11H3V9L10 2Z"
+        stroke="currentColor"
+        strokeWidth="1.2"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function TrashIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+      <path
+        d="M3 4H11L10.2 12H3.8L3 4Z"
+        stroke="currentColor"
+        strokeWidth="1.2"
+        strokeLinejoin="round"
+      />
+      <path d="M2 4H12" stroke="currentColor" strokeWidth="1.2" />
+      <path d="M5 4V2.5H9V4" stroke="currentColor" strokeWidth="1.2" />
+    </svg>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,7 @@ import "./styles/sidebar.css";
 import "./styles/env-panel.css";
 import "./styles/terminal.css";
 import "./styles/command-palette.css";
+import "./styles/command-bookmarks.css";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>

--- a/src/styles/command-bookmarks.css
+++ b/src/styles/command-bookmarks.css
@@ -1,0 +1,332 @@
+/* ==========================================================
+   Command Bookmarks Panel
+   ========================================================== */
+
+.bookmarks-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+  z-index: 9998;
+  animation: cmd-backdrop-in 0.12s ease-out;
+}
+
+.bookmarks-panel {
+  position: fixed;
+  top: 10%;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 580px;
+  max-width: calc(100vw - 40px);
+  max-height: 70vh;
+  background-color: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow:
+    0 24px 64px rgba(0, 0, 0, 0.6),
+    0 0 0 1px rgba(255, 255, 255, 0.04);
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  animation: cmd-palette-in 0.15s ease-out;
+}
+
+/* ── Header ── */
+
+.bookmarks-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px 10px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.bookmarks-title {
+  font-size: 0.88em;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.bookmarks-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.bookmarks-action-btn {
+  font-family: var(--font-sans);
+  font-size: 0.72em;
+  font-weight: 500;
+  color: var(--text-secondary);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 4px 10px;
+  cursor: pointer;
+  transition:
+    color 0.1s,
+    background-color 0.1s;
+}
+
+.bookmarks-action-btn:hover {
+  color: var(--text-primary);
+  background-color: var(--bg-hover);
+}
+
+.bookmarks-action-primary {
+  color: var(--bg-base);
+  background-color: var(--accent);
+  border-color: var(--accent);
+}
+
+.bookmarks-action-primary:hover {
+  background-color: var(--accent-hover);
+  color: var(--bg-base);
+}
+
+.bookmarks-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  font-size: 16px;
+  line-height: 1;
+  background: none;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: color 0.1s;
+}
+
+.bookmarks-close:hover {
+  color: var(--text-primary);
+}
+
+/* ── Form ── */
+
+.bookmarks-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border-subtle);
+  background-color: var(--bg-elevated);
+}
+
+.bookmarks-form-input,
+.bookmarks-form-textarea {
+  font-family: var(--font-mono);
+  font-size: 0.82em;
+  color: var(--text-primary);
+  background: var(--bg-base);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 6px 10px;
+  outline: none;
+  transition: border-color 0.15s;
+  resize: none;
+}
+
+.bookmarks-form-input:focus,
+.bookmarks-form-textarea:focus {
+  border-color: var(--accent);
+}
+
+.bookmarks-form-input::placeholder,
+.bookmarks-form-textarea::placeholder {
+  color: var(--text-muted);
+}
+
+.bookmarks-form-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.bookmarks-form-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.78em;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.bookmarks-form-label input[type="checkbox"] {
+  accent-color: var(--accent);
+}
+
+.bookmarks-form-actions {
+  display: flex;
+  gap: 6px;
+}
+
+/* ── Search ── */
+
+.bookmarks-search-wrap {
+  padding: 8px 16px;
+}
+
+.bookmarks-search {
+  width: 100%;
+  font-family: var(--font-sans);
+  font-size: 0.82em;
+  color: var(--text-primary);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  padding: 6px 10px;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.bookmarks-search:focus {
+  border-color: var(--accent);
+}
+
+.bookmarks-search::placeholder {
+  color: var(--text-muted);
+}
+
+/* ── List ── */
+
+.bookmarks-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px 10px 10px;
+  overscroll-behavior: contain;
+}
+
+.bookmarks-list::-webkit-scrollbar {
+  width: 5px;
+}
+
+.bookmarks-list::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.bookmarks-list::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 3px;
+}
+
+.bookmarks-empty {
+  padding: 24px 16px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.82em;
+}
+
+/* ── Groups ── */
+
+.bookmarks-group {
+  margin-bottom: 6px;
+}
+
+.bookmarks-group-label {
+  font-size: 0.68em;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  padding: 8px 6px 4px;
+}
+
+/* ── Bookmark items ── */
+
+.bookmark-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 8px;
+  border-radius: var(--radius-sm);
+  transition: background-color 0.1s;
+}
+
+.bookmark-item:hover {
+  background-color: var(--accent-muted);
+}
+
+.bookmark-item-main {
+  flex: 1;
+  min-width: 0;
+  cursor: pointer;
+}
+
+.bookmark-item-label {
+  font-size: 0.82em;
+  font-weight: 500;
+  color: var(--text-primary);
+  margin-bottom: 2px;
+}
+
+.bookmark-item-command {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 0.75em;
+  color: var(--accent);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.bookmark-item-tags {
+  display: flex;
+  gap: 4px;
+  margin-top: 4px;
+  flex-wrap: wrap;
+}
+
+.bookmark-tag {
+  font-size: 0.65em;
+  font-weight: 500;
+  color: var(--text-muted);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: 3px;
+  padding: 1px 6px;
+}
+
+.bookmark-item-actions {
+  display: flex;
+  gap: 2px;
+  flex-shrink: 0;
+  opacity: 0;
+  transition: opacity 0.1s;
+}
+
+.bookmark-item:hover .bookmark-item-actions {
+  opacity: 1;
+}
+
+.bookmark-btn-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  background: none;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition:
+    color 0.1s,
+    background-color 0.1s;
+}
+
+.bookmark-btn-icon:hover {
+  background-color: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.bookmark-btn-danger:hover {
+  color: var(--danger);
+}


### PR DESCRIPTION
## Summary
- Add `command_bookmarks` table with global and project-scoped bookmark support
- Backend: Rust CRUD commands (`create_bookmark`, `list_bookmarks`, `update_bookmark`, `delete_bookmark`) with full test coverage
- Frontend: `CommandBookmarks` panel accessible via **Cmd+B** or command palette
- Features: create/edit/delete bookmarks, tags, global vs project scope, filter/search, import/export as JSON
- Integrated into command palette as "Command Bookmarks" under Tools category

## Test plan
- [x] Rust tests pass (`cargo test` — 82 tests including new `bookmark_crud`)
- [x] TypeScript type check passes
- [x] ESLint passes
- [x] Prettier passes
- [x] Vitest passes
- [x] Clippy passes with `-D warnings`
- [x] `cargo fmt --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)