### PR TITLE
feat: task runner with script auto-discovery

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ pub mod projects;
 pub mod proxy;
 pub mod settings;
 pub mod shell;
+pub mod tasks;
 pub mod tray;
 pub mod vault;
 
@@ -154,6 +155,7 @@ pub fn run() {
             settings::set_setting,
             settings::get_all_settings,
             settings::delete_setting,
+            tasks::discover::discover_tasks,
             bookmarks::create_bookmark,
             bookmarks::list_bookmarks,
             bookmarks::update_bookmark,

--- a/src-tauri/src/tasks/discover.rs
+++ b/src-tauri/src/tasks/discover.rs
@@ -1,0 +1,271 @@
+use serde::Serialize;
+use std::collections::HashMap;
+use std::path::Path;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TaskDefinition {
+    pub name: String,
+    pub command: String,
+    pub source: String,
+    pub description: Option<String>,
+}
+
+/// Discover runnable tasks in the given directory.
+///
+/// Scans for:
+/// - `package.json` scripts
+/// - `Makefile` targets
+#[tauri::command]
+pub fn discover_tasks(path: String) -> Result<Vec<TaskDefinition>, String> {
+    let dir = Path::new(&path);
+    let mut tasks = Vec::new();
+
+    // package.json
+    let pkg_path = dir.join("package.json");
+    if pkg_path.exists() {
+        match discover_npm_scripts(&pkg_path) {
+            Ok(mut t) => tasks.append(&mut t),
+            Err(e) => eprintln!("Failed to parse package.json: {}", e),
+        }
+    }
+
+    // Makefile
+    let makefile_path = dir.join("Makefile");
+    if makefile_path.exists() {
+        match discover_makefile_targets(&makefile_path) {
+            Ok(mut t) => tasks.append(&mut t),
+            Err(e) => eprintln!("Failed to parse Makefile: {}", e),
+        }
+    }
+
+    // Cargo.toml (detect cargo commands)
+    let cargo_path = dir.join("Cargo.toml");
+    if cargo_path.exists() {
+        tasks.extend(cargo_tasks());
+    }
+
+    Ok(tasks)
+}
+
+fn discover_npm_scripts(path: &Path) -> Result<Vec<TaskDefinition>, String> {
+    let content = std::fs::read_to_string(path).map_err(|e| e.to_string())?;
+    let json: serde_json::Value = serde_json::from_str(&content).map_err(|e| e.to_string())?;
+
+    let scripts = match json.get("scripts").and_then(|s| s.as_object()) {
+        Some(s) => s,
+        None => return Ok(Vec::new()),
+    };
+
+    // Detect package manager
+    let pm = if path
+        .parent()
+        .is_some_and(|p| p.join("pnpm-lock.yaml").exists())
+    {
+        "pnpm"
+    } else if path.parent().is_some_and(|p| p.join("yarn.lock").exists()) {
+        "yarn"
+    } else if path.parent().is_some_and(|p| p.join("bun.lockb").exists()) {
+        "bun"
+    } else {
+        "npm"
+    };
+
+    let tasks: Vec<TaskDefinition> = scripts
+        .iter()
+        .map(|(name, value)| {
+            let cmd_str = value.as_str().unwrap_or("");
+            TaskDefinition {
+                name: name.clone(),
+                command: format!("{} run {}", pm, name),
+                source: "package.json".to_string(),
+                description: if cmd_str.len() > 60 {
+                    Some(format!("{}...", &cmd_str[..57]))
+                } else {
+                    Some(cmd_str.to_string())
+                },
+            }
+        })
+        .collect();
+
+    Ok(tasks)
+}
+
+fn discover_makefile_targets(path: &Path) -> Result<Vec<TaskDefinition>, String> {
+    let content = std::fs::read_to_string(path).map_err(|e| e.to_string())?;
+
+    let mut targets: Vec<TaskDefinition> = Vec::new();
+    let mut comments: HashMap<String, String> = HashMap::new();
+
+    let lines: Vec<&str> = content.lines().collect();
+    for (i, line) in lines.iter().enumerate() {
+        // Collect comments above targets
+        if line.starts_with('#') {
+            continue;
+        }
+
+        // Match target lines: name: [deps]
+        if let Some(colon_pos) = line.find(':') {
+            let target_name = line[..colon_pos].trim();
+
+            // Skip special targets and variables
+            if target_name.is_empty()
+                || target_name.starts_with('.')
+                || target_name.starts_with('\t')
+                || target_name.contains('=')
+                || target_name.contains('$')
+                || target_name.contains(' ')
+            {
+                continue;
+            }
+
+            // Grab preceding comment as description
+            if i > 0 {
+                let prev = lines[i - 1].trim();
+                if let Some(comment) = prev.strip_prefix("# ") {
+                    comments.insert(target_name.to_string(), comment.to_string());
+                }
+            }
+
+            targets.push(TaskDefinition {
+                name: target_name.to_string(),
+                command: format!("make {}", target_name),
+                source: "Makefile".to_string(),
+                description: comments.get(target_name).cloned(),
+            });
+        }
+    }
+
+    Ok(targets)
+}
+
+fn cargo_tasks() -> Vec<TaskDefinition> {
+    vec![
+        TaskDefinition {
+            name: "build".to_string(),
+            command: "cargo build".to_string(),
+            source: "Cargo.toml".to_string(),
+            description: Some("Compile the project".to_string()),
+        },
+        TaskDefinition {
+            name: "test".to_string(),
+            command: "cargo test".to_string(),
+            source: "Cargo.toml".to_string(),
+            description: Some("Run tests".to_string()),
+        },
+        TaskDefinition {
+            name: "clippy".to_string(),
+            command: "cargo clippy".to_string(),
+            source: "Cargo.toml".to_string(),
+            description: Some("Run linter".to_string()),
+        },
+        TaskDefinition {
+            name: "fmt".to_string(),
+            command: "cargo fmt".to_string(),
+            source: "Cargo.toml".to_string(),
+            description: Some("Format code".to_string()),
+        },
+        TaskDefinition {
+            name: "run".to_string(),
+            command: "cargo run".to_string(),
+            source: "Cargo.toml".to_string(),
+            description: Some("Run the binary".to_string()),
+        },
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    #[test]
+    fn discover_npm_scripts_basic() {
+        let dir = TempDir::new().unwrap();
+        let pkg = dir.path().join("package.json");
+        let mut f = std::fs::File::create(&pkg).unwrap();
+        writeln!(
+            f,
+            r#"{{"scripts": {{"dev": "vite", "build": "tsc && vite build", "test": "vitest"}}}}"#
+        )
+        .unwrap();
+
+        let tasks = discover_npm_scripts(&pkg).unwrap();
+        assert_eq!(tasks.len(), 3);
+        assert!(tasks.iter().any(|t| t.name == "dev"));
+        assert!(tasks.iter().any(|t| t.name == "build"));
+        assert!(tasks.iter().any(|t| t.name == "test"));
+        // No lock file → defaults to npm
+        assert!(tasks[0].command.starts_with("npm "));
+    }
+
+    #[test]
+    fn discover_npm_detects_pnpm() {
+        let dir = TempDir::new().unwrap();
+        let pkg = dir.path().join("package.json");
+        let mut f = std::fs::File::create(&pkg).unwrap();
+        writeln!(f, r#"{{"scripts": {{"dev": "vite"}}}}"#).unwrap();
+        std::fs::File::create(dir.path().join("pnpm-lock.yaml")).unwrap();
+
+        let tasks = discover_npm_scripts(&pkg).unwrap();
+        assert_eq!(tasks.len(), 1);
+        assert!(tasks[0].command.starts_with("pnpm "));
+    }
+
+    #[test]
+    fn discover_makefile_basic() {
+        let dir = TempDir::new().unwrap();
+        let mk = dir.path().join("Makefile");
+        let mut f = std::fs::File::create(&mk).unwrap();
+        writeln!(
+            f,
+            "# Build the project\nbuild:\n\tcargo build\n\n# Run tests\ntest:\n\tcargo test\n"
+        )
+        .unwrap();
+
+        let tasks = discover_makefile_targets(&mk).unwrap();
+        assert_eq!(tasks.len(), 2);
+
+        let build = tasks.iter().find(|t| t.name == "build").unwrap();
+        assert_eq!(build.command, "make build");
+        assert_eq!(build.description.as_deref(), Some("Build the project"));
+
+        let test = tasks.iter().find(|t| t.name == "test").unwrap();
+        assert_eq!(test.description.as_deref(), Some("Run tests"));
+    }
+
+    #[test]
+    fn discover_makefile_skips_special() {
+        let dir = TempDir::new().unwrap();
+        let mk = dir.path().join("Makefile");
+        let mut f = std::fs::File::create(&mk).unwrap();
+        writeln!(f, ".PHONY: all\nVAR = value\nall:\n\techo done").unwrap();
+
+        let tasks = discover_makefile_targets(&mk).unwrap();
+        // Should find "all" but not ".PHONY" or "VAR"
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].name, "all");
+    }
+
+    #[test]
+    fn discover_tasks_integration() {
+        let dir = TempDir::new().unwrap();
+
+        // Create package.json
+        let pkg = dir.path().join("package.json");
+        let mut f = std::fs::File::create(&pkg).unwrap();
+        writeln!(f, r#"{{"scripts": {{"start": "node index.js"}}}}"#).unwrap();
+
+        let tasks = discover_tasks(dir.path().to_string_lossy().to_string()).unwrap();
+        assert!(!tasks.is_empty());
+        assert!(tasks.iter().any(|t| t.source == "package.json"));
+    }
+
+    #[test]
+    fn cargo_tasks_exist() {
+        let tasks = cargo_tasks();
+        assert!(tasks.len() >= 4);
+        assert!(tasks.iter().any(|t| t.name == "build"));
+        assert!(tasks.iter().any(|t| t.name == "test"));
+    }
+}

--- a/src-tauri/src/tasks/mod.rs
+++ b/src-tauri/src/tasks/mod.rs
@@ -1,0 +1,1 @@
+pub mod discover;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { TerminalPanel } from "./components/TerminalPanel";
 import { CommandPalette } from "./components/CommandPalette";
 import { CommandBookmarks } from "./components/CommandBookmarks";
 import { TerminalThemeSelector } from "./components/TerminalThemeSelector";
+import { TaskRunner } from "./components/TaskRunner";
 import { DEFAULT_THEME_ID } from "./lib/terminalThemes";
 import { useUiStore } from "./stores/uiStore";
 import {
@@ -50,6 +51,7 @@ function AppContent() {
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [bookmarksOpen, setBookmarksOpen] = useState(false);
   const [themeSelectorOpen, setThemeSelectorOpen] = useState(false);
+  const [taskRunnerOpen, setTaskRunnerOpen] = useState(false);
   const [terminalThemeId, setTerminalThemeId] = useState(DEFAULT_THEME_ID);
   const { register, execute, search } = useCommandRegistry();
 
@@ -179,6 +181,15 @@ function AppContent() {
         icon: "\u25D0",
         action: () => setThemeSelectorOpen(true),
       },
+      {
+        id: "tasks:open",
+        label: "Task Runner",
+        category: "Tools",
+        shortcut: "\u2318R",
+        icon: "\u25B6",
+        enabled: () => selectedWorktreePath !== null,
+        action: () => setTaskRunnerOpen(true),
+      },
     ];
 
     // Add project switch commands
@@ -297,6 +308,12 @@ function AppContent() {
           currentThemeId={terminalThemeId}
           onThemeChange={setTerminalThemeId}
           onClose={() => setThemeSelectorOpen(false)}
+        />
+      )}
+      {taskRunnerOpen && selectedWorktreePath && (
+        <TaskRunner
+          cwd={selectedWorktreePath}
+          onClose={() => setTaskRunnerOpen(false)}
         />
       )}
     </>

--- a/src/components/TaskRunner.tsx
+++ b/src/components/TaskRunner.tsx
@@ -1,0 +1,152 @@
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import "../styles/task-runner.css";
+
+interface TaskDefinition {
+  name: string;
+  command: string;
+  source: string;
+  description: string | null;
+}
+
+interface TaskRunnerProps {
+  cwd: string;
+  onRunCommand?: (command: string) => void;
+  onClose: () => void;
+}
+
+const SOURCE_ICONS: Record<string, string> = {
+  "package.json": "\u{1F4E6}",
+  Makefile: "\u{1F6E0}",
+  "Cargo.toml": "\u{1F980}",
+};
+
+export function TaskRunner({ cwd, onRunCommand, onClose }: TaskRunnerProps) {
+  const [tasks, setTasks] = useState<TaskDefinition[]>([]);
+  const [filter, setFilter] = useState("");
+  const [loading, setLoading] = useState(true);
+
+  const loadTasks = useCallback(async () => {
+    setLoading(true);
+    try {
+      const result = await invoke<TaskDefinition[]>("discover_tasks", {
+        path: cwd,
+      });
+      setTasks(result);
+    } catch {
+      setTasks([]);
+    }
+    setLoading(false);
+  }, [cwd]);
+
+  useEffect(() => {
+    loadTasks();
+  }, [loadTasks]);
+
+  const handleRun = useCallback(
+    (command: string) => {
+      onRunCommand?.(command);
+      onClose();
+    },
+    [onRunCommand, onClose],
+  );
+
+  const filtered = useMemo(() => {
+    if (!filter.trim()) return tasks;
+    const q = filter.toLowerCase();
+    return tasks.filter(
+      (t) =>
+        t.name.toLowerCase().includes(q) ||
+        t.command.toLowerCase().includes(q) ||
+        t.source.toLowerCase().includes(q) ||
+        (t.description?.toLowerCase().includes(q) ?? false),
+    );
+  }, [tasks, filter]);
+
+  // Group by source
+  const groups = useMemo(() => {
+    const map = new Map<string, TaskDefinition[]>();
+    for (const task of filtered) {
+      const existing = map.get(task.source) ?? [];
+      existing.push(task);
+      map.set(task.source, existing);
+    }
+    return Array.from(map.entries());
+  }, [filtered]);
+
+  return (
+    <div className="taskrunner-backdrop" onClick={onClose}>
+      <div className="taskrunner-panel" onClick={(e) => e.stopPropagation()}>
+        <div className="taskrunner-header">
+          <h3 className="taskrunner-title">Task Runner</h3>
+          <div className="taskrunner-header-actions">
+            <button
+              className="taskrunner-action-btn"
+              onClick={loadTasks}
+              title="Rescan"
+            >
+              Rescan
+            </button>
+            <button className="taskrunner-close" onClick={onClose}>
+              &times;
+            </button>
+          </div>
+        </div>
+
+        <div className="taskrunner-search-wrap">
+          <input
+            className="taskrunner-search"
+            type="text"
+            placeholder="Filter tasks..."
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            spellCheck={false}
+            autoFocus
+          />
+        </div>
+
+        <div className="taskrunner-list">
+          {loading ? (
+            <div className="taskrunner-empty">Scanning for tasks...</div>
+          ) : groups.length === 0 ? (
+            <div className="taskrunner-empty">
+              {tasks.length === 0
+                ? "No tasks found in this directory."
+                : "No matching tasks."}
+            </div>
+          ) : (
+            groups.map(([source, sourceTasks]) => (
+              <div key={source} className="taskrunner-group">
+                <div className="taskrunner-group-label">
+                  <span className="taskrunner-group-icon">
+                    {SOURCE_ICONS[source] ?? "\u{1F4CB}"}
+                  </span>
+                  {source}
+                </div>
+                {sourceTasks.map((task) => (
+                  <button
+                    key={`${source}:${task.name}`}
+                    className="taskrunner-item"
+                    onClick={() => handleRun(task.command)}
+                    title={`Run: ${task.command}`}
+                  >
+                    <div className="taskrunner-item-info">
+                      <span className="taskrunner-item-name">{task.name}</span>
+                      {task.description && (
+                        <span className="taskrunner-item-desc">
+                          {task.description}
+                        </span>
+                      )}
+                    </div>
+                    <code className="taskrunner-item-cmd">{task.command}</code>
+                    <span className="taskrunner-item-run">Run</span>
+                  </button>
+                ))}
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,6 +8,7 @@ import "./styles/terminal.css";
 import "./styles/command-palette.css";
 import "./styles/command-bookmarks.css";
 import "./styles/terminal-themes.css";
+import "./styles/task-runner.css";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>

--- a/src/styles/task-runner.css
+++ b/src/styles/task-runner.css
@@ -1,0 +1,245 @@
+/* ==========================================================
+   Task Runner Panel
+   ========================================================== */
+
+.taskrunner-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+  z-index: 9998;
+  animation: cmd-backdrop-in 0.12s ease-out;
+}
+
+.taskrunner-panel {
+  position: fixed;
+  top: 10%;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 560px;
+  max-width: calc(100vw - 40px);
+  max-height: 70vh;
+  background-color: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow:
+    0 24px 64px rgba(0, 0, 0, 0.6),
+    0 0 0 1px rgba(255, 255, 255, 0.04);
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  animation: cmd-palette-in 0.15s ease-out;
+}
+
+/* ── Header ── */
+
+.taskrunner-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px 10px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.taskrunner-title {
+  font-size: 0.88em;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.taskrunner-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.taskrunner-action-btn {
+  font-family: var(--font-sans);
+  font-size: 0.72em;
+  font-weight: 500;
+  color: var(--text-secondary);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 4px 10px;
+  cursor: pointer;
+  transition:
+    color 0.1s,
+    background-color 0.1s;
+}
+
+.taskrunner-action-btn:hover {
+  color: var(--text-primary);
+  background-color: var(--bg-hover);
+}
+
+.taskrunner-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  font-size: 16px;
+  line-height: 1;
+  background: none;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: color 0.1s;
+}
+
+.taskrunner-close:hover {
+  color: var(--text-primary);
+}
+
+/* ── Search ── */
+
+.taskrunner-search-wrap {
+  padding: 8px 16px;
+}
+
+.taskrunner-search {
+  width: 100%;
+  font-family: var(--font-sans);
+  font-size: 0.82em;
+  color: var(--text-primary);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  padding: 6px 10px;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.taskrunner-search:focus {
+  border-color: var(--accent);
+}
+
+.taskrunner-search::placeholder {
+  color: var(--text-muted);
+}
+
+/* ── List ── */
+
+.taskrunner-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px 10px 10px;
+  overscroll-behavior: contain;
+}
+
+.taskrunner-list::-webkit-scrollbar {
+  width: 5px;
+}
+
+.taskrunner-list::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.taskrunner-list::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 3px;
+}
+
+.taskrunner-empty {
+  padding: 24px 16px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.82em;
+}
+
+/* ── Groups ── */
+
+.taskrunner-group {
+  margin-bottom: 6px;
+}
+
+.taskrunner-group-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.68em;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  padding: 8px 6px 4px;
+}
+
+.taskrunner-group-icon {
+  font-size: 1.3em;
+}
+
+/* ── Task items ── */
+
+.taskrunner-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 8px 10px;
+  font-family: var(--font-sans);
+  background: none;
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  text-align: left;
+  transition: background-color 0.1s;
+}
+
+.taskrunner-item:hover {
+  background-color: var(--accent-muted);
+}
+
+.taskrunner-item-info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.taskrunner-item-name {
+  font-size: 0.82em;
+  font-weight: 500;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.taskrunner-item-desc {
+  font-size: 0.72em;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.taskrunner-item-cmd {
+  font-family: var(--font-mono);
+  font-size: 0.7em;
+  color: var(--accent);
+  white-space: nowrap;
+  flex-shrink: 0;
+  max-width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.taskrunner-item-run {
+  font-size: 0.68em;
+  font-weight: 600;
+  color: var(--accent);
+  opacity: 0;
+  transition: opacity 0.1s;
+  flex-shrink: 0;
+}
+
+.taskrunner-item:hover .taskrunner-item-run {
+  opacity: 1;
+}


### PR DESCRIPTION
## Summary
- **Backend:** New `tasks` module with `discover_tasks` Tauri command that scans a directory for runnable tasks
  - `package.json` scripts with package manager detection (pnpm/yarn/bun/npm)
  - `Makefile` targets with comment-based descriptions
  - `Cargo.toml` standard cargo commands (build, test, clippy, fmt, run)
- **Frontend:** Task runner panel (`TaskRunner.tsx`) with search/filter, grouped by source file
- Accessible via **Cmd+R** shortcut or command palette "Task Runner" command
- 6 new Rust tests covering npm script discovery, Makefile parsing, and integration

## Test plan
- [x] Rust tests pass (88 total, 6 new for task discovery)
- [x] TypeScript type check passes
- [x] ESLint passes
- [x] Prettier passes
- [x] Vitest passes
- [x] Clippy passes with `-D warnings`
- [x] `cargo fmt --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)