### PR TITLE
feat: keyboard shortcuts help panel

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { CommandBookmarks } from "./components/CommandBookmarks";
 import { TerminalThemeSelector } from "./components/TerminalThemeSelector";
 import { TaskRunner } from "./components/TaskRunner";
 import { AppThemePicker } from "./components/AppThemePicker";
+import { KeyboardShortcuts } from "./components/KeyboardShortcuts";
 import { DEFAULT_THEME_ID } from "./lib/terminalThemes";
 import { getAppThemeById } from "./themes/builtin";
 import { applyTheme, loadSavedThemeId } from "./themes/engine";
@@ -56,6 +57,7 @@ function AppContent() {
   const [themeSelectorOpen, setThemeSelectorOpen] = useState(false);
   const [taskRunnerOpen, setTaskRunnerOpen] = useState(false);
   const [appThemePickerOpen, setAppThemePickerOpen] = useState(false);
+  const [shortcutsOpen, setShortcutsOpen] = useState(false);
   const [appThemeId, setAppThemeId] = useState("midnight");
   const [terminalThemeId, setTerminalThemeId] = useState(DEFAULT_THEME_ID);
   const { register, execute, search } = useCommandRegistry();
@@ -198,6 +200,14 @@ function AppContent() {
         action: () => setThemeSelectorOpen(true),
       },
       {
+        id: "shortcuts:open",
+        label: "Keyboard Shortcuts",
+        category: "Help",
+        shortcut: "\u2318?",
+        icon: "\u2328",
+        action: () => setShortcutsOpen(true),
+      },
+      {
         id: "tasks:open",
         label: "Task Runner",
         category: "Tools",
@@ -259,6 +269,12 @@ function AppContent() {
         key: "t",
         meta: true,
         action: () => setThemeSelectorOpen((p) => !p),
+      },
+      {
+        key: "/",
+        meta: true,
+        shift: true,
+        action: () => setShortcutsOpen((p) => !p),
       },
       {
         key: ",",
@@ -338,6 +354,9 @@ function AppContent() {
           onThemeChange={setAppThemeId}
           onClose={() => setAppThemePickerOpen(false)}
         />
+      )}
+      {shortcutsOpen && (
+        <KeyboardShortcuts onClose={() => setShortcutsOpen(false)} />
       )}
     </>
   );

--- a/src/components/KeyboardShortcuts.tsx
+++ b/src/components/KeyboardShortcuts.tsx
@@ -1,0 +1,80 @@
+import "../styles/keyboard-shortcuts.css";
+
+interface ShortcutGroup {
+  label: string;
+  shortcuts: Array<{
+    keys: string[];
+    description: string;
+  }>;
+}
+
+const SHORTCUT_GROUPS: ShortcutGroup[] = [
+  {
+    label: "General",
+    shortcuts: [
+      { keys: ["\u2318", "K"], description: "Open command palette" },
+      { keys: ["\u2318", ","], description: "Open settings" },
+      { keys: ["\u2318", "B"], description: "Command bookmarks" },
+      { keys: ["\u2318", "T"], description: "Terminal theme selector" },
+      { keys: ["\u2318", "R"], description: "Task runner" },
+      { keys: ["\u2318", "?"], description: "Keyboard shortcuts" },
+    ],
+  },
+  {
+    label: "Terminal",
+    shortcuts: [
+      { keys: ["\u2318", "\\"], description: "Split pane vertically" },
+      {
+        keys: ["\u2318", "\u21E7", "-"],
+        description: "Split pane horizontally",
+      },
+      { keys: ["\u2318", "\u21E7", "W"], description: "Close active pane" },
+    ],
+  },
+  {
+    label: "Navigation",
+    shortcuts: [
+      { keys: ["Esc"], description: "Close current panel" },
+      { keys: ["\u2191", "\u2193"], description: "Navigate items" },
+      { keys: ["Enter"], description: "Select / confirm" },
+    ],
+  },
+];
+
+interface KeyboardShortcutsProps {
+  onClose: () => void;
+}
+
+export function KeyboardShortcuts({ onClose }: KeyboardShortcutsProps) {
+  return (
+    <div className="shortcuts-backdrop" onClick={onClose}>
+      <div className="shortcuts-panel" onClick={(e) => e.stopPropagation()}>
+        <div className="shortcuts-header">
+          <h3 className="shortcuts-title">Keyboard Shortcuts</h3>
+          <button className="shortcuts-close" onClick={onClose}>
+            &times;
+          </button>
+        </div>
+        <div className="shortcuts-body">
+          {SHORTCUT_GROUPS.map((group) => (
+            <div key={group.label} className="shortcuts-group">
+              <div className="shortcuts-group-label">{group.label}</div>
+              {group.shortcuts.map((shortcut) => (
+                <div key={shortcut.description} className="shortcuts-row">
+                  <span className="shortcuts-desc">{shortcut.description}</span>
+                  <span className="shortcuts-keys">
+                    {shortcut.keys.map((key, i) => (
+                      <kbd key={i} className="shortcuts-kbd">
+                        {key}
+                      </kbd>
+                    ))}
+                  </span>
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,6 +10,7 @@ import "./styles/command-bookmarks.css";
 import "./styles/terminal-themes.css";
 import "./styles/task-runner.css";
 import "./styles/app-theme-picker.css";
+import "./styles/keyboard-shortcuts.css";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>

--- a/src/styles/keyboard-shortcuts.css
+++ b/src/styles/keyboard-shortcuts.css
@@ -1,0 +1,142 @@
+/* ==========================================================
+   Keyboard Shortcuts Help
+   ========================================================== */
+
+.shortcuts-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+  z-index: 9998;
+  animation: cmd-backdrop-in 0.12s ease-out;
+}
+
+.shortcuts-panel {
+  position: fixed;
+  top: 15%;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 440px;
+  max-width: calc(100vw - 40px);
+  max-height: 65vh;
+  background-color: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow:
+    0 24px 64px rgba(0, 0, 0, 0.6),
+    0 0 0 1px rgba(255, 255, 255, 0.04);
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  animation: cmd-palette-in 0.15s ease-out;
+}
+
+.shortcuts-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px 10px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.shortcuts-title {
+  font-size: 0.88em;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.shortcuts-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  font-size: 16px;
+  line-height: 1;
+  background: none;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: color 0.1s;
+}
+
+.shortcuts-close:hover {
+  color: var(--text-primary);
+}
+
+.shortcuts-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px 16px 16px;
+  overscroll-behavior: contain;
+}
+
+.shortcuts-body::-webkit-scrollbar {
+  width: 5px;
+}
+
+.shortcuts-body::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.shortcuts-body::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 3px;
+}
+
+/* ── Groups ── */
+
+.shortcuts-group {
+  margin-bottom: 12px;
+}
+
+.shortcuts-group-label {
+  font-size: 0.68em;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  padding: 8px 0 4px;
+}
+
+/* ── Rows ── */
+
+.shortcuts-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 5px 0;
+}
+
+.shortcuts-desc {
+  font-size: 0.8em;
+  color: var(--text-secondary);
+}
+
+.shortcuts-keys {
+  display: flex;
+  gap: 3px;
+  flex-shrink: 0;
+}
+
+.shortcuts-kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  height: 22px;
+  padding: 0 5px;
+  font-family: var(--font-mono);
+  font-size: 0.68em;
+  font-weight: 500;
+  color: var(--text-secondary);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  box-shadow: 0 1px 0 var(--border-strong);
+  line-height: 1;
+}


### PR DESCRIPTION
## Summary
- New **keyboard shortcuts help panel** showing all available shortcuts grouped by category
- Categories: General, Terminal, Navigation
- Accessible via **Cmd+Shift+/** (Cmd+?) or command palette "Keyboard Shortcuts" under Help
- Styled kbd elements with realistic key cap appearance

## Test plan
- [x] TypeScript type check passes
- [x] ESLint passes
- [x] Prettier passes
- [x] Vitest passes
- [x] No Rust changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)