### PR TITLE
feat: add custom theme editor with live preview and import/export

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { TerminalThemeSelector } from "./components/TerminalThemeSelector";
 import { TaskRunner } from "./components/TaskRunner";
 import { AppThemePicker } from "./components/AppThemePicker";
 import { KeyboardShortcuts } from "./components/KeyboardShortcuts";
+import { ThemeEditor } from "./components/ThemeEditor";
 import { DEFAULT_THEME_ID } from "./lib/terminalThemes";
 import { getAppThemeById } from "./themes/builtin";
 import { applyTheme, loadSavedThemeId } from "./themes/engine";
@@ -60,6 +61,7 @@ function AppContent() {
   const [taskRunnerOpen, setTaskRunnerOpen] = useState(false);
   const [appThemePickerOpen, setAppThemePickerOpen] = useState(false);
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
+  const [themeEditorOpen, setThemeEditorOpen] = useState(false);
   const [appThemeId, setAppThemeId] = useState("midnight");
   const [terminalThemeId, setTerminalThemeId] = useState(DEFAULT_THEME_ID);
   const { register, execute, search } = useCommandRegistry();
@@ -192,6 +194,13 @@ function AppContent() {
         category: "Appearance",
         icon: "\u25D1",
         action: () => setAppThemePickerOpen(true),
+      },
+      {
+        id: "theme:editor",
+        label: "Theme Editor",
+        category: "Appearance",
+        icon: "\uD83C\uDFA8",
+        action: () => setThemeEditorOpen(true),
       },
       {
         id: "theme:terminal",
@@ -372,6 +381,16 @@ function AppContent() {
           currentThemeId={appThemeId}
           onThemeChange={setAppThemeId}
           onClose={() => setAppThemePickerOpen(false)}
+        />
+      )}
+      {themeEditorOpen && (
+        <ThemeEditor
+          currentThemeId={appThemeId}
+          onClose={() => setThemeEditorOpen(false)}
+          onThemeSave={(theme) => {
+            applyTheme(theme);
+            setAppThemeId(theme.id);
+          }}
         />
       )}
       {shortcutsOpen && (

--- a/src/components/ThemeEditor.tsx
+++ b/src/components/ThemeEditor.tsx
@@ -1,0 +1,456 @@
+import { useState, useCallback, useRef, useEffect } from "react";
+import { BUILTIN_THEMES, getAppThemeById } from "../themes/builtin";
+import { applyTheme } from "../themes/engine";
+import type { AppTheme } from "../themes/engine";
+import { loadCustomThemes, saveCustomThemes } from "../lib/customThemes";
+import "../styles/theme-editor.css";
+
+interface ThemeEditorProps {
+  currentThemeId: string;
+  onClose: () => void;
+  onThemeSave: (theme: AppTheme) => void;
+}
+
+type ColorKey = keyof AppTheme["colors"];
+
+interface ColorGroup {
+  label: string;
+  keys: ColorKey[];
+}
+
+const COLOR_GROUPS: ColorGroup[] = [
+  {
+    label: "Backgrounds",
+    keys: ["bgBase", "bgSurface", "bgElevated", "bgHover"],
+  },
+  {
+    label: "Borders",
+    keys: ["borderSubtle", "border", "borderStrong"],
+  },
+  {
+    label: "Text",
+    keys: ["textPrimary", "textSecondary", "textMuted"],
+  },
+  {
+    label: "Accent",
+    keys: ["accent", "accentHover", "accentMuted", "accentGlow"],
+  },
+  {
+    label: "Semantic",
+    keys: ["danger", "dangerMuted", "warning", "success"],
+  },
+];
+
+const COLOR_LABELS: Record<ColorKey, string> = {
+  bgBase: "Base",
+  bgSurface: "Surface",
+  bgElevated: "Elevated",
+  bgHover: "Hover",
+  borderSubtle: "Subtle",
+  border: "Default",
+  borderStrong: "Strong",
+  textPrimary: "Primary",
+  textSecondary: "Secondary",
+  textMuted: "Muted",
+  accent: "Accent",
+  accentHover: "Hover",
+  accentMuted: "Muted",
+  accentGlow: "Glow",
+  danger: "Danger",
+  dangerMuted: "Danger Muted",
+  warning: "Warning",
+  success: "Success",
+};
+
+function generateId(): string {
+  return `custom-${Date.now().toString(36)}`;
+}
+
+/**
+ * Normalise any CSS colour (hex, rgb, rgba, named) to a 6-digit hex string
+ * so it can be consumed by <input type="color">.  Falls back to black.
+ */
+function toHex6(raw: string): string {
+  if (/^#[0-9a-fA-F]{6}$/.test(raw)) return raw;
+  if (/^#[0-9a-fA-F]{3}$/.test(raw)) {
+    const [, r, g, b] = raw.split("");
+    return `#${r}${r}${g}${g}${b}${b}`;
+  }
+
+  // Try creating an off-screen element to resolve any CSS colour
+  try {
+    const el = document.createElement("span");
+    el.style.color = raw;
+    document.body.appendChild(el);
+    const computed = getComputedStyle(el).color;
+    document.body.removeChild(el);
+
+    const match = computed.match(
+      /rgba?\(\s*(\d+),\s*(\d+),\s*(\d+)(?:,\s*[\d.]+)?\s*\)/,
+    );
+    if (match) {
+      const hex = (n: string) => parseInt(n).toString(16).padStart(2, "0");
+      return `#${hex(match[1])}${hex(match[2])}${hex(match[3])}`;
+    }
+  } catch {
+    // ignore
+  }
+  return "#000000";
+}
+
+export function ThemeEditor({
+  currentThemeId,
+  onClose,
+  onThemeSave,
+}: ThemeEditorProps) {
+  const originalTheme = getAppThemeById(currentThemeId);
+
+  const [baseThemeId, setBaseThemeId] = useState(currentThemeId);
+  const [themeName, setThemeName] = useState("My Custom Theme");
+  const [variant, setVariant] = useState<"dark" | "light">(
+    originalTheme.variant,
+  );
+  const [colors, setColors] = useState<AppTheme["colors"]>({
+    ...originalTheme.colors,
+  });
+
+  const importRef = useRef<HTMLInputElement>(null);
+
+  // Live preview: apply theme whenever colors / variant change
+  useEffect(() => {
+    const preview: AppTheme = {
+      id: "__preview__",
+      name: themeName,
+      variant,
+      colors,
+    };
+    applyTheme(preview);
+  }, [colors, variant, themeName]);
+
+  const handleBaseChange = useCallback(
+    (id: string) => {
+      const base = getAppThemeById(id);
+      setBaseThemeId(id);
+      setVariant(base.variant);
+      setColors({ ...base.colors });
+    },
+    [setBaseThemeId, setVariant, setColors],
+  );
+
+  const handleColorChange = useCallback(
+    (key: ColorKey, value: string) => {
+      setColors((prev) => ({ ...prev, [key]: value }));
+    },
+    [setColors],
+  );
+
+  const handleCancel = useCallback(() => {
+    applyTheme(originalTheme);
+    onClose();
+  }, [originalTheme, onClose]);
+
+  const handleSave = useCallback(async () => {
+    const newTheme: AppTheme = {
+      id: generateId(),
+      name: themeName.trim() || "Custom Theme",
+      variant,
+      colors,
+    };
+
+    // Persist
+    const existing = await loadCustomThemes();
+    existing.push(newTheme);
+    await saveCustomThemes(existing);
+
+    onThemeSave(newTheme);
+    onClose();
+  }, [themeName, variant, colors, onThemeSave, onClose]);
+
+  const handleExport = useCallback(() => {
+    const theme: AppTheme = {
+      id: generateId(),
+      name: themeName.trim() || "Custom Theme",
+      variant,
+      colors,
+    };
+    const blob = new Blob([JSON.stringify(theme, null, 2)], {
+      type: "application/json",
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${theme.name.replace(/\s+/g, "-").toLowerCase()}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }, [themeName, variant, colors]);
+
+  const handleImport = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = () => {
+        try {
+          const parsed = JSON.parse(reader.result as string) as AppTheme;
+          if (parsed.colors && parsed.name) {
+            setThemeName(parsed.name);
+            setVariant(parsed.variant ?? "dark");
+            setColors({ ...parsed.colors });
+          }
+        } catch {
+          // invalid file — ignore
+        }
+      };
+      reader.readAsText(file);
+      // Reset so the same file can be re-imported
+      e.target.value = "";
+    },
+    [setThemeName, setVariant, setColors],
+  );
+
+  return (
+    <div className="theme-editor-backdrop" onClick={handleCancel}>
+      <div className="theme-editor-panel" onClick={(e) => e.stopPropagation()}>
+        {/* Header */}
+        <div className="theme-editor-header">
+          <h3 className="theme-editor-title">Theme Editor</h3>
+          <button className="theme-editor-close" onClick={handleCancel}>
+            &times;
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="theme-editor-body">
+          {/* Left: controls */}
+          <div className="theme-editor-left">
+            {/* Meta fields */}
+            <div className="theme-editor-meta">
+              <div className="theme-editor-field">
+                <label>Theme Name</label>
+                <input
+                  type="text"
+                  value={themeName}
+                  onChange={(e) => setThemeName(e.target.value)}
+                  placeholder="My Custom Theme"
+                />
+              </div>
+
+              <div className="theme-editor-field">
+                <label>Base Theme</label>
+                <select
+                  value={baseThemeId}
+                  onChange={(e) => handleBaseChange(e.target.value)}
+                >
+                  {BUILTIN_THEMES.map((t) => (
+                    <option key={t.id} value={t.id}>
+                      {t.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div className="theme-editor-field">
+                <label>Variant</label>
+                <div className="theme-editor-variant-toggle">
+                  <button
+                    className={`theme-editor-variant-btn ${variant === "dark" ? "theme-editor-variant-btn-active" : ""}`}
+                    onClick={() => setVariant("dark")}
+                  >
+                    Dark
+                  </button>
+                  <button
+                    className={`theme-editor-variant-btn ${variant === "light" ? "theme-editor-variant-btn-active" : ""}`}
+                    onClick={() => setVariant("light")}
+                  >
+                    Light
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            {/* Color groups */}
+            {COLOR_GROUPS.map((group) => (
+              <div key={group.label} className="theme-editor-group">
+                <h4 className="theme-editor-group-title">{group.label}</h4>
+                {group.keys.map((key) => (
+                  <ColorRow
+                    key={key}
+                    colorKey={key}
+                    value={colors[key]}
+                    onChange={handleColorChange}
+                  />
+                ))}
+              </div>
+            ))}
+          </div>
+
+          {/* Right: preview */}
+          <div className="theme-editor-right">
+            <p className="theme-editor-preview-label">Preview</p>
+            <div
+              className="theme-editor-preview-mockup"
+              style={{ background: colors.bgBase }}
+            >
+              <div
+                className="theme-editor-preview-sidebar"
+                style={{ background: colors.bgSurface }}
+              >
+                <div
+                  className="theme-editor-preview-bar"
+                  style={{ background: colors.accent, width: "60%" }}
+                />
+                <div
+                  className="theme-editor-preview-bar"
+                  style={{ background: colors.textMuted, width: "80%" }}
+                />
+                <div
+                  className="theme-editor-preview-bar"
+                  style={{ background: colors.textMuted, width: "45%" }}
+                />
+              </div>
+              <div
+                className="theme-editor-preview-content"
+                style={{ background: colors.bgElevated }}
+              >
+                <div
+                  className="theme-editor-preview-line"
+                  style={{ background: colors.textPrimary, width: "70%" }}
+                />
+                <div
+                  className="theme-editor-preview-line"
+                  style={{ background: colors.textSecondary, width: "50%" }}
+                />
+                <div
+                  className="theme-editor-preview-line"
+                  style={{ background: colors.textMuted, width: "35%" }}
+                />
+                <div className="theme-editor-preview-dots">
+                  <span
+                    className="theme-editor-preview-dot"
+                    style={{ background: colors.accent }}
+                  />
+                  <span
+                    className="theme-editor-preview-dot"
+                    style={{ background: colors.danger }}
+                  />
+                  <span
+                    className="theme-editor-preview-dot"
+                    style={{ background: colors.warning }}
+                  />
+                  <span
+                    className="theme-editor-preview-dot"
+                    style={{ background: colors.success }}
+                  />
+                </div>
+              </div>
+              <div className="theme-editor-preview-text">
+                <span style={{ color: colors.textPrimary, fontSize: "0.82em" }}>
+                  Primary text
+                </span>
+                <span
+                  style={{ color: colors.textSecondary, fontSize: "0.76em" }}
+                >
+                  Secondary text
+                </span>
+                <span style={{ color: colors.textMuted, fontSize: "0.7em" }}>
+                  Muted text
+                </span>
+              </div>
+            </div>
+
+            {/* Border preview */}
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                gap: 4,
+                padding: 8,
+                borderRadius: "var(--radius-sm)",
+                background: colors.bgSurface,
+              }}
+            >
+              <div
+                style={{
+                  height: 1,
+                  background: colors.borderSubtle,
+                }}
+              />
+              <div style={{ height: 1, background: colors.border }} />
+              <div
+                style={{
+                  height: 1,
+                  background: colors.borderStrong,
+                }}
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="theme-editor-footer">
+          <button
+            className="theme-editor-btn"
+            onClick={() => importRef.current?.click()}
+          >
+            Import JSON
+          </button>
+          <input
+            ref={importRef}
+            className="theme-editor-import-input"
+            type="file"
+            accept=".json,application/json"
+            onChange={handleImport}
+          />
+          <button className="theme-editor-btn" onClick={handleExport}>
+            Export JSON
+          </button>
+          <div className="theme-editor-footer-spacer" />
+          <button className="theme-editor-btn" onClick={handleCancel}>
+            Cancel
+          </button>
+          <button
+            className="theme-editor-btn theme-editor-btn-primary"
+            onClick={handleSave}
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ── Color row subcomponent ── */
+
+function ColorRow({
+  colorKey,
+  value,
+  onChange,
+}: {
+  colorKey: ColorKey;
+  value: string;
+  onChange: (key: ColorKey, value: string) => void;
+}) {
+  const hex6 = toHex6(value);
+
+  return (
+    <div className="theme-editor-color-row">
+      <span className="theme-editor-color-label">{COLOR_LABELS[colorKey]}</span>
+      <div className="theme-editor-swatch-wrapper">
+        <div className="theme-editor-swatch" style={{ background: value }} />
+        <input
+          className="theme-editor-color-input"
+          type="color"
+          value={hex6}
+          onChange={(e) => onChange(colorKey, e.target.value)}
+        />
+      </div>
+      <input
+        className="theme-editor-hex"
+        type="text"
+        value={value}
+        onChange={(e) => onChange(colorKey, e.target.value)}
+      />
+    </div>
+  );
+}

--- a/src/lib/customThemes.ts
+++ b/src/lib/customThemes.ts
@@ -1,0 +1,29 @@
+import { invoke } from "@tauri-apps/api/core";
+import type { AppTheme } from "../themes/engine";
+
+const STORAGE_KEY = "custom_themes";
+
+export async function loadCustomThemes(): Promise<AppTheme[]> {
+  try {
+    const raw = await invoke<string | null>("get_setting", {
+      key: STORAGE_KEY,
+    });
+    if (!raw?.trim()) return [];
+    return JSON.parse(raw) as AppTheme[];
+  } catch {
+    return [];
+  }
+}
+
+export async function saveCustomThemes(themes: AppTheme[]): Promise<void> {
+  await invoke("set_setting", {
+    key: STORAGE_KEY,
+    value: JSON.stringify(themes),
+  });
+}
+
+export async function deleteCustomTheme(themeId: string): Promise<void> {
+  const themes = await loadCustomThemes();
+  const filtered = themes.filter((t) => t.id !== themeId);
+  await saveCustomThemes(filtered);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -12,6 +12,7 @@ import "./styles/task-runner.css";
 import "./styles/app-theme-picker.css";
 import "./styles/keyboard-shortcuts.css";
 import "./styles/github-sidebar.css";
+import "./styles/theme-editor.css";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>

--- a/src/styles/theme-editor.css
+++ b/src/styles/theme-editor.css
@@ -1,0 +1,378 @@
+/* ==========================================================
+   Theme Editor Modal
+   ========================================================== */
+
+.theme-editor-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+  z-index: 9998;
+  animation: cmd-backdrop-in 0.12s ease-out;
+}
+
+.theme-editor-panel {
+  position: fixed;
+  top: 5%;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 860px;
+  max-width: calc(100vw - 40px);
+  max-height: 88vh;
+  background-color: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow:
+    0 24px 64px rgba(0, 0, 0, 0.6),
+    0 0 0 1px rgba(255, 255, 255, 0.04);
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  animation: cmd-palette-in 0.15s ease-out;
+}
+
+/* ── Header ── */
+
+.theme-editor-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px 10px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.theme-editor-title {
+  font-size: 0.88em;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.theme-editor-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  font-size: 16px;
+  line-height: 1;
+  background: none;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: color 0.1s;
+}
+
+.theme-editor-close:hover {
+  color: var(--text-primary);
+}
+
+/* ── Body: two-column layout ── */
+
+.theme-editor-body {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.theme-editor-left {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+  overscroll-behavior: contain;
+}
+
+.theme-editor-left::-webkit-scrollbar {
+  width: 5px;
+}
+
+.theme-editor-left::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.theme-editor-left::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 3px;
+}
+
+.theme-editor-right {
+  width: 280px;
+  flex-shrink: 0;
+  border-left: 1px solid var(--border-subtle);
+  padding: 16px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+/* ── Meta fields (name, base theme, variant) ── */
+
+.theme-editor-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 16px;
+}
+
+.theme-editor-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.theme-editor-field label {
+  font-size: 0.72em;
+  font-weight: 500;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.theme-editor-field input[type="text"],
+.theme-editor-field select {
+  padding: 6px 10px;
+  font-size: 0.82em;
+  color: var(--text-primary);
+  background-color: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.theme-editor-field input[type="text"]:focus,
+.theme-editor-field select:focus {
+  border-color: var(--accent);
+}
+
+.theme-editor-variant-toggle {
+  display: flex;
+  gap: 4px;
+}
+
+.theme-editor-variant-btn {
+  flex: 1;
+  padding: 5px 0;
+  font-size: 0.76em;
+  font-weight: 500;
+  cursor: pointer;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    color 0.15s;
+}
+
+.theme-editor-variant-btn:hover {
+  border-color: var(--border-strong);
+}
+
+.theme-editor-variant-btn-active {
+  background: var(--accent-muted);
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+/* ── Color group ── */
+
+.theme-editor-group {
+  margin-bottom: 14px;
+}
+
+.theme-editor-group-title {
+  font-size: 0.72em;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin: 0 0 6px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.theme-editor-color-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 0;
+}
+
+.theme-editor-color-label {
+  font-size: 0.74em;
+  color: var(--text-secondary);
+  width: 110px;
+  flex-shrink: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.theme-editor-swatch-wrapper {
+  position: relative;
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
+}
+
+.theme-editor-swatch {
+  width: 24px;
+  height: 24px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  cursor: pointer;
+  transition: border-color 0.15s;
+}
+
+.theme-editor-swatch:hover {
+  border-color: var(--accent);
+}
+
+.theme-editor-color-input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  width: 24px;
+  height: 24px;
+  cursor: pointer;
+  border: none;
+  padding: 0;
+}
+
+.theme-editor-hex {
+  font-size: 0.74em;
+  font-family: monospace;
+  color: var(--text-muted);
+  width: 80px;
+  padding: 3px 6px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  outline: none;
+}
+
+.theme-editor-hex:focus {
+  border-color: var(--accent);
+}
+
+/* ── Preview panel (right column) ── */
+
+.theme-editor-preview-label {
+  font-size: 0.72em;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin: 0;
+}
+
+.theme-editor-preview-mockup {
+  border-radius: var(--radius);
+  overflow: hidden;
+  border: 1px solid var(--border);
+}
+
+.theme-editor-preview-sidebar {
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.theme-editor-preview-bar {
+  height: 4px;
+  border-radius: 2px;
+}
+
+.theme-editor-preview-content {
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.theme-editor-preview-line {
+  height: 4px;
+  border-radius: 2px;
+}
+
+.theme-editor-preview-dots {
+  display: flex;
+  gap: 4px;
+  margin-top: 4px;
+}
+
+.theme-editor-preview-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+.theme-editor-preview-text {
+  font-size: 0.72em;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.theme-editor-preview-text span {
+  display: block;
+}
+
+/* ── Footer buttons ── */
+
+.theme-editor-footer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.theme-editor-footer-spacer {
+  flex: 1;
+}
+
+.theme-editor-btn {
+  padding: 6px 14px;
+  font-size: 0.78em;
+  font-weight: 500;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    color 0.15s;
+}
+
+.theme-editor-btn:hover {
+  border-color: var(--border-strong);
+  color: var(--text-primary);
+}
+
+.theme-editor-btn-primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+.theme-editor-btn-primary:hover {
+  background: var(--accent-hover);
+  border-color: var(--accent-hover);
+  color: #fff;
+}
+
+.theme-editor-import-input {
+  display: none;
+}


### PR DESCRIPTION
## Summary
- Visual color picker for all 18 theme variables grouped by category
- Live preview as colors change
- Import/export themes as JSON, start from any built-in theme
- Custom themes persisted to settings

## Test plan
- [ ] Verify color pickers update theme in real-time
- [ ] Verify export/import JSON round-trip