### PR TITLE
feat: add React error boundaries and global error toast

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,7 @@
 import { useState, useCallback, useMemo, useEffect, useRef } from "react";
+import { ErrorProvider } from "./contexts/ErrorContext";
+import { ErrorBoundary } from "./components/ErrorBoundary";
+import { GlobalErrorToast } from "./components/GlobalErrorToast";
 import { invoke } from "@tauri-apps/api/core";
 import { MainLayout } from "./layouts/MainLayout";
 import { AuthButton } from "./components/AuthButton";
@@ -1660,14 +1663,21 @@ function App() {
   });
 
   return (
-    <MainLayout
-      onOpenSearch={() => sidebarActionsRef.current.openSearch()}
-      onOpenAiChat={() => sidebarActionsRef.current.openAiChat()}
-      onOpenNotifications={() => sidebarActionsRef.current.openNotifications()}
-      onOpenSettings={() => sidebarActionsRef.current.openSettings()}
-    >
-      <AppContent sidebarActionsRef={sidebarActionsRef} />
-    </MainLayout>
+    <ErrorProvider>
+      <ErrorBoundary name="App">
+        <MainLayout
+          onOpenSearch={() => sidebarActionsRef.current.openSearch()}
+          onOpenAiChat={() => sidebarActionsRef.current.openAiChat()}
+          onOpenNotifications={() => sidebarActionsRef.current.openNotifications()}
+          onOpenSettings={() => sidebarActionsRef.current.openSettings()}
+        >
+          <ErrorBoundary name="AppContent">
+            <AppContent sidebarActionsRef={sidebarActionsRef} />
+          </ErrorBoundary>
+        </MainLayout>
+        <GlobalErrorToast />
+      </ErrorBoundary>
+    </ErrorProvider>
   );
 }
 

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,54 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import "../styles/error-boundary.css";
+
+interface Props {
+  children: ReactNode;
+  /** Optional label for the boundary (shown in fallback UI) */
+  name?: string;
+  /** Render a custom fallback instead of the default panel */
+  fallback?: (error: Error, reset: () => void) => ReactNode;
+}
+
+interface State {
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error(
+      `[ErrorBoundary${this.props.name ? ` (${this.props.name})` : ""}]`,
+      error,
+      info.componentStack,
+    );
+  }
+
+  reset = () => this.setState({ error: null });
+
+  render() {
+    const { error } = this.state;
+    if (!error) return this.props.children;
+
+    if (this.props.fallback) {
+      return this.props.fallback(error, this.reset);
+    }
+
+    return (
+      <div className="error-boundary-fallback">
+        <div className="error-boundary-icon">⚠</div>
+        <h3 className="error-boundary-title">
+          {this.props.name ? `${this.props.name} failed to render` : "Something went wrong"}
+        </h3>
+        <p className="error-boundary-message">{error.message}</p>
+        <button className="error-boundary-reset" onClick={this.reset}>
+          Try again
+        </button>
+      </div>
+    );
+  }
+}

--- a/src/components/GlobalErrorToast.tsx
+++ b/src/components/GlobalErrorToast.tsx
@@ -1,0 +1,50 @@
+import { useEffect } from "react";
+import { useErrorReporter, type AppError } from "../contexts/ErrorContext";
+import "../styles/global-error-toast.css";
+
+const AUTO_DISMISS_MS: Record<AppError["severity"], number> = {
+  info: 4000,
+  warning: 6000,
+  error: 0, // errors stay until manually dismissed
+};
+
+function Toast({ err, onDismiss }: { err: AppError; onDismiss: () => void }) {
+  useEffect(() => {
+    const ms = AUTO_DISMISS_MS[err.severity];
+    if (ms > 0) {
+      const t = setTimeout(onDismiss, ms);
+      return () => clearTimeout(t);
+    }
+  }, [err.id, err.severity, onDismiss]);
+
+  return (
+    <div className={`global-toast global-toast--${err.severity}`} role="alert">
+      <div className="global-toast__body">
+        <span className="global-toast__msg">{err.message}</span>
+        {err.detail && (
+          <span className="global-toast__detail">{err.detail}</span>
+        )}
+      </div>
+      <button
+        className="global-toast__close"
+        onClick={onDismiss}
+        aria-label="Dismiss"
+      >
+        ✕
+      </button>
+    </div>
+  );
+}
+
+export function GlobalErrorToast() {
+  const { errors, dismissError } = useErrorReporter();
+  if (errors.length === 0) return null;
+
+  return (
+    <div className="global-toast-stack" aria-live="polite">
+      {errors.map((err) => (
+        <Toast key={err.id} err={err} onDismiss={() => dismissError(err.id)} />
+      ))}
+    </div>
+  );
+}

--- a/src/contexts/ErrorContext.tsx
+++ b/src/contexts/ErrorContext.tsx
@@ -1,0 +1,69 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useRef,
+  useState,
+} from "react";
+
+export interface AppError {
+  id: string;
+  message: string;
+  detail?: string;
+  severity: "error" | "warning" | "info";
+  timestamp: number;
+}
+
+interface ErrorContextValue {
+  errors: AppError[];
+  reportError: (
+    message: string,
+    detail?: string,
+    severity?: AppError["severity"],
+  ) => void;
+  dismissError: (id: string) => void;
+  clearErrors: () => void;
+}
+
+export const ErrorContext = createContext<ErrorContextValue>({
+  errors: [],
+  reportError: () => {},
+  dismissError: () => {},
+  clearErrors: () => {},
+});
+
+export function ErrorProvider({ children }: { children: React.ReactNode }) {
+  const [errors, setErrors] = useState<AppError[]>([]);
+  const counterRef = useRef(0);
+
+  const reportError = useCallback(
+    (
+      message: string,
+      detail?: string,
+      severity: AppError["severity"] = "error",
+    ) => {
+      const id = `err-${Date.now()}-${++counterRef.current}`;
+      const entry: AppError = { id, message, detail, severity, timestamp: Date.now() };
+      setErrors((prev) => [...prev.slice(-9), entry]); // cap at 10
+    },
+    [],
+  );
+
+  const dismissError = useCallback((id: string) => {
+    setErrors((prev) => prev.filter((e) => e.id !== id));
+  }, []);
+
+  const clearErrors = useCallback(() => {
+    setErrors([]);
+  }, []);
+
+  return (
+    <ErrorContext.Provider value={{ errors, reportError, dismissError, clearErrors }}>
+      {children}
+    </ErrorContext.Provider>
+  );
+}
+
+export function useErrorReporter() {
+  return useContext(ErrorContext);
+}

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useRef, useEffect } from "react";
 import { Sidebar } from "../components/Sidebar";
 import { GitHubSidebar } from "../components/GitHubSidebar";
 import { UiContext } from "../stores/uiStore";
+import { ErrorBoundary } from "../components/ErrorBoundary";
 
 const SIDEBAR_MIN = 200;
 const SIDEBAR_MAX = 480;
@@ -159,12 +160,14 @@ export function MainLayout({
     >
       <div className="main-layout">
         <div className="sidebar-panel" style={{ width: sidebarWidth }}>
-          <Sidebar
-            onOpenSearch={onOpenSearch}
-            onOpenAiChat={onOpenAiChat}
-            onOpenNotifications={onOpenNotifications}
-            onOpenSettings={onOpenSettings}
-          />
+          <ErrorBoundary name="Sidebar">
+            <Sidebar
+              onOpenSearch={onOpenSearch}
+              onOpenAiChat={onOpenAiChat}
+              onOpenNotifications={onOpenNotifications}
+              onOpenSettings={onOpenSettings}
+            />
+          </ErrorBoundary>
         </div>
         <div className="resize-handle" onMouseDown={handleMouseDown} />
         <div className="content-area">{children}</div>
@@ -175,7 +178,9 @@ export function MainLayout({
               onMouseDown={handleRightMouseDown}
             />
             <div style={{ width: rightSidebarWidth, flexShrink: 0 }}>
-              <GitHubSidebar projectId={selectedProjectId} />
+              <ErrorBoundary name="GitHub Sidebar">
+                <GitHubSidebar projectId={selectedProjectId} />
+              </ErrorBoundary>
             </div>
           </>
         )}

--- a/src/styles/error-boundary.css
+++ b/src/styles/error-boundary.css
@@ -1,0 +1,54 @@
+.error-boundary-fallback {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 32px 24px;
+  min-height: 120px;
+  background: var(--bg-surface);
+  border: 1px solid var(--danger-muted);
+  border-radius: var(--radius-lg);
+  text-align: center;
+  color: var(--text-secondary);
+}
+
+.error-boundary-icon {
+  font-size: 24px;
+  color: var(--danger);
+  line-height: 1;
+}
+
+.error-boundary-title {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.error-boundary-message {
+  margin: 0;
+  font-size: 11px;
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+  max-width: 420px;
+  word-break: break-word;
+}
+
+.error-boundary-reset {
+  margin-top: 8px;
+  padding: 5px 14px;
+  font-size: 12px;
+  font-family: var(--font-sans);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.error-boundary-reset:hover {
+  background: var(--bg-hover);
+  border-color: var(--border-strong);
+}

--- a/src/styles/global-error-toast.css
+++ b/src/styles/global-error-toast.css
@@ -1,0 +1,103 @@
+.global-toast-stack {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column-reverse;
+  gap: 8px;
+  max-width: 380px;
+  pointer-events: none;
+}
+
+.global-toast {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  box-shadow: var(--shadow-lg);
+  pointer-events: all;
+  animation: toast-in 0.2s var(--ease-spring);
+}
+
+@keyframes toast-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.97);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+.global-toast--error {
+  border-color: rgba(239, 68, 68, 0.3);
+  background: rgba(239, 68, 68, 0.07);
+}
+
+.global-toast--warning {
+  border-color: rgba(245, 158, 11, 0.3);
+  background: rgba(245, 158, 11, 0.07);
+}
+
+.global-toast--info {
+  border-color: var(--border);
+  background: var(--bg-elevated);
+}
+
+.global-toast__body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.global-toast__msg {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-primary);
+  line-height: 1.4;
+}
+
+.global-toast--error .global-toast__msg {
+  color: #fca5a5;
+}
+
+.global-toast--warning .global-toast__msg {
+  color: #fcd34d;
+}
+
+.global-toast__detail {
+  font-size: 11px;
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+  line-height: 1.4;
+  word-break: break-word;
+}
+
+.global-toast__close {
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 10px;
+  border-radius: 3px;
+  padding: 0;
+  transition: color 0.15s, background 0.15s;
+}
+
+.global-toast__close:hover {
+  color: var(--text-primary);
+  background: var(--bg-hover);
+}


### PR DESCRIPTION
## Summary
- Adds `ErrorBoundary` class component — wraps App, AppContent, Sidebar, and GitHub Sidebar so a single panel crash no longer kills the whole UI
- Adds `ErrorProvider` context + `useErrorReporter()` hook — any component can surface non-fatal errors without crashing
- Adds `GlobalErrorToast` — stacked toast shelf (bottom-right) with auto-dismiss for info/warning and manual dismiss for errors

## What changed
| File | Change |
|------|--------|
| `src/contexts/ErrorContext.tsx` | New — error provider + `useErrorReporter` hook |
| `src/components/ErrorBoundary.tsx` | New — React class-based boundary with reset |
| `src/components/GlobalErrorToast.tsx` | New — toast shelf driven by ErrorContext |
| `src/styles/error-boundary.css` | New — fallback panel styles |
| `src/styles/global-error-toast.css` | New — toast animation + severity colours |
| `src/App.tsx` | Wrap root + AppContent in ErrorBoundary; mount GlobalErrorToast |
| `src/layouts/MainLayout.tsx` | Wrap Sidebar + GitHubSidebar in ErrorBoundary |

## Test plan
- [ ] Open app normally — no visible change
- [ ] Simulate a component throw (add `throw new Error("test")` to any panel) — boundary shows "Try again" fallback, rest of UI stays functional
- [ ] Call `useErrorReporter().reportError("hello", "detail", "warning")` from console/devtools — toast appears, auto-dismisses after 6 s
- [ ] Trigger an `"error"` severity toast — stays until manually closed with ✕

🤖 Generated with [Claude Code](https://claude.com/claude-code)