### PR TITLE
feat(rust): add CommandError type, AppDb::conn() helper, fix watcher unwraps

### DIFF
--- a/src-tauri/src/claudemd/watcher.rs
+++ b/src-tauri/src/claudemd/watcher.rs
@@ -39,7 +39,10 @@ impl ClaudeMdWatcher {
 
         // Check if debounce window has elapsed
         let should_run = {
-            let last = self.last_run.lock().unwrap();
+            let last = self
+                .last_run
+                .lock()
+                .unwrap_or_else(|p| p.into_inner());
             last.elapsed() >= debounce
         };
 
@@ -49,7 +52,10 @@ impl ClaudeMdWatcher {
 
         // Take all pending IDs
         let worktree_ids: Vec<i64> = {
-            let mut pending = self.pending.lock().unwrap();
+            let mut pending = self
+                .pending
+                .lock()
+                .unwrap_or_else(|p| p.into_inner());
             let ids: Vec<i64> = pending.drain().collect();
             ids
         };
@@ -60,7 +66,10 @@ impl ClaudeMdWatcher {
 
         // Update last run time
         {
-            let mut last = self.last_run.lock().unwrap();
+            let mut last = self
+                .last_run
+                .lock()
+                .unwrap_or_else(|p| p.into_inner());
             *last = Instant::now();
         }
 

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -1,4 +1,5 @@
 use rusqlite::Connection;
+use std::sync::MutexGuard;
 use std::fs;
 use std::sync::Mutex;
 use tauri::{AppHandle, Manager};
@@ -26,6 +27,24 @@ impl From<DbError> for tauri::Error {
 
 /// Thread-safe wrapper around a SQLite connection for use as Tauri managed state.
 pub struct AppDb(pub Mutex<Connection>);
+
+impl AppDb {
+    /// Acquire the database connection.
+    ///
+    /// If the mutex is poisoned (a previous thread panicked while holding it),
+    /// the inner connection is recovered and reused. SQLite transactions are
+    /// atomic, so any incomplete work from the panicking thread was already
+    /// rolled back, making recovery safe.
+    ///
+    /// Use this in background workers and helpers. For Tauri command handlers
+    /// that already propagate `Result<_, String>`, prefer the explicit
+    /// `db.0.lock().map_err(...)` pattern so the frontend receives a clear error.
+    pub fn conn(&self) -> MutexGuard<Connection> {
+        self.0
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
 
 /// Initializes the SQLite database in the app's data directory.
 /// Creates all required tables, indexes, and triggers if they do not already exist.

--- a/src-tauri/src/errors.rs
+++ b/src-tauri/src/errors.rs
@@ -1,0 +1,55 @@
+/// Structured error type for Tauri command handlers.
+///
+/// All variants serialize to a human-readable string via `Display` (which is
+/// what Tauri sends to the frontend as the `Result<_, String>` error value).
+/// The prefixed format (`[NOT_FOUND] …`) lets the frontend distinguish error
+/// classes without parsing free-form strings.
+#[derive(Debug)]
+pub enum CommandError {
+    /// A requested entity does not exist (project, worktree, profile …).
+    NotFound(String),
+    /// The caller supplied invalid input.
+    Invalid(String),
+    /// A database operation failed.
+    Database(String),
+    /// An I/O operation failed.
+    Io(String),
+    /// An external service or sub-process failed.
+    External(String),
+    /// A mutex was unavailable (lock contention, poisoned lock …).
+    Lock(String),
+}
+
+impl std::fmt::Display for CommandError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotFound(msg) => write!(f, "[NOT_FOUND] {msg}"),
+            Self::Invalid(msg) => write!(f, "[INVALID] {msg}"),
+            Self::Database(msg) => write!(f, "[DATABASE] {msg}"),
+            Self::Io(msg) => write!(f, "[IO] {msg}"),
+            Self::External(msg) => write!(f, "[EXTERNAL] {msg}"),
+            Self::Lock(msg) => write!(f, "[LOCK] {msg}"),
+        }
+    }
+}
+
+// Allow `?` from rusqlite errors in commands that return `Result<_, CommandError>`.
+impl From<rusqlite::Error> for CommandError {
+    fn from(e: rusqlite::Error) -> Self {
+        Self::Database(e.to_string())
+    }
+}
+
+impl From<std::io::Error> for CommandError {
+    fn from(e: std::io::Error) -> Self {
+        Self::Io(e.to_string())
+    }
+}
+
+// Tauri expects `Result<T, String>` from commands, so provide a blanket
+// conversion from CommandError into the serialized string.
+impl From<CommandError> for String {
+    fn from(e: CommandError) -> Self {
+        e.to_string()
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ pub mod ai;
 pub mod backup;
 pub mod bookmarks;
 pub mod browser;
+pub mod errors;
 pub mod claudemd;
 pub mod clipboard;
 pub mod collaboration;


### PR DESCRIPTION
## Summary
Three targeted Rust resilience improvements with no behaviour change to existing command handlers.

## What changed

| File | Change |
|------|--------|
| `src-tauri/src/errors.rs` | New -- `CommandError` enum with typed variants |
| `src-tauri/src/db/mod.rs` | New `AppDb::conn()` helper with poison recovery |
| `src-tauri/src/claudemd/watcher.rs` | Replace 3 `lock().unwrap()` with `unwrap_or_else` |
| `src-tauri/src/lib.rs` | Register `pub mod errors` |

### CommandError enum
```rust
pub enum CommandError {
    NotFound(String),   // [NOT_FOUND] ...
    Invalid(String),    // [INVALID] ...
    Database(String),   // [DATABASE] ...
    Io(String),         // [IO] ...
    External(String),   // [EXTERNAL] ...
    Lock(String),       // [LOCK] ...
}
```
Each variant serializes with a bracket prefix — the frontend can check `error.startsWith("[NOT_FOUND]")` to handle missing-entity errors differently from database errors.

### AppDb::conn()
```rust
pub fn conn(&self) -> MutexGuard<Connection> {
    self.0.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
}
```
Background workers can now call `db.conn()` instead of `db.0.lock().unwrap()`. If a thread panics while holding the lock, the next caller recovers the inner value instead of also panicking.

### claudemd/watcher.rs
The three `lock().unwrap()` calls on `last_run` and `pending` internal mutexes are replaced with `unwrap_or_else(|p| p.into_inner())`. This prevents a poisoned debounce timer from permanently halting CLAUDE.md regeneration.

## Test plan
- [ ] Build succeeds: `cargo check` in `src-tauri/`
- [ ] All existing Rust tests pass: `cargo test` in `src-tauri/`
- [ ] CLAUDE.md regeneration still works after worktree changes
- [ ] New `errors.rs` can be imported with `use workroot_lib::errors::CommandError`

Generated with [Claude Code](https://claude.com/claude-code)
