### PR TITLE
feat: add HTTP timeouts to GitHub API client and frontend invoke retry utility

### DIFF
--- a/src-tauri/src/collaboration/notifications.rs
+++ b/src-tauri/src/collaboration/notifications.rs
@@ -1,4 +1,4 @@
-use crate::github::auth;
+use crate::github::{self, auth};
 use serde::Serialize;
 
 #[derive(Debug, Serialize)]
@@ -18,7 +18,7 @@ pub struct Notification {
 pub async fn get_notifications() -> Result<Vec<Notification>, String> {
     let token = auth::get_token()?.ok_or_else(|| "Not authenticated".to_string())?;
 
-    let client = reqwest::Client::new();
+    let client = github::api_client()?;
     let resp = client
         .get("https://api.github.com/notifications?per_page=30")
         .header("Authorization", format!("Bearer {}", token))
@@ -94,7 +94,7 @@ pub async fn get_notifications() -> Result<Vec<Notification>, String> {
 pub async fn mark_notification_read(thread_id: String) -> Result<(), String> {
     let token = auth::get_token()?.ok_or_else(|| "Not authenticated".to_string())?;
 
-    let client = reqwest::Client::new();
+    let client = github::api_client()?;
     let resp = client
         .patch(format!(
             "https://api.github.com/notifications/threads/{}",

--- a/src-tauri/src/github/activity.rs
+++ b/src-tauri/src/github/activity.rs
@@ -208,7 +208,7 @@ pub async fn list_repo_pulls(
     let (owner, repo_name) = get_project_remote(&db, project_id)?;
     let token = auth::get_token()?.ok_or("Not authenticated. Please sign in with GitHub first.")?;
 
-    let client = reqwest::Client::new();
+    let client = super::api_client()?;
     let url = format!(
         "https://api.github.com/repos/{}/{}/pulls?state=open&per_page=25&sort=updated",
         owner, repo_name
@@ -241,7 +241,7 @@ pub async fn list_repo_issues(
     let (owner, repo_name) = get_project_remote(&db, project_id)?;
     let token = auth::get_token()?.ok_or("Not authenticated. Please sign in with GitHub first.")?;
 
-    let client = reqwest::Client::new();
+    let client = super::api_client()?;
     let url = format!(
         "https://api.github.com/repos/{}/{}/issues?state=open&per_page=25&sort=updated&direction=desc",
         owner, repo_name
@@ -281,7 +281,7 @@ pub async fn get_repo_activity(
     let (owner, repo_name) = get_project_remote(&db, project_id)?;
     let token = auth::get_token()?.ok_or("Not authenticated. Please sign in with GitHub first.")?;
 
-    let client = reqwest::Client::new();
+    let client = super::api_client()?;
     let url = format!(
         "https://api.github.com/repos/{}/{}/events?per_page=20",
         owner, repo_name

--- a/src-tauri/src/github/auth.rs
+++ b/src-tauri/src/github/auth.rs
@@ -63,7 +63,7 @@ pub fn get_token_from_env_or_gh() -> Result<Option<String>, String> {
 /// at the verification_uri.
 pub async fn start_device_flow(db: State<'_, AppDb>) -> Result<DeviceCodeResponse, String> {
     let client_id = get_client_id(&db)?;
-    let client = reqwest::Client::new();
+    let client = super::api_client()?;
     let resp = client
         .post("https://github.com/login/device/code")
         .header("Accept", "application/json")
@@ -103,7 +103,7 @@ pub async fn poll_for_token(
     interval: u64,
 ) -> Result<String, String> {
     let client_id = get_client_id(&db)?;
-    let client = reqwest::Client::new();
+    let client = super::api_client()?;
     let poll_interval = std::time::Duration::from_secs(interval.max(5));
     let max_attempts = 120; // ~10 minutes at 5s interval
 
@@ -186,7 +186,7 @@ pub async fn get_authenticated_user() -> Result<Option<GitHubUser>, String> {
         None => return Ok(None),
     };
 
-    let client = reqwest::Client::new();
+    let client = super::api_client()?;
     let resp = client
         .get("https://api.github.com/user")
         .header("Authorization", format!("Bearer {}", token))

--- a/src-tauri/src/github/ci.rs
+++ b/src-tauri/src/github/ci.rs
@@ -112,7 +112,7 @@ pub async fn get_pr_status(
 
     let token = auth::get_token()?.ok_or("Not authenticated. Please sign in with GitHub first.")?;
 
-    let client = reqwest::Client::new();
+    let client = super::api_client()?;
 
     // Fetch PR detail, checks, and reviews in parallel
     let pr_url = format!(

--- a/src-tauri/src/github/mod.rs
+++ b/src-tauri/src/github/mod.rs
@@ -6,6 +6,20 @@ pub mod repos;
 
 use serde::{Deserialize, Serialize};
 
+/// Build a `reqwest::Client` pre-configured for GitHub API calls.
+///
+/// - 30 s connect timeout
+/// - 30 s request timeout
+/// - `User-Agent` header required by the GitHub API
+pub(crate) fn api_client() -> Result<reqwest::Client, String> {
+    reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .connect_timeout(std::time::Duration::from_secs(10))
+        .user_agent(concat!("workroot/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .map_err(|e| format!("Failed to build HTTP client: {}", e))
+}
+
 /// Represents the device code flow response from GitHub.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct DeviceCodeResponse {

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -87,7 +87,7 @@ pub async fn create_pull_request(
 
     let token = auth::get_token()?.ok_or("Not authenticated. Please sign in with GitHub first.")?;
 
-    let client = reqwest::Client::new();
+    let client = super::api_client()?;
     let resp = client
         .post(format!(
             "https://api.github.com/repos/{}/{}/pulls",
@@ -150,7 +150,7 @@ pub async fn get_pr_for_branch(
 
     let token = auth::get_token()?.ok_or("Not authenticated. Please sign in with GitHub first.")?;
 
-    let client = reqwest::Client::new();
+    let client = super::api_client()?;
     let resp = client
         .get(format!(
             "https://api.github.com/repos/{}/{}/pulls",

--- a/src-tauri/src/github/repos.rs
+++ b/src-tauri/src/github/repos.rs
@@ -20,7 +20,7 @@ pub async fn list_user_repos() -> Result<Vec<GitHubRepo>, String> {
     let token = auth::get_token()?
         .ok_or_else(|| "Not authenticated. Please sign in with GitHub first.".to_string())?;
 
-    let client = reqwest::Client::new();
+    let client = super::api_client()?;
     let mut all_repos = Vec::new();
     let mut page = 1u32;
 

--- a/src/lib/invoke.ts
+++ b/src/lib/invoke.ts
@@ -1,0 +1,88 @@
+import { invoke as tauriInvoke } from "@tauri-apps/api/core";
+
+// ─── Retry configuration ────────────────────────────────────────────────────
+
+export interface RetryOptions {
+  /** Maximum number of attempts (including the first). Default: 3. */
+  maxAttempts?: number;
+  /** Base delay in ms before first retry (doubles each attempt). Default: 200. */
+  baseDelayMs?: number;
+  /** Maximum delay cap in ms. Default: 5000. */
+  maxDelayMs?: number;
+}
+
+const DEFAULTS: Required<RetryOptions> = {
+  maxAttempts: 3,
+  baseDelayMs: 200,
+  maxDelayMs: 5000,
+};
+
+// ─── Transient error detection ─────────────────────────────────────────────
+
+/**
+ * Returns true if the error string looks like a transient failure that is
+ * worth retrying (IPC timeout, channel broken, DB lock contention).
+ * Permanent errors (NOT_FOUND, INVALID, auth failures) are not retried.
+ */
+function isTransient(err: unknown): boolean {
+  const msg = String(err).toLowerCase();
+  return (
+    msg.includes("timeout") ||
+    msg.includes("channel") ||
+    msg.includes("ipc") ||
+    msg.includes("[lock]") ||
+    msg.includes("connection refused") ||
+    msg.includes("broken pipe")
+  );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// ─── Public API ────────────────────────────────────────────────────────────
+
+/**
+ * Wrapper around `invoke()` with configurable exponential-backoff retry.
+ *
+ * Only retries on transient errors (IPC timeouts, lock contention, channel
+ * failures). Permanent errors (validation failures, not-found, auth) are
+ * surfaced immediately.
+ *
+ * ```ts
+ * // Drop-in replacement for invoke() with default retry behaviour:
+ * const result = await invokeWithRetry<MyType>("my_command", { arg: 1 });
+ *
+ * // Custom retry config:
+ * const result = await invokeWithRetry<MyType>("my_command", { arg: 1 }, { maxAttempts: 5 });
+ * ```
+ */
+export async function invokeWithRetry<T>(
+  cmd: string,
+  args?: Record<string, unknown>,
+  retryOpts?: RetryOptions,
+): Promise<T> {
+  const opts = { ...DEFAULTS, ...retryOpts };
+  let lastErr: unknown;
+
+  for (let attempt = 1; attempt <= opts.maxAttempts; attempt++) {
+    try {
+      return await tauriInvoke<T>(cmd, args);
+    } catch (err) {
+      lastErr = err;
+
+      const isLastAttempt = attempt === opts.maxAttempts;
+      if (isLastAttempt || !isTransient(err)) {
+        throw err;
+      }
+
+      const delay = Math.min(
+        opts.baseDelayMs * Math.pow(2, attempt - 1),
+        opts.maxDelayMs,
+      );
+      await sleep(delay);
+    }
+  }
+
+  throw lastErr;
+}


### PR DESCRIPTION
## Summary
Two network resilience improvements: proper timeouts on all GitHub HTTP calls, and a frontend `invokeWithRetry()` utility for transient IPC failures.

## What changed

### Rust: GitHub API client with timeouts (`src-tauri/src/github/mod.rs`)
```rust
pub(crate) fn api_client() -> Result<reqwest::Client, String> {
    reqwest::Client::builder()
        .timeout(Duration::from_secs(30))
        .connect_timeout(Duration::from_secs(10))
        .user_agent("workroot/<version>")
        .build()
        ...
}
```
All 10 `reqwest::Client::new()` calls in `github/` and `collaboration/notifications.rs` are replaced with `api_client()?`. Previously, any GitHub API call that hung (network issue, GitHub outage) would block the Tauri thread indefinitely.

### Frontend: `invokeWithRetry()` (`src/lib/invoke.ts`)
```ts
const result = await invokeWithRetry<MyType>("my_command", { arg: 1 });
// or with custom config:
const result = await invokeWithRetry<MyType>("cmd", args, { maxAttempts: 5, baseDelayMs: 500 });
```
- Drop-in replacement for `invoke()` with exponential backoff (200ms, 400ms, 800ms... capped at 5s)
- **Only retries transient errors**: IPC timeouts, channel failures, `[LOCK]` errors
- **Does not retry permanent errors**: validation failures (`[INVALID]`), missing entities (`[NOT_FOUND]`), auth errors
- Default: 3 attempts, 200ms base delay, 5s cap

## Files changed

| File | Change |
|------|--------|
| `src-tauri/src/github/mod.rs` | New `api_client()` helper with timeouts + User-Agent |
| `src-tauri/src/github/activity.rs` | Use `api_client()` |
| `src-tauri/src/github/auth.rs` | Use `api_client()` |
| `src-tauri/src/github/ci.rs` | Use `api_client()` |
| `src-tauri/src/github/repos.rs` | Use `api_client()` |
| `src-tauri/src/github/pr.rs` | Use `api_client()` |
| `src-tauri/src/collaboration/notifications.rs` | Use `api_client()` |
| `src/lib/invoke.ts` | New -- `invokeWithRetry()` with exponential backoff |

## Test plan
- [ ] GitHub API calls (list PRs, notifications, CI status) still work normally
- [ ] Simulate a hung GitHub request -- verify it times out in ~30s instead of hanging forever
- [ ] `invokeWithRetry("some_command")` works as a drop-in for `invoke("some_command")`
- [ ] Transient error (simulate `[LOCK]` response) triggers a retry
- [ ] Permanent error (`[NOT_FOUND]`) surfaces immediately without retrying

Generated with [Claude Code](https://claude.com/claude-code)
