### PR TITLE
fix: resolve CI format:check failures (CSS parse error + formatting)

### DIFF
--- a/src/components/CommitPanel.tsx
+++ b/src/components/CommitPanel.tsx
@@ -135,8 +135,20 @@ export function CommitPanel({
           title="Generate commit message with AI"
         >
           <svg width="9" height="9" viewBox="0 0 12 12" fill="none">
-            <path d="M6 1l1.2 3.8L11 6 7.2 7.2 6 11l-1.2-3.8L1 6l3.8-1.2z" stroke="currentColor" strokeWidth="1" strokeLinejoin="round" fill="currentColor" opacity="0.3" />
-            <path d="M6 1l1.2 3.8L11 6 7.2 7.2 6 11l-1.2-3.8L1 6l3.8-1.2z" stroke="currentColor" strokeWidth="1" strokeLinejoin="round" />
+            <path
+              d="M6 1l1.2 3.8L11 6 7.2 7.2 6 11l-1.2-3.8L1 6l3.8-1.2z"
+              stroke="currentColor"
+              strokeWidth="1"
+              strokeLinejoin="round"
+              fill="currentColor"
+              opacity="0.3"
+            />
+            <path
+              d="M6 1l1.2 3.8L11 6 7.2 7.2 6 11l-1.2-3.8L1 6l3.8-1.2z"
+              stroke="currentColor"
+              strokeWidth="1"
+              strokeLinejoin="round"
+            />
           </svg>
           {generating ? "…" : "AI"}
         </button>

--- a/src/components/CreatePRPanel.tsx
+++ b/src/components/CreatePRPanel.tsx
@@ -109,8 +109,21 @@ export function CreatePRPanel({ worktreeId, branch }: CreatePRPanelProps) {
   if (loading) {
     return (
       <div className="create-pr-loading">
-        <svg width="14" height="14" viewBox="0 0 14 14" fill="none" style={{ animation: "spin 1s linear infinite" }}>
-          <circle cx="7" cy="7" r="5.5" stroke="currentColor" strokeWidth="1.5" strokeDasharray="20 15" />
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 14 14"
+          fill="none"
+          style={{ animation: "spin 1s linear infinite" }}
+        >
+          <circle
+            cx="7"
+            cy="7"
+            r="5.5"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeDasharray="20 15"
+          />
         </svg>
         Loading…
       </div>
@@ -126,11 +139,24 @@ export function CreatePRPanel({ worktreeId, branch }: CreatePRPanelProps) {
         <div className="create-pr-success">
           <div className="create-pr-success-icon">
             <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
-              <path d="M4 9l4 4 6-7" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+              <path
+                d="M4 9l4 4 6-7"
+                stroke="currentColor"
+                strokeWidth="1.8"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
             </svg>
           </div>
-          <span className="create-pr-success-title">PR #{createdPR.number} created</span>
-          <a className="create-pr-success-link" href={createdPR.html_url} target="_blank" rel="noopener noreferrer">
+          <span className="create-pr-success-title">
+            PR #{createdPR.number} created
+          </span>
+          <a
+            className="create-pr-success-link"
+            href={createdPR.html_url}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             View on GitHub ↗
           </a>
         </div>
@@ -145,10 +171,33 @@ export function CreatePRPanel({ worktreeId, branch }: CreatePRPanelProps) {
           <span className="create-pr-title">Pull Request</span>
           <div className="create-pr-branch-flow">
             <span className="create-pr-branch-chip">
-              <svg className="create-pr-chip-icon" width="10" height="10" viewBox="0 0 12 12" fill="none">
-                <circle cx="3" cy="3" r="2" stroke="currentColor" strokeWidth="1.2" />
-                <circle cx="9" cy="9" r="2" stroke="currentColor" strokeWidth="1.2" />
-                <path d="M3 5v1a3 3 0 003 3h0" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+              <svg
+                className="create-pr-chip-icon"
+                width="10"
+                height="10"
+                viewBox="0 0 12 12"
+                fill="none"
+              >
+                <circle
+                  cx="3"
+                  cy="3"
+                  r="2"
+                  stroke="currentColor"
+                  strokeWidth="1.2"
+                />
+                <circle
+                  cx="9"
+                  cy="9"
+                  r="2"
+                  stroke="currentColor"
+                  strokeWidth="1.2"
+                />
+                <path
+                  d="M3 5v1a3 3 0 003 3h0"
+                  stroke="currentColor"
+                  strokeWidth="1.2"
+                  strokeLinecap="round"
+                />
               </svg>
               {branch}
             </span>
@@ -156,13 +205,26 @@ export function CreatePRPanel({ worktreeId, branch }: CreatePRPanelProps) {
         </div>
         <div className="create-pr-existing-card">
           <span className="create-pr-existing-badge">
-            <svg width="8" height="8" viewBox="0 0 8 8" fill="currentColor"><circle cx="4" cy="4" r="3" /></svg>
+            <svg width="8" height="8" viewBox="0 0 8 8" fill="currentColor">
+              <circle cx="4" cy="4" r="3" />
+            </svg>
             PR #{existingPR.number} open{existingPR.draft ? " · draft" : ""}
           </span>
           <span className="create-pr-existing-title">{existingPR.title}</span>
-          <a className="create-pr-existing-link" href={existingPR.html_url} target="_blank" rel="noopener noreferrer">
+          <a
+            className="create-pr-existing-link"
+            href={existingPR.html_url}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
-              <path d="M2 6h8M7 3l3 3-3 3" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
+              <path
+                d="M2 6h8M7 3l3 3-3 3"
+                stroke="currentColor"
+                strokeWidth="1.2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
             </svg>
             Open on GitHub
           </a>
@@ -177,22 +239,68 @@ export function CreatePRPanel({ worktreeId, branch }: CreatePRPanelProps) {
         <span className="create-pr-title">Create Pull Request</span>
         <div className="create-pr-branch-flow">
           <span className="create-pr-branch-chip">
-            <svg className="create-pr-chip-icon" width="10" height="10" viewBox="0 0 12 12" fill="none">
-              <circle cx="3" cy="3" r="2" stroke="currentColor" strokeWidth="1.2" />
-              <circle cx="9" cy="9" r="2" stroke="currentColor" strokeWidth="1.2" />
-              <path d="M3 5v1a3 3 0 003 3h0" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+            <svg
+              className="create-pr-chip-icon"
+              width="10"
+              height="10"
+              viewBox="0 0 12 12"
+              fill="none"
+            >
+              <circle
+                cx="3"
+                cy="3"
+                r="2"
+                stroke="currentColor"
+                strokeWidth="1.2"
+              />
+              <circle
+                cx="9"
+                cy="9"
+                r="2"
+                stroke="currentColor"
+                strokeWidth="1.2"
+              />
+              <path
+                d="M3 5v1a3 3 0 003 3h0"
+                stroke="currentColor"
+                strokeWidth="1.2"
+                strokeLinecap="round"
+              />
             </svg>
             {branch}
           </span>
           <span className="create-pr-branch-arrow">
             <svg width="14" height="10" viewBox="0 0 14 10" fill="none">
-              <path d="M1 5h11M9 2l3 3-3 3" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
+              <path
+                d="M1 5h11M9 2l3 3-3 3"
+                stroke="currentColor"
+                strokeWidth="1.2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
             </svg>
           </span>
           <span className="create-pr-base-chip">
-            <svg className="create-pr-chip-icon" width="10" height="10" viewBox="0 0 12 12" fill="none">
-              <circle cx="6" cy="3" r="2" stroke="currentColor" strokeWidth="1.2" />
-              <path d="M6 5v6" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+            <svg
+              className="create-pr-chip-icon"
+              width="10"
+              height="10"
+              viewBox="0 0 12 12"
+              fill="none"
+            >
+              <circle
+                cx="6"
+                cy="3"
+                r="2"
+                stroke="currentColor"
+                strokeWidth="1.2"
+              />
+              <path
+                d="M6 5v6"
+                stroke="currentColor"
+                strokeWidth="1.2"
+                strokeLinecap="round"
+              />
             </svg>
             {baseBranch}
           </span>
@@ -223,8 +331,20 @@ export function CreatePRPanel({ worktreeId, branch }: CreatePRPanelProps) {
               title="Generate with AI"
             >
               <svg width="11" height="11" viewBox="0 0 12 12" fill="none">
-                <path d="M6 1l1.2 3.8L11 6 7.2 7.2 6 11l-1.2-3.8L1 6l3.8-1.2z" stroke="currentColor" strokeWidth="1" strokeLinejoin="round" fill="currentColor" opacity="0.3" />
-                <path d="M6 1l1.2 3.8L11 6 7.2 7.2 6 11l-1.2-3.8L1 6l3.8-1.2z" stroke="currentColor" strokeWidth="1" strokeLinejoin="round" />
+                <path
+                  d="M6 1l1.2 3.8L11 6 7.2 7.2 6 11l-1.2-3.8L1 6l3.8-1.2z"
+                  stroke="currentColor"
+                  strokeWidth="1"
+                  strokeLinejoin="round"
+                  fill="currentColor"
+                  opacity="0.3"
+                />
+                <path
+                  d="M6 1l1.2 3.8L11 6 7.2 7.2 6 11l-1.2-3.8L1 6l3.8-1.2z"
+                  stroke="currentColor"
+                  strokeWidth="1"
+                  strokeLinejoin="round"
+                />
               </svg>
               {generatingDesc ? "Generating…" : "AI Generate"}
             </button>
@@ -270,16 +390,41 @@ export function CreatePRPanel({ worktreeId, branch }: CreatePRPanelProps) {
         >
           {creating ? (
             <>
-              <svg width="13" height="13" viewBox="0 0 14 14" fill="none" style={{ animation: "spin 1s linear infinite" }}>
-                <circle cx="7" cy="7" r="5.5" stroke="currentColor" strokeWidth="1.5" strokeDasharray="20 15" />
+              <svg
+                width="13"
+                height="13"
+                viewBox="0 0 14 14"
+                fill="none"
+                style={{ animation: "spin 1s linear infinite" }}
+              >
+                <circle
+                  cx="7"
+                  cy="7"
+                  r="5.5"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeDasharray="20 15"
+                />
               </svg>
               Creating…
             </>
           ) : (
             <>
               <svg width="13" height="13" viewBox="0 0 14 14" fill="none">
-                <path d="M3 7c0-2.2 1.8-4 4-4h5M9 1l3 2-3 2" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
-                <path d="M11 9c0 2.2-1.8 4-4 4H2M5 13l-3-2 3-2" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+                <path
+                  d="M3 7c0-2.2 1.8-4 4-4h5M9 1l3 2-3 2"
+                  stroke="currentColor"
+                  strokeWidth="1.4"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M11 9c0 2.2-1.8 4-4 4H2M5 13l-3-2 3-2"
+                  stroke="currentColor"
+                  strokeWidth="1.4"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
               </svg>
               Create Pull Request
             </>

--- a/src/components/GitHubSidebar.tsx
+++ b/src/components/GitHubSidebar.tsx
@@ -379,19 +379,43 @@ export function GitHubSidebar({ projectId }: GitHubSidebarProps) {
       <div className="gh-sidebar__content">
         {authError ? (
           <div className="gh-sidebar__auth-panel">
-            <svg width="28" height="28" viewBox="0 0 28 28" fill="none" aria-hidden="true" style={{ margin: "0 auto 8px", display: "block" }}>
-              <circle cx="14" cy="10" r="4.5" stroke="var(--text-muted)" strokeWidth="1.5"/>
-              <path d="M5 24c0-4.97 4.03-9 9-9s9 4.03 9 9" stroke="var(--text-muted)" strokeWidth="1.5" strokeLinecap="round"/>
+            <svg
+              width="28"
+              height="28"
+              viewBox="0 0 28 28"
+              fill="none"
+              aria-hidden="true"
+              style={{ margin: "0 auto 8px", display: "block" }}
+            >
+              <circle
+                cx="14"
+                cy="10"
+                r="4.5"
+                stroke="var(--text-muted)"
+                strokeWidth="1.5"
+              />
+              <path
+                d="M5 24c0-4.97 4.03-9 9-9s9 4.03 9 9"
+                stroke="var(--text-muted)"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+              />
             </svg>
-            <p className="gh-sidebar__auth-msg">Sign in to GitHub to view {activeTab}.</p>
+            <p className="gh-sidebar__auth-msg">
+              Sign in to GitHub to view {activeTab}.
+            </p>
 
             {deviceCode ? (
               <div className="gh-sidebar__device-flow">
                 <p className="gh-sidebar__device-hint">
                   Go to <strong>github.com/login/device</strong> and enter:
                 </p>
-                <div className="gh-sidebar__device-code">{deviceCode.user_code}</div>
-                <p className="gh-sidebar__device-waiting">Waiting for authorization…</p>
+                <div className="gh-sidebar__device-code">
+                  {deviceCode.user_code}
+                </div>
+                <p className="gh-sidebar__device-waiting">
+                  Waiting for authorization…
+                </p>
               </div>
             ) : showPatForm ? (
               <div className="gh-sidebar__pat-form">
@@ -406,7 +430,9 @@ export function GitHubSidebar({ projectId }: GitHubSidebarProps) {
                   }}
                   autoFocus
                 />
-                {signInError && <p className="gh-sidebar__auth-error">{signInError}</p>}
+                {signInError && (
+                  <p className="gh-sidebar__auth-error">{signInError}</p>
+                )}
                 <div className="gh-sidebar__pat-actions">
                   <button
                     className="gh-sidebar__signin-btn"
@@ -417,7 +443,10 @@ export function GitHubSidebar({ projectId }: GitHubSidebarProps) {
                   </button>
                   <button
                     className="gh-sidebar__signin-btn gh-sidebar__signin-btn--secondary"
-                    onClick={() => { setShowPatForm(false); setSignInError(null); }}
+                    onClick={() => {
+                      setShowPatForm(false);
+                      setSignInError(null);
+                    }}
                   >
                     Cancel
                   </button>
@@ -425,7 +454,9 @@ export function GitHubSidebar({ projectId }: GitHubSidebarProps) {
               </div>
             ) : (
               <div className="gh-sidebar__signin-options">
-                {signInError && <p className="gh-sidebar__auth-error">{signInError}</p>}
+                {signInError && (
+                  <p className="gh-sidebar__auth-error">{signInError}</p>
+                )}
                 <button
                   className="gh-sidebar__signin-btn"
                   onClick={handleDeviceFlow}

--- a/src/components/ProjectGroup.tsx
+++ b/src/components/ProjectGroup.tsx
@@ -62,7 +62,13 @@ export function ProjectGroup({
       >
         <span className={`project-chevron ${expanded ? "expanded" : ""}`}>
           <svg width="9" height="9" viewBox="0 0 9 9" fill="none">
-            <path d="M2.5 1.5l4 3-4 3" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+            <path
+              d="M2.5 1.5l4 3-4 3"
+              stroke="currentColor"
+              strokeWidth="1.4"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
           </svg>
         </span>
         <span className="project-info">

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -91,32 +91,50 @@ export function Sidebar({
               <circle cx="10" cy="3.5" r="2" fill="currentColor" />
               {/* Trunk */}
               <line
-                x1="10" y1="5.5"
-                x2="10" y2="11"
+                x1="10"
+                y1="5.5"
+                x2="10"
+                y2="11"
                 stroke="currentColor"
                 strokeWidth="1.5"
                 strokeLinecap="round"
               />
               {/* Left branch */}
               <line
-                x1="10" y1="11"
-                x2="4" y2="16.5"
+                x1="10"
+                y1="11"
+                x2="4"
+                y2="16.5"
                 stroke="currentColor"
                 strokeWidth="1.5"
                 strokeLinecap="round"
               />
               {/* Right branch */}
               <line
-                x1="10" y1="11"
-                x2="16" y2="16.5"
+                x1="10"
+                y1="11"
+                x2="16"
+                y2="16.5"
                 stroke="currentColor"
                 strokeWidth="1.5"
                 strokeLinecap="round"
               />
               {/* Left leaf */}
-              <circle cx="4" cy="16.5" r="2" fill="currentColor" opacity="0.75" />
+              <circle
+                cx="4"
+                cy="16.5"
+                r="2"
+                fill="currentColor"
+                opacity="0.75"
+              />
               {/* Right leaf */}
-              <circle cx="16" cy="16.5" r="2" fill="currentColor" opacity="0.75" />
+              <circle
+                cx="16"
+                cy="16.5"
+                r="2"
+                fill="currentColor"
+                opacity="0.75"
+              />
             </svg>
           </span>
           <span className="sidebar-title">Workroot</span>

--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -156,16 +156,15 @@ export function TerminalPanel({
   // Per-tab renderLeaf so inactive tabs can stay mounted (visibility:hidden)
   // without being confused about active/visible state.
   const makeRenderLeaf = useCallback(
-    (tabId: string) =>
-      (paneId: string, isFocused: boolean) => (
-        <TerminalInstance
-          key={paneId}
-          cwd={cwd}
-          active={tabId === activeTabId && isFocused}
-          visible={tabId === activeTabId}
-          themeId={themeId}
-        />
-      ),
+    (tabId: string) => (paneId: string, isFocused: boolean) => (
+      <TerminalInstance
+        key={paneId}
+        cwd={cwd}
+        active={tabId === activeTabId && isFocused}
+        visible={tabId === activeTabId}
+        themeId={themeId}
+      />
+    ),
     [cwd, activeTabId, themeId],
   );
 

--- a/src/components/WorktreeItem.tsx
+++ b/src/components/WorktreeItem.tsx
@@ -82,16 +82,38 @@ export function WorktreeItem({ worktree, onDelete }: WorktreeItemProps) {
       >
         <span className="worktree-branch-icon">
           <svg width="11" height="11" viewBox="0 0 12 12" fill="none">
-            <circle cx="3" cy="3" r="1.8" stroke="currentColor" strokeWidth="1.2" />
-            <circle cx="9" cy="9" r="1.8" stroke="currentColor" strokeWidth="1.2" />
-            <path d="M3 4.8v1.2a3 3 0 003 3h0" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+            <circle
+              cx="3"
+              cy="3"
+              r="1.8"
+              stroke="currentColor"
+              strokeWidth="1.2"
+            />
+            <circle
+              cx="9"
+              cy="9"
+              r="1.8"
+              stroke="currentColor"
+              strokeWidth="1.2"
+            />
+            <path
+              d="M3 4.8v1.2a3 3 0 003 3h0"
+              stroke="currentColor"
+              strokeWidth="1.2"
+              strokeLinecap="round"
+            />
           </svg>
         </span>
         <span className="worktree-branch-name">{worktree.branch_name}</span>
         <span className="worktree-indicators">
-          <span className={`worktree-status-dot ${statusClass}`} title={worktree.status} />
+          <span
+            className={`worktree-status-dot ${statusClass}`}
+            title={worktree.status}
+          />
           {worktree.is_dirty && (
-            <span className="worktree-dirty" title="Uncommitted changes">M</span>
+            <span className="worktree-dirty" title="Uncommitted changes">
+              M
+            </span>
           )}
           {worktree.port && (
             <span className="worktree-port">:{worktree.port}</span>

--- a/src/styles.css
+++ b/src/styles.css
@@ -41,10 +41,14 @@
   --radius-lg: 10px;
 
   /* Shadows */
-  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.3), 0 0 0 1px rgba(255, 255, 255, 0.03) inset;
-  --shadow: 0 4px 16px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(255, 255, 255, 0.04) inset;
-  --shadow-lg: 0 12px 40px rgba(0, 0, 0, 0.55), 0 0 0 1px rgba(255, 255, 255, 0.05) inset;
-  --shadow-accent: 0 4px 16px rgba(16, 185, 129, 0.2), 0 0 0 1px rgba(16, 185, 129, 0.15) inset;
+  --shadow-sm:
+    0 1px 3px rgba(0, 0, 0, 0.3), 0 0 0 1px rgba(255, 255, 255, 0.03) inset;
+  --shadow:
+    0 4px 16px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(255, 255, 255, 0.04) inset;
+  --shadow-lg:
+    0 12px 40px rgba(0, 0, 0, 0.55), 0 0 0 1px rgba(255, 255, 255, 0.05) inset;
+  --shadow-accent:
+    0 4px 16px rgba(16, 185, 129, 0.2), 0 0 0 1px rgba(16, 185, 129, 0.15) inset;
 
   /* Easing */
   --ease-spring: cubic-bezier(0.16, 1, 0.3, 1);
@@ -367,7 +371,9 @@ button:disabled {
    ========================================================== */
 
 @keyframes spin {
-  to { transform: rotate(360deg); }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 ::-webkit-scrollbar {
@@ -430,8 +436,12 @@ button:disabled {
 }
 
 @keyframes panel-overlay-in {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 .panel-dialog {
@@ -450,7 +460,8 @@ button:disabled {
     0 24px 80px rgba(0, 0, 0, 0.6),
     0 8px 24px rgba(0, 0, 0, 0.3),
     0 0 0 1px rgba(255, 255, 255, 0.05) inset;
-  animation: panel-dialog-in 0.22s var(--ease-spring, cubic-bezier(0.16, 1, 0.3, 1));
+  animation: panel-dialog-in 0.22s
+    var(--ease-spring, cubic-bezier(0.16, 1, 0.3, 1));
 }
 
 @keyframes panel-dialog-in {

--- a/src/styles/commit-panel.css
+++ b/src/styles/commit-panel.css
@@ -56,7 +56,9 @@
   font-size: 12.5px;
   outline: none;
   box-sizing: border-box;
-  transition: border-color 0.15s, box-shadow 0.15s;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
 }
 
 .commit-subject::placeholder {
@@ -87,7 +89,9 @@
   background: transparent;
   color: var(--accent);
   cursor: pointer;
-  transition: background-color 0.15s, box-shadow 0.15s;
+  transition:
+    background-color 0.15s,
+    box-shadow 0.15s;
 }
 
 .commit-ai-btn:hover:not(:disabled) {
@@ -133,7 +137,9 @@
   resize: vertical;
   min-height: 42px;
   box-sizing: border-box;
-  transition: border-color 0.15s, box-shadow 0.15s;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
 }
 
 .commit-body::placeholder {
@@ -195,7 +201,10 @@
   font-weight: 500;
   cursor: pointer;
   border-radius: var(--radius-sm);
-  transition: background-color 0.15s, border-color 0.15s, color 0.15s;
+  transition:
+    background-color 0.15s,
+    border-color 0.15s,
+    color 0.15s;
 }
 
 .commit-btn:hover:not(:disabled) {

--- a/src/styles/create-pr.css
+++ b/src/styles/create-pr.css
@@ -125,7 +125,9 @@
   font-family: var(--font-sans);
   font-size: 0.85em;
   outline: none;
-  transition: border-color 0.15s, box-shadow 0.15s;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
   width: 100%;
   box-sizing: border-box;
 }
@@ -151,7 +153,9 @@
   outline: none;
   resize: vertical;
   min-height: 130px;
-  transition: border-color 0.15s, box-shadow 0.15s;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
   width: 100%;
   box-sizing: border-box;
 }
@@ -179,7 +183,10 @@
   color: var(--accent);
   border-radius: 20px;
   cursor: pointer;
-  transition: background 0.15s, border-color 0.15s, box-shadow 0.15s;
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    box-shadow 0.15s;
   white-space: nowrap;
 }
 
@@ -250,7 +257,9 @@
   cursor: pointer;
   position: relative;
   flex-shrink: 0;
-  transition: background 0.15s, border-color 0.15s;
+  transition:
+    background 0.15s,
+    border-color 0.15s;
 }
 
 .create-pr-toggle input[type="checkbox"]:checked {
@@ -307,7 +316,10 @@
   align-items: center;
   justify-content: center;
   gap: 6px;
-  transition: background 0.15s, box-shadow 0.15s, transform 0.1s;
+  transition:
+    background 0.15s,
+    box-shadow 0.15s,
+    transform 0.1s;
 }
 
 .create-pr-btn:hover:not(:disabled) {
@@ -376,7 +388,9 @@
   border: 1px solid var(--border);
   padding: 4px 12px;
   border-radius: var(--radius);
-  transition: border-color 0.15s, color 0.15s;
+  transition:
+    border-color 0.15s,
+    color 0.15s;
 }
 
 .create-pr-success-link:hover {

--- a/src/styles/github-sidebar.css
+++ b/src/styles/github-sidebar.css
@@ -361,7 +361,9 @@
   cursor: pointer;
   font-size: 0.78em;
   line-height: 1.35;
-  transition: background-color 0.1s, border-color 0.1s;
+  transition:
+    background-color 0.1s,
+    border-color 0.1s;
   box-sizing: border-box;
 }
 

--- a/src/styles/network-tab.css
+++ b/src/styles/network-tab.css
@@ -71,7 +71,7 @@
   text-transform: uppercase;
   color: var(--text-muted, #888);
   border-bottom: 1px solid var(--border);
-  background: var(--bg-elevated));
+  background: var(--bg-elevated);
 }
 
 .network-col-method {

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -70,7 +70,11 @@
   min-height: 0;
   overflow-y: auto;
   background:
-    radial-gradient(ellipse 60% 40% at 50% 30%, rgba(16, 185, 129, 0.04) 0%, transparent 70%),
+    radial-gradient(
+      ellipse 60% 40% at 50% 30%,
+      rgba(16, 185, 129, 0.04) 0%,
+      transparent 70%
+    ),
     var(--bg-base);
 }
 
@@ -80,7 +84,6 @@
   margin: 0 auto;
   text-align: center;
 }
-
 
 /* ==========================================================
    Sidebar
@@ -504,7 +507,8 @@
    ========================================================== */
 
 @keyframes wt-pulse {
-  0%, 100% {
+  0%,
+  100% {
     box-shadow: 0 0 0 0 rgba(34, 197, 94, 0);
   }
   50% {
@@ -628,8 +632,15 @@
 }
 
 @keyframes wt-active-breathe {
-  0%, 100% { opacity: 1; box-shadow: 0 0 4px rgba(34, 197, 94, 0.6); }
-  50% { opacity: 0.75; box-shadow: 0 0 8px rgba(34, 197, 94, 0.3); }
+  0%,
+  100% {
+    opacity: 1;
+    box-shadow: 0 0 4px rgba(34, 197, 94, 0.6);
+  }
+  50% {
+    opacity: 0.75;
+    box-shadow: 0 0 8px rgba(34, 197, 94, 0.3);
+  }
 }
 
 .wt-status-stopped {
@@ -749,7 +760,9 @@
   color: var(--text-secondary);
   border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: background-color 0.15s, color 0.15s;
+  transition:
+    background-color 0.15s,
+    color 0.15s;
 }
 
 .new-worktree-cancel:hover {

--- a/src/styles/status-bar.css
+++ b/src/styles/status-bar.css
@@ -42,7 +42,9 @@
   white-space: nowrap;
   line-height: 24px;
   cursor: default;
-  transition: background-color 0.12s, color 0.12s;
+  transition:
+    background-color 0.12s,
+    color 0.12s;
   position: relative;
 }
 
@@ -53,11 +55,13 @@
 
 /* Subtle dividers between items */
 .status-bar-item + .status-bar-item {
-  border-left: 1px solid color-mix(in srgb, var(--border-subtle) 70%, transparent);
+  border-left: 1px solid
+    color-mix(in srgb, var(--border-subtle) 70%, transparent);
 }
 
 .status-bar-right .status-bar-item:first-child {
-  border-left: 1px solid color-mix(in srgb, var(--border-subtle) 70%, transparent);
+  border-left: 1px solid
+    color-mix(in srgb, var(--border-subtle) 70%, transparent);
 }
 
 .status-bar-branch {
@@ -91,7 +95,8 @@
 }
 
 @keyframes sb-connected-breathe {
-  0%, 100% {
+  0%,
+  100% {
     opacity: 1;
     box-shadow: 0 0 5px rgba(34, 197, 94, 0.5);
   }


### PR DESCRIPTION
## What was failing

`pnpm format:check` (the Frontend CI job) was failing with exit code 2 due to:

1. **Hard parse error** in `src/styles/network-tab.css` line 74:
   ```css
   /* before */
   background: var(--bg-elevated));   /* extra ) */

   /* after */
   background: var(--bg-elevated);
   ```
   This caused Prettier to crash entirely, preventing any other file from being checked.

2. **13 files with formatting violations** (trailing whitespace, indentation, quote style, line length) introduced in the UI/UX overhaul commits.

## What was fixed

- `src/styles/network-tab.css` — removed extra `)` on line 74
- Ran `pnpm format` to auto-fix all remaining formatting issues in the 13 affected files

## Verification

All three frontend CI checks pass locally:
```
pnpm typecheck  ✓
pnpm lint       ✓
pnpm format:check  ✓  All matched files use Prettier code style!
```

Rust checks (`cargo fmt --check`, `cargo clippy -- -D warnings`) were already clean.

## Note on billing failures

The Build jobs and some Frontend/Backend jobs on main are also failing with:
> "The job was not started because recent account payments have failed or your spending limit needs to be increased."

That's a GitHub Actions billing issue — please check **Settings → Billing & plans** in your GitHub account.

Generated with [Claude Code](https://claude.com/claude-code)
