### PR TITLE
feat: release workflow, auto-updater, and worktree history

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -55,7 +55,7 @@
       "open": true
     },
     "updater": {
-      "pubkey": "PLACEHOLDER_REPLACE_WITH_OUTPUT_OF_tauri_signer_generate",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDk4Rjk4MkVCQkUwNzZBRjIKUldUeWFnZSs2NEw1bUd5NnpZbldnUGVWOGNHY3hIdGFKbXl4eWtBcWt6LzBZYmduNW9vUWpwSVIK",
       "endpoints": [
         "https://github.com/sauravpanda/workroot/releases/latest/download/latest.json"
       ],


### PR DESCRIPTION
## Summary

Worktree soft-delete (history preserved), release workflow, and auto-updater.

## Changes

**Worktree history**
- delete_worktree archives instead of destroying — sets status=archived + deleted_at, leaves files on disk
- New list_worktree_history Tauri command returns all worktrees including archived ones
- WorktreeInfo and useWorktrees hook updated with deleted_at and loadWorktreeHistory()

**Releases + auto-updates**
- .github/workflows/release.yml — triggers on v* tags, builds macOS (arm64 + x86), Linux, Windows, signs artifacts, publishes GitHub Release with latest.json
- tauri-plugin-updater + tauri-plugin-process added and wired up in lib.rs
- Updater configured in tauri.conf.json with public signing key and GitHub Releases endpoint

## To cut a release
```
git tag v0.1.0 && git push origin v0.1.0
```

## Required GitHub Secrets
- TAURI_SIGNING_PRIVATE_KEY — private key matching the pubkey in tauri.conf.json
- TAURI_SIGNING_PRIVATE_KEY_PASSWORD — password for the key (empty string if none)
- APPLE_* secrets are optional — builds succeed without them, just no notarization