### PR TITLE
fix: set TERM=xterm-256color when spawning PTY shell

### DIFF
--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -336,6 +336,7 @@ function TerminalInstance({
           cols: Math.max(term.cols, 1),
           rows: Math.max(term.rows, 1),
           cwd,
+          env: { TERM: "xterm-256color" },
         });
         ptyRef.current = pty;
 


### PR DESCRIPTION
## Summary
- Adds `env: { TERM: "xterm-256color" }` to the PTY spawn options in `TerminalPanel.tsx`
- Fixes `TERM environment variable not set` error when using `clear` and other terminal commands in the built-in terminal

## Test plan
- [ ] Open the built-in terminal in Workroot
- [ ] Run `clear` — should work without error
- [ ] Run `echo $TERM` — should output `xterm-256color`