### PR TITLE
feat: switch UI font from Sora to Geist

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Sora:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
     <title>Workroot</title>
   </head>
   <body>

--- a/src/styles.css
+++ b/src/styles.css
@@ -32,7 +32,7 @@
   --success: #22c55e;
 
   /* Typography */
-  --font-sans: "Sora", system-ui, -apple-system, sans-serif;
+  --font-sans: "Geist", system-ui, -apple-system, sans-serif;
   --font-mono: "JetBrains Mono", "Menlo", "Monaco", monospace;
 
   /* Radii */


### PR DESCRIPTION
Replaces Sora with Geist (Vercel font) for a sharper, more developer-appropriate look. Updates Google Fonts URL in index.html and --font-sans variable in styles.css. Base font-size unchanged at 15px.