### PR TITLE
fix: backspace in terminal + WebGL renderer

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@tauri-apps/plugin-dialog": "^2.6.0",
     "@tauri-apps/plugin-shell": "^2.0.0",
     "@xterm/addon-fit": "^0.11.0",
+    "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@xterm/addon-fit':
         specifier: ^0.11.0
         version: 0.11.0
+      '@xterm/addon-webgl':
+        specifier: ^0.19.0
+        version: 0.19.0
       '@xterm/xterm':
         specifier: ^6.0.0
         version: 6.0.0
@@ -987,6 +990,9 @@ packages:
 
   '@xterm/addon-fit@0.11.0':
     resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
+
+  '@xterm/addon-webgl@0.19.0':
+    resolution: {integrity: sha512-b3fMOsyLVuCeNJWxolACEUED0vm7qC0cy4wRvf3oURSzDTYVQiGPhTnhWZwIHdvC48Y+oLhvYXnY4XDXPoJo6A==}
 
   '@xterm/xterm@6.0.0':
     resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==}
@@ -2357,6 +2363,8 @@ snapshots:
       - supports-color
 
   '@xterm/addon-fit@0.11.0': {}
+
+  '@xterm/addon-webgl@0.19.0': {}
 
   '@xterm/xterm@6.0.0': {}
 

--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
+import { WebglAddon } from "@xterm/addon-webgl";
 import { invoke } from "@tauri-apps/api/core";
 import { spawn } from "tauri-pty";
 import type { IPty } from "tauri-pty";
@@ -311,8 +312,31 @@ function TerminalInstance({
     term.loadAddon(fitAddon);
     term.open(el);
 
+    // GPU-accelerated renderer; fall back silently if WebGL is unavailable.
+    try {
+      const webgl = new WebglAddon();
+      webgl.onContextLoss(() => webgl.dispose());
+      term.loadAddon(webgl);
+    } catch {
+      // WebGL not available — xterm falls back to its canvas renderer.
+    }
+
     termRef.current = term;
     fitAddonRef.current = fitAddon;
+
+    // Prevent WebKit/WKWebView from consuming Backspace/Delete as browser
+    // navigation before xterm can handle them. Capture phase so we run first;
+    // only fires when this terminal container holds focus so other inputs
+    // (search boxes, etc.) are unaffected. xterm still processes the key
+    // through its own listener — preventDefault() only blocks browser defaults.
+    const preventBrowserNav = (e: KeyboardEvent) => {
+      if (e.key === "Backspace" || e.key === "Delete") {
+        if (el.contains(document.activeElement)) {
+          e.preventDefault();
+        }
+      }
+    };
+    window.addEventListener("keydown", preventBrowserNav, true);
 
     // Load settings, fit, spawn
     const initTimer = setTimeout(async () => {
@@ -375,6 +399,7 @@ function TerminalInstance({
     return () => {
       cancelled = true;
       clearTimeout(initTimer);
+      window.removeEventListener("keydown", preventBrowserNav, true);
       try {
         ptyRef.current?.kill();
       } catch {


### PR DESCRIPTION
## Summary

- **Backspace fix**: In Tauri's WKWebView, Backspace/Delete can be consumed by the browser as a navigation shortcut before xterm.js sees the event. Adds a capture-phase keydown listener that calls preventDefault() only when the terminal container holds focus — so other inputs in the app are unaffected.
- **WebGL renderer**: Adds @xterm/addon-webgl for GPU-accelerated terminal rendering with a silent fallback to canvas if WebGL is unavailable.

## Test plan

- [ ] Open terminal, type with typos, verify Backspace deletes characters
- [ ] Verify Backspace still works in other text inputs (settings, search fields)
- [ ] Verify smoother rendering at high throughput (e.g. cat a large file)
- [ ] No JS errors in console on load