### PR TITLE
fix: auto-replace spaces with dashes in branch name input

### DIFF
--- a/src/components/ProjectGroup.tsx
+++ b/src/components/ProjectGroup.tsx
@@ -112,7 +112,9 @@ export function ProjectGroup({
                 type="text"
                 placeholder="branch name"
                 value={newBranchName}
-                onChange={(e) => setNewBranchName(e.target.value)}
+                onChange={(e) =>
+                  setNewBranchName(e.target.value.replace(/ /g, "-"))
+                }
                 className="new-worktree-input"
                 autoFocus
               />


### PR DESCRIPTION
Closes #36

Replaces spaces with dashes in real-time as the user types in the branch name input, so `my feature branch` becomes `my-feature-branch` without an error.