### PR TITLE
fix: leverage gh CLI / env vars for GitHub auth

### DIFF
--- a/src-tauri/src/github/activity.rs
+++ b/src-tauri/src/github/activity.rs
@@ -206,7 +206,7 @@ pub async fn list_repo_pulls(
     project_id: i64,
 ) -> Result<Vec<RepoPull>, String> {
     let (owner, repo_name) = get_project_remote(&db, project_id)?;
-    let token = auth::get_token()?.ok_or("Not authenticated. Please sign in with GitHub first.")?;
+    let token = auth::get_token_from_env_or_gh()?.ok_or("Not authenticated. Please sign in with GitHub or the gh CLI.")?;
 
     let client = super::api_client()?;
     let url = format!(
@@ -239,7 +239,7 @@ pub async fn list_repo_issues(
     project_id: i64,
 ) -> Result<Vec<RepoIssue>, String> {
     let (owner, repo_name) = get_project_remote(&db, project_id)?;
-    let token = auth::get_token()?.ok_or("Not authenticated. Please sign in with GitHub first.")?;
+    let token = auth::get_token_from_env_or_gh()?.ok_or("Not authenticated. Please sign in with GitHub or the gh CLI.")?;
 
     let client = super::api_client()?;
     let url = format!(
@@ -279,7 +279,7 @@ pub async fn get_repo_activity(
     project_id: i64,
 ) -> Result<Vec<RepoEvent>, String> {
     let (owner, repo_name) = get_project_remote(&db, project_id)?;
-    let token = auth::get_token()?.ok_or("Not authenticated. Please sign in with GitHub first.")?;
+    let token = auth::get_token_from_env_or_gh()?.ok_or("Not authenticated. Please sign in with GitHub or the gh CLI.")?;
 
     let client = super::api_client()?;
     let url = format!(

--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -85,7 +85,7 @@ pub async fn create_pull_request(
         (owner, repo_name, branch)
     };
 
-    let token = auth::get_token()?.ok_or("Not authenticated. Please sign in with GitHub first.")?;
+    let token = auth::get_token_from_env_or_gh()?.ok_or("Not authenticated. Please sign in with GitHub or the gh CLI.")?;
 
     let client = super::api_client()?;
     let resp = client
@@ -148,7 +148,7 @@ pub async fn get_pr_for_branch(
         (owner, repo_name, branch)
     };
 
-    let token = auth::get_token()?.ok_or("Not authenticated. Please sign in with GitHub first.")?;
+    let token = auth::get_token_from_env_or_gh()?.ok_or("Not authenticated. Please sign in with GitHub or the gh CLI.")?;
 
     let client = super::api_client()?;
     let resp = client

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -78,7 +78,7 @@ async fn github_get_user() -> Result<Option<GitHubUser>, String> {
 
 #[tauri::command]
 fn github_check_auth() -> Result<bool, String> {
-    Ok(auth::get_token()?.is_some())
+    Ok(auth::get_token_from_env_or_gh()?.is_some())
 }
 
 #[tauri::command]

--- a/src-tauri/src/projects.rs
+++ b/src-tauri/src/projects.rs
@@ -116,9 +116,9 @@ pub async fn clone_and_register(
         return Err(format!("Directory already exists: {}", local_path_str));
     }
 
-    // Get token for clone auth
-    let token = auth::get_token()?
-        .ok_or_else(|| "Not authenticated. Please sign in with GitHub first.".to_string())?;
+    // Get token for clone auth (keychain, env vars, or gh CLI)
+    let token = auth::get_token_from_env_or_gh()?
+        .ok_or_else(|| "Not authenticated. Please sign in with GitHub or the gh CLI.".to_string())?;
 
     // Clone in a blocking task to not block the async runtime
     let clone_url_owned = clone_url.clone();


### PR DESCRIPTION
Closes #38

All GitHub API calls (`list_repo_pulls`, `list_repo_issues`, `get_repo_activity`, `create_pull_request`, `get_pr_for_branch`, `clone_and_register`, and the status bar auth check) now fall back to the gh CLI token (`gh auth token`) and `GH_TOKEN`/`GITHUB_TOKEN` env vars when no keychain token is set.

Users with the GitHub CLI already authenticated no longer need to sign in separately in Workroot.