### PR TITLE
chore: bump version to 0.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 
 [build-dependencies]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Version bump for the 0.1.4 release.

**Changes since 0.1.3:**
- fix: backspace in terminal + WebGL renderer (#40)
- fix: auto-replace spaces with dashes in branch name input (#36, #43)
- feat: clickable links in terminal output (#39, #44)
- feat: manual check for updates button in Settings (#41, #45)
- fix: use gh CLI / env token for all GitHub API calls (#38, #46)
- feat: persist terminals across worktree switches (#37, #42, #47)