### PR TITLE
ui: slim down quick actions bar and auto-hide

### DIFF
--- a/src/components/QuickActions.tsx
+++ b/src/components/QuickActions.tsx
@@ -22,7 +22,7 @@ interface ActionButton {
   id: string;
   icon: string;
   label: string;
-  group: "git" | "tools" | "view";
+  group: "git" | "view";
 }
 
 /* ------------------------------------------------------------------ */
@@ -34,15 +34,8 @@ const ACTIONS: ActionButton[] = [
   { id: "commit", icon: "\u2713", label: "Commit", group: "git" },
   { id: "push", icon: "\u2191", label: "Push", group: "git" },
   { id: "pull", icon: "\u2193", label: "Pull", group: "git" },
-  { id: "stash", icon: "\u21B3", label: "Stash", group: "git" },
-  // Tools
-  { id: "test", icon: "\u25B6", label: "Tests", group: "tools" },
-  { id: "build", icon: "\u2692", label: "Build", group: "tools" },
-  { id: "lint", icon: "\u2261", label: "Lint", group: "tools" },
   // View
   { id: "diff", icon: "\u00B1", label: "Diff", group: "view" },
-  { id: "blame", icon: "\u2263", label: "Blame", group: "view" },
-  { id: "recording", icon: "\u25CF", label: "Record", group: "view" },
 ];
 
 /* ------------------------------------------------------------------ */
@@ -90,34 +83,43 @@ export function QuickActions({
     return () => clearInterval(interval);
   }, [checkStatus]);
 
+  const [hovered, setHovered] = useState(false);
+
   if (worktreeId === null || worktreePath === null) return null;
 
-  const groups: Array<"git" | "tools" | "view"> = ["git", "tools", "view"];
+  const groups: Array<"git" | "view"> = ["git", "view"];
+  const showDock = visible && hovered;
 
   return (
-    <div className={`qa-dock ${visible ? "qa-dock--visible" : ""}`}>
-      {/* Git status indicator */}
-      <div
-        className={`qa-status-dot ${isDirty ? "qa-status-dot--dirty" : "qa-status-dot--clean"}`}
-        title={isDirty ? "Working tree has changes" : "Working tree is clean"}
-      />
+    <div
+      className="qa-hover-zone"
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      <div className={`qa-dock ${showDock ? "qa-dock--visible" : ""}`}>
+        {/* Git status indicator */}
+        <div
+          className={`qa-status-dot ${isDirty ? "qa-status-dot--dirty" : "qa-status-dot--clean"}`}
+          title={isDirty ? "Working tree has changes" : "Working tree is clean"}
+        />
 
-      {groups.map((group, gi) => (
-        <div key={group} className="qa-group">
-          {gi > 0 && <div className="qa-divider" />}
-          {ACTIONS.filter((a) => a.group === group).map((action) => (
-            <button
-              key={action.id}
-              className="qa-btn"
-              onClick={() => onAction(action.id)}
-              title={action.label}
-            >
-              <span className="qa-btn-icon">{action.icon}</span>
-              <span className="qa-btn-label">{action.label}</span>
-            </button>
-          ))}
-        </div>
-      ))}
+        {groups.map((group, gi) => (
+          <div key={group} className="qa-group">
+            {gi > 0 && <div className="qa-divider" />}
+            {ACTIONS.filter((a) => a.group === group).map((action) => (
+              <button
+                key={action.id}
+                className="qa-btn"
+                onClick={() => onAction(action.id)}
+                title={action.label}
+              >
+                <span className="qa-btn-icon">{action.icon}</span>
+                <span className="qa-btn-label">{action.label}</span>
+              </button>
+            ))}
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/styles/quick-actions.css
+++ b/src/styles/quick-actions.css
@@ -1,12 +1,22 @@
 /* ==========================================================
-   Quick Actions — Floating macOS Dock-style bar
+   Quick Actions — Floating macOS Dock-style bar (auto-hide)
    ========================================================== */
 
-.qa-dock {
+.qa-hover-zone {
   position: fixed;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 300px;
+  height: 48px;
+  z-index: 9000;
+}
+
+.qa-dock {
+  position: absolute;
   bottom: 16px;
   left: 50%;
-  transform: translateX(-50%) translateY(100%);
+  transform: translateX(-50%) translateY(20px);
   display: flex;
   align-items: center;
   gap: 4px;
@@ -19,12 +29,12 @@
   box-shadow:
     0 12px 40px rgba(0, 0, 0, 0.5),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9000;
   opacity: 0;
   transition:
     transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1),
     opacity 0.2s ease;
   pointer-events: none;
+  white-space: nowrap;
 }
 
 .qa-dock--visible {


### PR DESCRIPTION
## Summary
- Remove redundant actions (Stash, Tests, Build, Lint, Blame, Record) — these are already accessible via the terminal
- Keep only core git actions: Commit, Push, Pull, Diff
- Auto-hide the dock by default; reveals on hover at the bottom edge

## Test plan
- [ ] Verify dock is hidden by default when a worktree is selected
- [ ] Hover bottom-center of window — dock should slide up
- [ ] Move mouse away — dock should hide again
- [ ] Verify only 4 buttons appear: Commit, Push, Pull, Diff