### PR TITLE
fix: make top tab bar horizontally scrollable

### DIFF
--- a/src/components/ContentToolbar.tsx
+++ b/src/components/ContentToolbar.tsx
@@ -156,7 +156,9 @@ export function ContentToolbar({
   useEffect(() => {
     const el = tabsRef.current;
     if (!el) return;
-    const activeEl = el.querySelector(".content-toolbar__tab--active") as HTMLElement | null;
+    const activeEl = el.querySelector(
+      ".content-toolbar__tab--active",
+    ) as HTMLElement | null;
     activeEl?.scrollIntoView({ block: "nearest", inline: "nearest" });
   }, [activeTab]);
 
@@ -194,7 +196,14 @@ export function ContentToolbar({
             type="button"
             aria-label="Scroll tabs left"
           >
-            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+            <svg
+              viewBox="0 0 16 16"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
               <path d="M10 12L6 8l4-4" />
             </svg>
           </button>
@@ -221,7 +230,14 @@ export function ContentToolbar({
             type="button"
             aria-label="Scroll tabs right"
           >
-            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+            <svg
+              viewBox="0 0 16 16"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
               <path d="M6 4l4 4-4 4" />
             </svg>
           </button>

--- a/src/styles/content-toolbar.css
+++ b/src/styles/content-toolbar.css
@@ -119,7 +119,9 @@
   color: var(--text-muted);
   cursor: pointer;
   padding: 0;
-  transition: color 0.12s, background-color 0.12s;
+  transition:
+    color 0.12s,
+    background-color 0.12s;
   z-index: 1;
 }
 


### PR DESCRIPTION
## Summary
- Wraps the tabs in a `content-toolbar__tabs-wrapper` flex container
- Changes `overflow: hidden` → `overflow-x: auto` with hidden scrollbar (CSS `scrollbar-width: none`)
- Adds `<` / `>` chevron scroll buttons that appear dynamically when overflow is detected via `ResizeObserver` + scroll event
- Scrolls the active tab into view automatically when the active tab changes

Closes #52

## Test plan
- [ ] Narrow the window until tabs overflow — left/right arrows appear and allow scrolling
- [ ] Click a clipped tab via the arrow — it scrolls into view
- [ ] Widen the window back — arrows disappear
- [ ] Switch tabs programmatically — active tab scrolls into view