### PR TITLE
fix: auto-select newly created worktree

### DIFF
--- a/src/components/ProjectGroup.tsx
+++ b/src/components/ProjectGroup.tsx
@@ -21,7 +21,14 @@ export function ProjectGroup({
   project,
   defaultExpanded = false,
 }: ProjectGroupProps) {
-  const { selectedProjectId, setSelectedProjectId } = useUiStore();
+  const {
+    selectedProjectId,
+    setSelectedProjectId,
+    setSelectedWorktreeId,
+    setSelectedWorktreePath,
+    setSelectedWorktreeName,
+    setShowSettings,
+  } = useUiStore();
   const isSelected = selectedProjectId === project.id;
   const [expanded, setExpanded] = useState(defaultExpanded);
   const [showNewWorktree, setShowNewWorktree] = useState(false);
@@ -51,11 +58,25 @@ export function ProjectGroup({
     async (e: React.FormEvent) => {
       e.preventDefault();
       if (!newBranchName.trim()) return;
-      await createWorktree(newBranchName.trim(), createNew);
+      const newWorktree = await createWorktree(newBranchName.trim(), createNew);
       setNewBranchName("");
       setShowNewWorktree(false);
+      if (newWorktree) {
+        setSelectedWorktreeId(newWorktree.id);
+        setSelectedWorktreePath(newWorktree.path);
+        setSelectedWorktreeName(newWorktree.branch_name);
+        setShowSettings(false);
+      }
     },
-    [newBranchName, createNew, createWorktree],
+    [
+      newBranchName,
+      createNew,
+      createWorktree,
+      setSelectedWorktreeId,
+      setSelectedWorktreePath,
+      setSelectedWorktreeName,
+      setShowSettings,
+    ],
   );
 
   const handleDelete = useCallback(

--- a/src/hooks/useWorktrees.ts
+++ b/src/hooks/useWorktrees.ts
@@ -63,19 +63,24 @@ export function useWorktrees(projectId: number | null) {
   }, [projectId, loadWorktrees]);
 
   const createWorktree = useCallback(
-    async (branchName: string, createNewBranch: boolean) => {
-      if (projectId === null) return;
+    async (
+      branchName: string,
+      createNewBranch: boolean,
+    ): Promise<WorktreeInfo | null> => {
+      if (projectId === null) return null;
       setIsLoading(true);
       setError(null);
       try {
-        await invoke<WorktreeInfo>("create_worktree", {
+        const newWorktree = await invoke<WorktreeInfo>("create_worktree", {
           projectId,
           branchName,
           createNewBranch,
         });
         await loadWorktrees();
+        return newWorktree;
       } catch (err: unknown) {
         setError(String(err));
+        return null;
       } finally {
         setIsLoading(false);
       }


### PR DESCRIPTION
## Summary
- Return the created `WorktreeInfo` from `createWorktree` in `useWorktrees.ts` (was previously discarded)
- In `ProjectGroup.handleCreateWorktree`, call `setSelectedWorktreeId/Path/Name` on the new worktree immediately after creation

The user now lands in the new worktree automatically — no extra click needed.

Closes #76