### PR TITLE
ui: migrate all dialogs and modals to shadcn Dialog/AlertDialog

### DIFF
--- a/src/components/AppPerformance.tsx
+++ b/src/components/AppPerformance.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import "../styles/app-performance.css";
+import { Dialog, DialogContent } from "./ui/dialog";
 
 interface AppMetrics {
   db_size_bytes: number;
@@ -81,8 +82,13 @@ export function AppPerformance({ onClose }: AppPerformanceProps) {
     : [];
 
   return (
-    <div className="appperf-backdrop" onClick={onClose}>
-      <div className="appperf-panel" onClick={(e) => e.stopPropagation()}>
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent className="appperf-panel">
         <div className="appperf-header">
           <h3 className="appperf-title">App Performance</h3>
           <div className="appperf-header-actions">
@@ -116,7 +122,7 @@ export function AppPerformance({ onClose }: AppPerformanceProps) {
             </div>
           )}
         </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/components/AppThemePicker.tsx
+++ b/src/components/AppThemePicker.tsx
@@ -3,6 +3,7 @@ import { BUILTIN_THEMES, getAppThemeById } from "../themes/builtin";
 import { applyTheme, saveThemeId } from "../themes/engine";
 import type { AppTheme } from "../themes/engine";
 import "../styles/app-theme-picker.css";
+import { Dialog, DialogContent } from "./ui/dialog";
 
 interface AppThemePickerProps {
   currentThemeId: string;
@@ -41,14 +42,16 @@ export function AppThemePicker({
   );
 
   return (
-    <div
-      className="app-theme-backdrop"
-      onClick={() => {
-        applyTheme(getAppThemeById(currentThemeId));
-        onClose();
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) {
+          applyTheme(getAppThemeById(currentThemeId));
+          onClose();
+        }
       }}
     >
-      <div className="app-theme-panel" onClick={(e) => e.stopPropagation()}>
+      <DialogContent className="app-theme-panel">
         <div className="app-theme-header">
           <h3 className="app-theme-title">App Theme</h3>
           <button
@@ -74,8 +77,8 @@ export function AppThemePicker({
             />
           ))}
         </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }
 

--- a/src/components/ClipboardHistory.tsx
+++ b/src/components/ClipboardHistory.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { Dialog, DialogContent } from "./ui/dialog";
 
 interface ClipboardEntry {
   id: number;
@@ -94,8 +95,13 @@ export function ClipboardHistory({ onClose }: ClipboardHistoryProps) {
   }, []);
 
   return (
-    <div className="cliph-backdrop" onClick={onClose}>
-      <div className="cliph-panel" onClick={(e) => e.stopPropagation()}>
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent className="cliph-panel">
         <div className="cliph-header">
           <h3 className="cliph-title">Clipboard History</h3>
           <div className="cliph-header-actions">
@@ -189,7 +195,7 @@ export function ClipboardHistory({ onClose }: ClipboardHistoryProps) {
             })
           )}
         </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/components/CommandBookmarks.tsx
+++ b/src/components/CommandBookmarks.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import "../styles/command-bookmarks.css";
+import { Dialog, DialogContent } from "./ui/dialog";
 
 interface Bookmark {
   id: number;
@@ -171,8 +172,13 @@ export function CommandBookmarks({
   const projectBookmarks = filtered.filter((b) => b.project_id !== null);
 
   return (
-    <div className="bookmarks-backdrop" onClick={onClose}>
-      <div className="bookmarks-panel" onClick={(e) => e.stopPropagation()}>
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent className="bookmarks-panel">
         <div className="bookmarks-header">
           <h3 className="bookmarks-title">Command Bookmarks</h3>
           <div className="bookmarks-header-actions">
@@ -314,8 +320,8 @@ export function CommandBookmarks({
             </>
           )}
         </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }
 

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect, useRef, useMemo } from "react";
 import type { Command } from "../hooks/useCommandRegistry";
+import { Dialog, DialogContent } from "./ui/dialog";
 
 interface CommandPaletteProps {
   open: boolean;
@@ -99,9 +100,13 @@ export function CommandPalette({
   let flatIndex = 0;
 
   return (
-    <>
-      <div className="cmd-palette-backdrop" onClick={onClose} />
-      <div className="cmd-palette" role="dialog" aria-label="Command palette">
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent className="cmd-palette" aria-label="Command palette">
         <div className="cmd-palette-input-wrap">
           <SearchIcon />
           <input
@@ -158,8 +163,8 @@ export function CommandPalette({
             ))
           )}
         </div>
-      </div>
-    </>
+      </DialogContent>
+    </Dialog>
   );
 }
 

--- a/src/components/CoverageReport.tsx
+++ b/src/components/CoverageReport.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useMemo } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import "../styles/coverage-report.css";
+import { Dialog, DialogContent } from "./ui/dialog";
 
 interface CoverageEntry {
   file: string;
@@ -52,8 +53,13 @@ export function CoverageReport({ cwd, onClose }: CoverageReportProps) {
   }, [entries]);
 
   return (
-    <div className="coverage-backdrop" onClick={onClose}>
-      <div className="coverage-panel" onClick={(e) => e.stopPropagation()}>
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent className="coverage-panel">
         <div className="coverage-header">
           <h3 className="coverage-title">Coverage Report</h3>
           <div className="coverage-header-actions">
@@ -143,7 +149,7 @@ export function CoverageReport({ cwd, onClose }: CoverageReportProps) {
             </>
           )}
         </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/components/DependencyAnalyzer.tsx
+++ b/src/components/DependencyAnalyzer.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect, useMemo } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { Dialog, DialogContent } from "./ui/dialog";
 
 interface DependencyInfo {
   name: string;
@@ -121,8 +122,13 @@ export function DependencyAnalyzer({ cwd, onClose }: DependencyAnalyzerProps) {
   ];
 
   return (
-    <div className="depan-backdrop" onClick={onClose}>
-      <div className="depan-panel" onClick={(e) => e.stopPropagation()}>
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent className="depan-panel">
         <div className="depan-header">
           <h3 className="depan-title">Dependencies</h3>
           <div className="depan-header-actions">
@@ -226,7 +232,7 @@ export function DependencyAnalyzer({ cwd, onClose }: DependencyAnalyzerProps) {
             <div className="depan-empty">Unable to analyze dependencies.</div>
           )}
         </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/components/DirectoryStats.tsx
+++ b/src/components/DirectoryStats.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect, useMemo } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { Dialog, DialogContent } from "./ui/dialog";
 
 interface ExtensionStat {
   extension: string;
@@ -89,8 +90,13 @@ export function DirectoryStats({ cwd, onClose }: DirectoryStatsProps) {
   }, [stats]);
 
   return (
-    <div className="dirstats-backdrop" onClick={onClose}>
-      <div className="dirstats-panel" onClick={(e) => e.stopPropagation()}>
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent className="dirstats-panel">
         <div className="dirstats-header">
           <h3 className="dirstats-title">Directory Stats</h3>
           <div className="dirstats-header-actions">
@@ -200,7 +206,7 @@ export function DirectoryStats({ cwd, onClose }: DirectoryStatsProps) {
             </div>
           )}
         </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/components/DockerPanel.tsx
+++ b/src/components/DockerPanel.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import "../styles/docker-panel.css";
+import { Dialog, DialogContent } from "./ui/dialog";
 
 interface ContainerInfo {
   id: string;
@@ -76,8 +77,13 @@ export function DockerPanel({ cwd, onClose }: DockerPanelProps) {
   };
 
   return (
-    <div className="docker-backdrop" onClick={onClose}>
-      <div className="docker-panel" onClick={(e) => e.stopPropagation()}>
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent className="docker-panel">
         <div className="docker-header">
           <h3 className="docker-title">Docker</h3>
           <div className="docker-header-actions">
@@ -173,7 +179,7 @@ export function DockerPanel({ cwd, onClose }: DockerPanelProps) {
             </>
           )}
         </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/components/DoraMetrics.tsx
+++ b/src/components/DoraMetrics.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { Dialog, DialogContent } from "./ui/dialog";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -186,8 +187,13 @@ export function DoraMetrics({ projectId, onClose }: DoraMetricsProps) {
   const maxWeekly = metrics ? Math.max(...metrics.weekly_deployments, 1) : 1;
 
   return (
-    <div className="dora-backdrop" onClick={onClose}>
-      <div className="dora-panel" onClick={(e) => e.stopPropagation()}>
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent className="dora-panel">
         {/* Header */}
         <div className="dora-header">
           <h3 className="dora-title">DORA Metrics</h3>
@@ -390,7 +396,7 @@ export function DoraMetrics({ projectId, onClose }: DoraMetricsProps) {
             <div className="dora-empty">No metrics data available.</div>
           )}
         </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/components/FlakyTests.tsx
+++ b/src/components/FlakyTests.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import "../styles/flaky-tests.css";
+import { Dialog, DialogContent } from "./ui/dialog";
 
 interface FlakyTest {
   test_name: string;
@@ -51,8 +52,13 @@ export function FlakyTests({ cwd, onClose }: FlakyTestsProps) {
   };
 
   return (
-    <div className="flaky-backdrop" onClick={onClose}>
-      <div className="flaky-panel" onClick={(e) => e.stopPropagation()}>
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent className="flaky-panel">
         <div className="flaky-header">
           <h3 className="flaky-title">Flaky Tests</h3>
           <div className="flaky-header-actions">
@@ -113,7 +119,7 @@ export function FlakyTests({ cwd, onClose }: FlakyTestsProps) {
             </table>
           )}
         </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/components/GitLogViewer.tsx
+++ b/src/components/GitLogViewer.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { Dialog, DialogContent } from "./ui/dialog";
 
 interface CommitEntry {
   id: string;
@@ -122,8 +123,13 @@ export function GitLogViewer({ worktreeId, onClose }: GitLogViewerProps) {
   }, []);
 
   return (
-    <div className="gitlog-backdrop" onClick={onClose}>
-      <div className="gitlog-panel" onClick={(e) => e.stopPropagation()}>
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent className="gitlog-panel">
         <div className="gitlog-header">
           <h3 className="gitlog-title">Git Log</h3>
           <button className="gitlog-close" onClick={onClose}>
@@ -232,7 +238,7 @@ export function GitLogViewer({ worktreeId, onClose }: GitLogViewerProps) {
             </>
           )}
         </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/components/NotificationCenter.tsx
+++ b/src/components/NotificationCenter.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import "../styles/notification-center.css";
+import { Dialog, DialogContent } from "./ui/dialog";
 
 interface Notification {
   id: string;
@@ -70,9 +71,13 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
   if (!open) return null;
 
   return (
-    <>
-      <div className="notif-backdrop" onClick={onClose} />
-      <div className="notif-panel">
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent className="notif-panel">
         <div className="notif-header">
           <h3 className="notif-title">
             Notifications
@@ -123,7 +128,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
             </div>
           )}
         </div>
-      </div>
-    </>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import "../styles/onboarding.css";
+import { Dialog, DialogContent } from "./ui/dialog";
 
 interface OnboardingWizardProps {
   onComplete: () => void;
@@ -55,8 +56,8 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
   };
 
   return (
-    <div className="onboarding-overlay">
-      <div className="onboarding-card">
+    <Dialog open>
+      <DialogContent className="onboarding-card">
         {step === "welcome" && (
           <>
             <h2 className="onboarding-title">Welcome to Workroot</h2>
@@ -162,7 +163,7 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
             />
           ))}
         </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/components/PluginRuntime.tsx
+++ b/src/components/PluginRuntime.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { Dialog, DialogContent } from "./ui/dialog";
 
 interface PluginDetail {
   name: string;
@@ -105,8 +106,13 @@ export function PluginRuntime({ cwd, onClose }: PluginRuntimeProps) {
   }, [cwd, installUrl, loadPlugins]);
 
   return (
-    <div className="plrt-backdrop" onClick={onClose}>
-      <div className="plrt-panel" onClick={(e) => e.stopPropagation()}>
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent className="plrt-panel">
         <div className="plrt-header">
           <h3 className="plrt-title">Plugin Runtime</h3>
           <div className="plrt-header-actions">
@@ -257,7 +263,7 @@ export function PluginRuntime({ cwd, onClose }: PluginRuntimeProps) {
             )}
           </div>
         </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { check } from "@tauri-apps/plugin-updater";
 import { relaunch } from "@tauri-apps/plugin-process";
+import { Dialog, DialogContent } from "./ui/dialog";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -594,13 +595,13 @@ export function SettingsPage({ onClose }: SettingsPageProps) {
   }
 
   return (
-    <div className="settings-page__backdrop" onClick={onClose}>
-      <div
-        className="settings-page__panel"
-        onClick={(e) => e.stopPropagation()}
-        role="dialog"
-        aria-label="Settings"
-      >
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent className="settings-page__panel" aria-label="Settings">
         {/* Header */}
         <div className="settings-page__header">
           <h2 className="settings-page__title">Settings</h2>
@@ -633,8 +634,8 @@ export function SettingsPage({ onClose }: SettingsPageProps) {
           {/* Content area */}
           <div className="settings-page__content">{renderContent()}</div>
         </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }
 

--- a/src/components/SshManager.tsx
+++ b/src/components/SshManager.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import "../styles/ssh-manager.css";
+import { Dialog, DialogContent } from "./ui/dialog";
 
 interface SshConnection {
   id: number;
@@ -159,8 +160,13 @@ export function SshManager({ onClose, onConnect }: SshManagerProps) {
   );
 
   return (
-    <div className="ssh-backdrop" onClick={onClose}>
-      <div className="ssh-panel" onClick={(e) => e.stopPropagation()}>
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent className="ssh-panel">
         <div className="ssh-header">
           <h3 className="ssh-title">SSH Connection Manager</h3>
           <div className="ssh-header-actions">
@@ -354,7 +360,7 @@ export function SshManager({ onClose, onConnect }: SshManagerProps) {
             })
           )}
         </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/components/TaskRunner.tsx
+++ b/src/components/TaskRunner.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import "../styles/task-runner.css";
+import { Dialog, DialogContent } from "./ui/dialog";
 
 interface TaskDefinition {
   name: string;
@@ -75,8 +76,13 @@ export function TaskRunner({ cwd, onRunCommand, onClose }: TaskRunnerProps) {
   }, [filtered]);
 
   return (
-    <div className="taskrunner-backdrop" onClick={onClose}>
-      <div className="taskrunner-panel" onClick={(e) => e.stopPropagation()}>
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent className="taskrunner-panel">
         <div className="taskrunner-header">
           <h3 className="taskrunner-title">Task Runner</h3>
           <div className="taskrunner-header-actions">
@@ -146,7 +152,7 @@ export function TaskRunner({ cwd, onRunCommand, onClose }: TaskRunnerProps) {
             ))
           )}
         </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/components/TaskScheduler.tsx
+++ b/src/components/TaskScheduler.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { Dialog, DialogContent } from "./ui/dialog";
 
 interface ScheduledTask {
   id: number;
@@ -117,8 +118,13 @@ export function TaskScheduler({ onClose }: TaskSchedulerProps) {
   );
 
   return (
-    <div className="tasksched-backdrop" onClick={onClose}>
-      <div className="tasksched-panel" onClick={(e) => e.stopPropagation()}>
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent className="tasksched-panel">
         <div className="tasksched-header">
           <h3 className="tasksched-title">Task Scheduler</h3>
           <button className="tasksched-close" onClick={onClose}>
@@ -256,7 +262,7 @@ export function TaskScheduler({ onClose }: TaskSchedulerProps) {
             ))
           )}
         </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/components/TerminalThemeSelector.tsx
+++ b/src/components/TerminalThemeSelector.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { TERMINAL_THEMES, getThemeById } from "../lib/terminalThemes";
 import "../styles/terminal-themes.css";
+import { Dialog, DialogContent } from "./ui/dialog";
 
 interface TerminalThemeSelectorProps {
   currentThemeId: string;
@@ -37,11 +38,13 @@ export function TerminalThemeSelector({
   );
 
   return (
-    <div className="theme-selector-backdrop" onClick={onClose}>
-      <div
-        className="theme-selector-panel"
-        onClick={(e) => e.stopPropagation()}
-      >
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent className="theme-selector-panel">
         <div className="theme-selector-header">
           <h3 className="theme-selector-title">Terminal Theme</h3>
           <button className="theme-selector-close" onClick={onClose}>
@@ -178,7 +181,7 @@ export function TerminalThemeSelector({
             </div>
           </div>
         </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/components/ThemeEditor.tsx
+++ b/src/components/ThemeEditor.tsx
@@ -4,6 +4,7 @@ import { applyTheme } from "../themes/engine";
 import type { AppTheme } from "../themes/engine";
 import { loadCustomThemes, saveCustomThemes } from "../lib/customThemes";
 import "../styles/theme-editor.css";
+import { Dialog, DialogContent } from "./ui/dialog";
 
 interface ThemeEditorProps {
   currentThemeId: string;
@@ -209,8 +210,13 @@ export function ThemeEditor({
   );
 
   return (
-    <div className="theme-editor-backdrop" onClick={handleCancel}>
-      <div className="theme-editor-panel" onClick={(e) => e.stopPropagation()}>
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) handleCancel();
+      }}
+    >
+      <DialogContent className="theme-editor-panel">
         {/* Header */}
         <div className="theme-editor-header">
           <h3 className="theme-editor-title">Theme Editor</h3>
@@ -415,8 +421,8 @@ export function ThemeEditor({
             Save
           </button>
         </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }
 

--- a/src/components/WorktreeItem.tsx
+++ b/src/components/WorktreeItem.tsx
@@ -1,6 +1,12 @@
 import { useState, useCallback } from "react";
 import type { WorktreeInfo, DeleteWarnings } from "../hooks/useWorktrees";
 import { useUiStore } from "../stores/uiStore";
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogAction,
+  AlertDialogCancel,
+} from "./ui/alert-dialog";
 
 interface WorktreeItemProps {
   worktree: WorktreeInfo;
@@ -167,11 +173,15 @@ export function WorktreeItem({
         </>
       )}
 
-      {deleteConfirm && (
-        <>
-          <div className="context-menu-backdrop" onClick={handleCancelDelete} />
-          <div className="delete-confirm-dialog">
-            <div className="delete-confirm-title">Delete worktree?</div>
+      <AlertDialog
+        open={!!deleteConfirm}
+        onOpenChange={(open) => {
+          if (!open) handleCancelDelete();
+        }}
+      >
+        <AlertDialogContent className="delete-confirm-dialog">
+          <div className="delete-confirm-title">Delete worktree?</div>
+          {deleteConfirm && (
             <div className="delete-confirm-warnings">
               {deleteConfirm.warnings.is_dirty && (
                 <div className="delete-confirm-warning">
@@ -187,23 +197,23 @@ export function WorktreeItem({
                 </div>
               )}
             </div>
-            <div className="delete-confirm-actions">
-              <button
-                className="delete-confirm-btn cancel"
-                onClick={handleCancelDelete}
-              >
-                Cancel
-              </button>
-              <button
-                className="delete-confirm-btn confirm"
-                onClick={handleConfirmDelete}
-              >
-                Delete Anyway
-              </button>
-            </div>
+          )}
+          <div className="delete-confirm-actions">
+            <AlertDialogCancel
+              className="delete-confirm-btn cancel"
+              onClick={handleCancelDelete}
+            >
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              className="delete-confirm-btn confirm"
+              onClick={handleConfirmDelete}
+            >
+              Delete Anyway
+            </AlertDialogAction>
           </div>
-        </>
-      )}
+        </AlertDialogContent>
+      </AlertDialog>
     </>
   );
 }

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import * as React from "react";
+import { AlertDialog as AlertDialogPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+const AlertDialog = AlertDialogPrimitive.Root;
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger;
+const AlertDialogPortal = AlertDialogPrimitive.Portal;
+
+const AlertDialogOverlay = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-[9998] bg-black/50 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className,
+    )}
+    {...props}
+  />
+));
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName;
+
+const AlertDialogContent = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <AlertDialogPortal>
+    <AlertDialogOverlay />
+    <AlertDialogPrimitive.Content
+      ref={ref}
+      className={cn(className)}
+      {...props}
+    >
+      {children}
+    </AlertDialogPrimitive.Content>
+  </AlertDialogPortal>
+));
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName;
+
+const AlertDialogAction = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Action>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Action ref={ref} className={cn(className)} {...props} />
+));
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName;
+
+const AlertDialogCancel = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Cancel ref={ref} className={cn(className)} {...props} />
+));
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName;
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogAction,
+  AlertDialogCancel,
+};

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import * as React from "react";
+import { Dialog as DialogPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+const Dialog = DialogPrimitive.Root;
+const DialogTrigger = DialogPrimitive.Trigger;
+const DialogPortal = DialogPrimitive.Portal;
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-[9998] bg-black/50 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className,
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+/**
+ * DialogContent — renders via portal with an overlay behind it.
+ * Does NOT impose its own positioning so each panel's existing CSS
+ * (position: fixed; top: X%; left: 50%; transform: translateX(-50%))
+ * continues to work unchanged.
+ */
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content ref={ref} className={cn(className)} {...props}>
+      {children}
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogClose,
+  DialogTrigger,
+  DialogContent,
+};

--- a/src/styles/app-performance.css
+++ b/src/styles/app-performance.css
@@ -2,15 +2,6 @@
    App Performance Dashboard – System monitor style
    ========================================================== */
 
-.appperf-backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.6);
-  backdrop-filter: blur(4px);
-  z-index: 9998;
-  animation: cmd-backdrop-in 0.12s ease-out;
-}
-
 .appperf-panel {
   position: fixed;
   top: 15%;

--- a/src/styles/app-theme-picker.css
+++ b/src/styles/app-theme-picker.css
@@ -2,15 +2,6 @@
    App Theme Picker
    ========================================================== */
 
-.app-theme-backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.6);
-  backdrop-filter: blur(4px);
-  z-index: 9998;
-  animation: cmd-backdrop-in 0.12s ease-out;
-}
-
 .app-theme-panel {
   position: fixed;
   top: 10%;

--- a/src/styles/clipboard-history.css
+++ b/src/styles/clipboard-history.css
@@ -2,15 +2,6 @@
    Clipboard History – Utility panel
    ========================================================== */
 
-.cliph-backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.6);
-  backdrop-filter: blur(4px);
-  z-index: 9998;
-  animation: cmd-backdrop-in 0.12s ease-out;
-}
-
 .cliph-panel {
   position: fixed;
   top: 10%;

--- a/src/styles/command-bookmarks.css
+++ b/src/styles/command-bookmarks.css
@@ -2,15 +2,6 @@
    Command Bookmarks Panel
    ========================================================== */
 
-.bookmarks-backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.6);
-  backdrop-filter: blur(4px);
-  z-index: 9998;
-  animation: cmd-backdrop-in 0.12s ease-out;
-}
-
 .bookmarks-panel {
   position: fixed;
   top: 10%;

--- a/src/styles/command-palette.css
+++ b/src/styles/command-palette.css
@@ -2,15 +2,6 @@
    Command Palette (Cmd+K)
    ========================================================== */
 
-.cmd-palette-backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.6);
-  backdrop-filter: blur(4px);
-  z-index: 9998;
-  animation: cmd-backdrop-in 0.12s ease-out;
-}
-
 @keyframes cmd-backdrop-in {
   from {
     opacity: 0;

--- a/src/styles/coverage-report.css
+++ b/src/styles/coverage-report.css
@@ -2,15 +2,6 @@
    Coverage Report
    ========================================================== */
 
-.coverage-backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.6);
-  backdrop-filter: blur(4px);
-  z-index: 9998;
-  animation: cmd-backdrop-in 0.12s ease-out;
-}
-
 .coverage-panel {
   position: fixed;
   top: 8%;

--- a/src/styles/dependency-analyzer.css
+++ b/src/styles/dependency-analyzer.css
@@ -2,15 +2,6 @@
    Dependency Analyzer — Clean Registry / Catalog View
    ========================================================== */
 
-.depan-backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.6);
-  backdrop-filter: blur(4px);
-  z-index: 9998;
-  animation: cmd-backdrop-in 0.12s ease-out;
-}
-
 .depan-panel {
   position: fixed;
   top: 6%;

--- a/src/styles/directory-stats.css
+++ b/src/styles/directory-stats.css
@@ -2,15 +2,6 @@
    Directory Stats — Storage / Disk Usage Analyzer
    ========================================================== */
 
-.dirstats-backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.6);
-  backdrop-filter: blur(4px);
-  z-index: 9998;
-  animation: cmd-backdrop-in 0.12s ease-out;
-}
-
 .dirstats-panel {
   position: fixed;
   top: 6%;

--- a/src/styles/docker-panel.css
+++ b/src/styles/docker-panel.css
@@ -2,15 +2,6 @@
    Docker Panel
    ========================================================== */
 
-.docker-backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.6);
-  backdrop-filter: blur(4px);
-  z-index: 9998;
-  animation: cmd-backdrop-in 0.12s ease-out;
-}
-
 .docker-panel {
   position: fixed;
   top: 10%;

--- a/src/styles/dora-metrics.css
+++ b/src/styles/dora-metrics.css
@@ -2,15 +2,6 @@
    DORA Metrics Dashboard
    ========================================================== */
 
-.dora-backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.6);
-  backdrop-filter: blur(4px);
-  z-index: 9998;
-  animation: cmd-backdrop-in 0.12s ease-out;
-}
-
 .dora-panel {
   position: fixed;
   top: 6%;

--- a/src/styles/flaky-tests.css
+++ b/src/styles/flaky-tests.css
@@ -2,15 +2,6 @@
    Flaky Tests
    ========================================================== */
 
-.flaky-backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.6);
-  backdrop-filter: blur(4px);
-  z-index: 9998;
-  animation: cmd-backdrop-in 0.12s ease-out;
-}
-
 .flaky-panel {
   position: fixed;
   top: 8%;

--- a/src/styles/git-log.css
+++ b/src/styles/git-log.css
@@ -2,15 +2,6 @@
    Git Log Viewer – Commit history
    ========================================================== */
 
-.gitlog-backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.6);
-  backdrop-filter: blur(4px);
-  z-index: 9998;
-  animation: cmd-backdrop-in 0.12s ease-out;
-}
-
 .gitlog-panel {
   position: fixed;
   top: 6%;

--- a/src/styles/notification-center.css
+++ b/src/styles/notification-center.css
@@ -2,14 +2,6 @@
    Notification Center — Right-side slide-in panel
    ========================================================== */
 
-.notif-backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.35);
-  z-index: 9998;
-  animation: cmd-backdrop-in 0.12s ease-out;
-}
-
 .notif-panel {
   position: fixed;
   top: 0;

--- a/src/styles/onboarding.css
+++ b/src/styles/onboarding.css
@@ -1,13 +1,3 @@
-.onboarding-overlay {
-  position: fixed;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: rgba(0, 0, 0, 0.6);
-  z-index: 1000;
-}
-
 .onboarding-card {
   background: var(--bg-primary);
   border: 1px solid var(--border);

--- a/src/styles/plugin-runtime.css
+++ b/src/styles/plugin-runtime.css
@@ -2,15 +2,6 @@
    Plugin Runtime — App Store / Package Manager aesthetic
    ========================================================== */
 
-.plrt-backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.6);
-  backdrop-filter: blur(4px);
-  z-index: 9998;
-  animation: cmd-backdrop-in 0.12s ease-out;
-}
-
 .plrt-panel {
   position: fixed;
   top: 6%;

--- a/src/styles/settings-page.css
+++ b/src/styles/settings-page.css
@@ -2,28 +2,6 @@
    Settings Page (Full Panel)
    ========================================================== */
 
-.settings-page__backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.5);
-  backdrop-filter: blur(6px);
-  -webkit-backdrop-filter: blur(6px);
-  z-index: 9000;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  animation: settings-page-backdrop-in 0.15s ease-out;
-}
-
-@keyframes settings-page-backdrop-in {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-
 .settings-page__panel {
   width: 820px;
   max-width: calc(100vw - 60px);

--- a/src/styles/ssh-manager.css
+++ b/src/styles/ssh-manager.css
@@ -2,15 +2,6 @@
    SSH Connection Manager – Terminal/server admin aesthetic
    ========================================================== */
 
-.ssh-backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.6);
-  backdrop-filter: blur(4px);
-  z-index: 9998;
-  animation: cmd-backdrop-in 0.12s ease-out;
-}
-
 .ssh-panel {
   position: fixed;
   top: 8%;

--- a/src/styles/task-runner.css
+++ b/src/styles/task-runner.css
@@ -2,15 +2,6 @@
    Task Runner Panel
    ========================================================== */
 
-.taskrunner-backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.6);
-  backdrop-filter: blur(4px);
-  z-index: 9998;
-  animation: cmd-backdrop-in 0.12s ease-out;
-}
-
 .taskrunner-panel {
   position: fixed;
   top: 10%;

--- a/src/styles/task-scheduler.css
+++ b/src/styles/task-scheduler.css
@@ -2,15 +2,6 @@
    Task Scheduler – System admin / cron job management
    ========================================================== */
 
-.tasksched-backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.6);
-  backdrop-filter: blur(4px);
-  z-index: 9998;
-  animation: cmd-backdrop-in 0.12s ease-out;
-}
-
 .tasksched-panel {
   position: fixed;
   top: 8%;

--- a/src/styles/terminal-themes.css
+++ b/src/styles/terminal-themes.css
@@ -2,15 +2,6 @@
    Terminal Theme Selector
    ========================================================== */
 
-.theme-selector-backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.6);
-  backdrop-filter: blur(4px);
-  z-index: 9998;
-  animation: cmd-backdrop-in 0.12s ease-out;
-}
-
 .theme-selector-panel {
   position: fixed;
   top: 8%;

--- a/src/styles/theme-editor.css
+++ b/src/styles/theme-editor.css
@@ -2,15 +2,6 @@
    Theme Editor Modal
    ========================================================== */
 
-.theme-editor-backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.6);
-  backdrop-filter: blur(4px);
-  z-index: 9998;
-  animation: cmd-backdrop-in 0.12s ease-out;
-}
-
 .theme-editor-panel {
   position: fixed;
   top: 5%;


### PR DESCRIPTION
## Summary
- Creates `src/components/ui/dialog.tsx` and `alert-dialog.tsx` backed by `@radix-ui/react-dialog` and `@radix-ui/react-alert-dialog` (already installed)
- Migrates **22 components** from custom `backdrop + panel` divs to shadcn primitives:
  - `SettingsPage` → `Dialog`
  - `WorktreeItem` delete confirmation → `AlertDialog`
  - `OnboardingWizard` → `Dialog`
  - 19 panel components (DockerPanel, FlakyTests, CommandPalette, AppThemePicker, CoverageReport, AppPerformance, ClipboardHistory, GitLogViewer, CommandBookmarks, TaskRunner, DoraMetrics, DependencyAnalyzer, DirectoryStats, SshManager, TaskScheduler, PluginRuntime, ThemeEditor, NotificationCenter, TerminalThemeSelector) → `Dialog`
- Removes all custom `.xxx-backdrop` CSS blocks from 19 CSS files
- All panels retain their existing CSS classes for sizing/positioning — radix-ui adds focus trap, Escape-to-close, and proper ARIA roles on top

## Test plan
- [ ] Open Settings — closes on Escape or clicking outside
- [ ] Delete a worktree — AlertDialog confirmation appears, Cancel/Delete Anyway work
- [ ] Open any panel (Docker, Flaky Tests, etc.) — closes on Escape or click outside
- [ ] Onboarding wizard renders correctly on first run
- [ ] `pnpm typecheck`, `pnpm lint`, `pnpm format:check` all pass

Closes #59