### PR TITLE
feat: add worktree search/filter to sidebar

### DIFF
--- a/src/components/ProjectGroup.tsx
+++ b/src/components/ProjectGroup.tsx
@@ -16,11 +16,13 @@ import { Input } from "./ui/input";
 interface ProjectGroupProps {
   project: ProjectInfo;
   defaultExpanded?: boolean;
+  filter?: string;
 }
 
 export function ProjectGroup({
   project,
   defaultExpanded = false,
+  filter = "",
 }: ProjectGroupProps) {
   const {
     selectedProjectId,
@@ -54,6 +56,18 @@ export function ProjectGroup({
       loadWorktrees();
     }
   }, [expanded, loadWorktrees]);
+
+  // Auto-expand when a filter is active so worktrees load and can be searched.
+  useEffect(() => {
+    if (filter && !expanded) {
+      setExpanded(true);
+    }
+  }, [filter, expanded]);
+
+  const q = filter.trim().toLowerCase();
+  const filteredWorktrees = q
+    ? worktrees.filter((wt) => wt.branch_name.toLowerCase().includes(q))
+    : worktrees;
 
   const toggleExpanded = useCallback(() => {
     setExpanded((prev) => !prev);
@@ -142,7 +156,11 @@ export function ProjectGroup({
                 <span className="project-framework">{project.framework}</span>
               )}
               {expanded && worktrees.length > 0 && (
-                <span className="project-wt-count">{worktrees.length}</span>
+                <span className="project-wt-count">
+                  {q && filteredWorktrees.length !== worktrees.length
+                    ? `${filteredWorktrees.length}/${worktrees.length}`
+                    : worktrees.length}
+                </span>
               )}
               {!project.exists_locally && (
                 <span className="project-missing">missing</span>
@@ -155,15 +173,18 @@ export function ProjectGroup({
           <div className="project-children">
             {error && <div className="project-error">{error}</div>}
 
-            {worktrees.length === 0 && !showNewWorktree && (
-              <div className="project-empty">No worktrees</div>
+            {filteredWorktrees.length === 0 && !showNewWorktree && (
+              <div className="project-empty">
+                {q ? "No matches" : "No worktrees"}
+              </div>
             )}
 
             <div className="worktree-list" role="group">
-              {worktrees.map((wt) => (
+              {filteredWorktrees.map((wt) => (
                 <WorktreeItem
                   key={wt.id}
                   worktree={wt}
+                  highlight={filter}
                   onDelete={handleDelete}
                   onHide={handleHide}
                   onCheckWarnings={checkDeleteWarnings}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,6 +1,14 @@
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import { open } from "@tauri-apps/plugin-dialog";
-import { Plus, Settings, Search, MessageCircle, Bell, Sun } from "lucide-react";
+import {
+  Plus,
+  Settings,
+  Search,
+  MessageCircle,
+  Bell,
+  Sun,
+  X,
+} from "lucide-react";
 import { useProjects } from "../hooks/useProjects";
 import { useUiStore } from "../stores/uiStore";
 import { ProjectGroup } from "./ProjectGroup";
@@ -29,6 +37,7 @@ export function Sidebar({
   onOpenSettings,
 }: SidebarProps) {
   const { projects, registerLocal, error } = useProjects();
+  const [filter, setFilter] = useState("");
   const {
     showSettings,
     setShowSettings,
@@ -164,6 +173,30 @@ export function Sidebar({
 
       {error && <div className="sidebar-error">{error}</div>}
 
+      {/* Search / filter input */}
+      <div className="sidebar-search">
+        <Search className="sidebar-search-icon" />
+        <input
+          className="sidebar-search-input"
+          type="text"
+          placeholder="Filter worktrees…"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          onKeyDown={(e) => e.key === "Escape" && setFilter("")}
+          spellCheck={false}
+          aria-label="Filter worktrees"
+        />
+        {filter && (
+          <button
+            className="sidebar-search-clear"
+            onClick={() => setFilter("")}
+            aria-label="Clear filter"
+          >
+            <X className="size-3" />
+          </button>
+        )}
+      </div>
+
       <ScrollArea className="flex-1">
         <div className="py-1" role="tree">
           {projects.length === 0 ? (
@@ -175,7 +208,11 @@ export function Sidebar({
             </div>
           ) : (
             projects.map((project) => (
-              <ProjectGroup key={project.id} project={project} />
+              <ProjectGroup
+                key={project.id}
+                project={project}
+                filter={filter}
+              />
             ))
           )}
         </div>

--- a/src/components/WorktreeItem.tsx
+++ b/src/components/WorktreeItem.tsx
@@ -4,13 +4,37 @@ import { useUiStore } from "../stores/uiStore";
 
 interface WorktreeItemProps {
   worktree: WorktreeInfo;
+  highlight?: string;
   onDelete: (id: number) => void;
   onHide: (id: number) => void;
   onCheckWarnings: (id: number) => Promise<DeleteWarnings | null>;
 }
 
+/** Render `text` with the first occurrence of `query` wrapped in a highlight mark. */
+function HighlightedText({
+  text,
+  query,
+}: {
+  text: string;
+  query: string;
+}): React.ReactNode {
+  if (!query) return text;
+  const idx = text.toLowerCase().indexOf(query.toLowerCase());
+  if (idx === -1) return text;
+  return (
+    <>
+      {text.slice(0, idx)}
+      <mark className="wt-match-highlight">
+        {text.slice(idx, idx + query.length)}
+      </mark>
+      {text.slice(idx + query.length)}
+    </>
+  );
+}
+
 export function WorktreeItem({
   worktree,
+  highlight = "",
   onDelete,
   onHide,
   onCheckWarnings,
@@ -133,7 +157,9 @@ export function WorktreeItem({
             />
           </svg>
         </span>
-        <span className="worktree-branch-name">{worktree.branch_name}</span>
+        <span className="worktree-branch-name">
+          <HighlightedText text={worktree.branch_name} query={highlight} />
+        </span>
         <span className="worktree-indicators">
           <span
             className={`worktree-status-dot ${statusClass}`}

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -178,6 +178,69 @@
 
 /* ---- Header actions (now uses shadcn Button with Tailwind classes) ---- */
 
+/* ---- Search / filter bar ---- */
+
+.sidebar-search {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--border-subtle);
+  flex-shrink: 0;
+}
+
+.sidebar-search-icon {
+  width: 12px;
+  height: 12px;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.sidebar-search-input {
+  flex: 1;
+  font-family: var(--font-sans);
+  font-size: 0.75em;
+  color: var(--text-primary);
+  background: transparent;
+  border: none;
+  outline: none;
+  min-width: 0;
+}
+
+.sidebar-search-input::placeholder {
+  color: var(--text-muted);
+}
+
+.sidebar-search-clear {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  background: none;
+  border: none;
+  border-radius: 3px;
+  color: var(--text-muted);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: color 0.1s;
+}
+
+.sidebar-search-clear:hover {
+  color: var(--text-primary);
+}
+
+/* Match highlight inside worktree branch names */
+
+.wt-match-highlight {
+  background: color-mix(in srgb, var(--accent) 30%, transparent);
+  color: var(--accent);
+  border-radius: 2px;
+  padding: 0 1px;
+  font-style: normal;
+}
+
 /* ---- Scrollable content (now uses shadcn ScrollArea) ---- */
 
 .sidebar-error {


### PR DESCRIPTION
Closes #62

## Summary
- **Sidebar**: compact filter input (with search icon + clear button) sits between the header and the project list; Escape resets it; passes the query to every `ProjectGroup`
- **ProjectGroup**: auto-expands when a filter is typed so worktrees load immediately; badge shows filtered count (`2/5`); displays "No matches" when nothing fits
- **WorktreeItem**: `HighlightedText` helper splits the branch name at the matched substring and wraps it in `<mark class="wt-match-highlight">` for inline highlighting
- **CSS**: search bar styles + accent-coloured highlight mark

## Test plan
- [ ] Type a partial branch name — matching worktrees appear highlighted, others hidden
- [ ] Collapsed projects auto-expand and load worktrees when you start typing
- [ ] Badge shows `matched/total` count while filtering
- [ ] Clear button (×) and Escape both reset the filter
- [ ] Empty state shows "No matches" when a project has no matching worktrees
- [ ] Normal view is unchanged when the input is empty

🤖 Generated with [Claude Code](https://claude.ai/claude-code)