### PR TITLE
feat: notify when agent completes work in a worktree

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -139,6 +139,7 @@ function AppContent({
     setSelectedWorktreeName,
     showRightSidebar,
     setShowRightSidebar,
+    markAgentDone,
   } = useUiStore();
 
   const [isGitHubConnected, setIsGitHubConnected] = useState(false);
@@ -156,6 +157,37 @@ function AppContent({
     usePanels();
   const [blameFilePath, setBlameFilePath] = useState("");
   const [contentTab, setContentTab] = useState("terminal");
+  const [agentDoneToast, setAgentDoneToast] = useState<string | null>(null);
+
+  // Request notification permission once on mount.
+  useEffect(() => {
+    if ("Notification" in window && Notification.permission === "default") {
+      Notification.requestPermission().catch(() => {});
+    }
+  }, []);
+
+  // Stable refs so the callback doesn't need to be in dependency arrays.
+  const selectedWorktreeIdRef = useRef(selectedWorktreeId);
+  const selectedWorktreeNameRef = useRef(selectedWorktreeName);
+  selectedWorktreeIdRef.current = selectedWorktreeId;
+  selectedWorktreeNameRef.current = selectedWorktreeName;
+
+  const handleAgentComplete = useCallback(() => {
+    const id = selectedWorktreeIdRef.current;
+    const name = selectedWorktreeNameRef.current ?? "Terminal";
+    if (id !== null) markAgentDone(id);
+    if (!document.hasFocus()) {
+      if ("Notification" in window && Notification.permission === "granted") {
+        new Notification("Agent completed", {
+          body: `${name} is ready for review`,
+          silent: false,
+        });
+      }
+    } else {
+      setAgentDoneToast(name);
+      setTimeout(() => setAgentDoneToast(null), 5000);
+    }
+  }, [markAgentDone]);
 
   // Reset content tab and close tab-launched panels when switching worktrees
   useEffect(() => {
@@ -1023,6 +1055,7 @@ function AppContent({
             cwd={selectedWorktreePath}
             worktreeName={selectedWorktreeName ?? "Shell"}
             themeId={terminalThemeId}
+            onAgentComplete={handleAgentComplete}
           />
         </>
       ) : (
@@ -1593,6 +1626,32 @@ function AppContent({
           else if (action === "tests") openPanel("testRunnerPanel");
         }}
       />
+      {agentDoneToast && (
+        <div
+          style={{
+            position: "fixed",
+            bottom: "48px",
+            right: "16px",
+            background: "var(--bg-elevated)",
+            border: "1px solid var(--accent-muted)",
+            borderLeft: "3px solid var(--accent)",
+            borderRadius: "6px",
+            padding: "10px 14px",
+            fontSize: "12.5px",
+            color: "var(--text-primary)",
+            boxShadow: "0 4px 16px rgba(0,0,0,0.4)",
+            zIndex: 9999,
+            maxWidth: "280px",
+            pointerEvents: "none",
+          }}
+        >
+          <span style={{ color: "var(--accent)", marginRight: "8px" }}>✓</span>
+          Agent done in{" "}
+          <strong style={{ color: "var(--text-primary)" }}>
+            {agentDoneToast}
+          </strong>
+        </div>
+      )}
     </>
   );
 }

--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -31,6 +31,7 @@ interface TerminalPanelProps {
   cwd: string;
   worktreeName: string;
   themeId?: string;
+  onAgentComplete?: () => void;
 }
 
 let paneCounter = 0;
@@ -72,6 +73,7 @@ export function TerminalPanel({
   cwd,
   worktreeName,
   themeId,
+  onAgentComplete,
 }: TerminalPanelProps) {
   // All per-worktree tab states, keyed by cwd path.
   const [pathStates, setPathStates] = useState<Record<string, PathTabState>>(
@@ -371,6 +373,9 @@ export function TerminalPanel({
                       active={isActivePathAndTab && isFocusedPane}
                       visible={isActivePathAndTab}
                       themeId={themeId}
+                      onAgentComplete={
+                        isActivePathAndTab ? onAgentComplete : undefined
+                      }
                     />,
                     container,
                     paneId,
@@ -390,6 +395,7 @@ interface TerminalInstanceProps {
   active: boolean;
   visible?: boolean;
   themeId?: string;
+  onAgentComplete?: () => void;
 }
 
 async function loadTerminalSettings(): Promise<{
@@ -421,16 +427,26 @@ async function loadTerminalSettings(): Promise<{
   }
 }
 
+// Minimum bytes of PTY output to count as "agent activity" before we watch for idle.
+const ACTIVITY_THRESHOLD_BYTES = 500;
+// How long the terminal must be idle (ms) after activity before we fire onAgentComplete.
+const IDLE_TIMEOUT_MS = 4000;
+
 function TerminalInstance({
   cwd,
   active,
   visible = true,
   themeId,
+  onAgentComplete,
 }: TerminalInstanceProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const termRef = useRef<Terminal | null>(null);
   const ptyRef = useRef<IPty | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
+  const activityBytesRef = useRef(0);
+  const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const onAgentCompleteRef = useRef(onAgentComplete);
+  onAgentCompleteRef.current = onAgentComplete;
 
   // Create xterm + PTY on mount, destroy on unmount
   useEffect(() => {
@@ -528,10 +544,27 @@ function TerminalInstance({
 
         pty.onData((data: Uint8Array) => {
           term.write(data);
+          // Activity tracking for agent-complete detection.
+          activityBytesRef.current += data.length;
+          if (idleTimerRef.current) clearTimeout(idleTimerRef.current);
+          if (activityBytesRef.current >= ACTIVITY_THRESHOLD_BYTES) {
+            idleTimerRef.current = setTimeout(() => {
+              idleTimerRef.current = null;
+              if (activityBytesRef.current >= ACTIVITY_THRESHOLD_BYTES) {
+                onAgentCompleteRef.current?.();
+              }
+              activityBytesRef.current = 0;
+            }, IDLE_TIMEOUT_MS);
+          }
         });
 
         pty.onExit(() => {
           term.write("\r\n\x1b[90m[Process exited]\x1b[0m\r\n");
+          if (idleTimerRef.current) {
+            clearTimeout(idleTimerRef.current);
+            idleTimerRef.current = null;
+          }
+          activityBytesRef.current = 0;
         });
 
         term.onData((data: string) => {
@@ -561,6 +594,11 @@ function TerminalInstance({
     return () => {
       cancelled = true;
       clearTimeout(initTimer);
+      if (idleTimerRef.current) {
+        clearTimeout(idleTimerRef.current);
+        idleTimerRef.current = null;
+      }
+      activityBytesRef.current = 0;
       window.removeEventListener("keydown", preventBrowserNav, true);
       try {
         ptyRef.current?.kill();

--- a/src/components/WorktreeItem.tsx
+++ b/src/components/WorktreeItem.tsx
@@ -21,8 +21,11 @@ export function WorktreeItem({
     setSelectedWorktreePath,
     setSelectedWorktreeName,
     setShowSettings,
+    agentDoneWorktreeIds,
+    clearAgentDone,
   } = useUiStore();
   const isSelected = selectedWorktreeId === worktree.id;
+  const isAgentDone = agentDoneWorktreeIds.has(worktree.id);
   const [contextMenu, setContextMenu] = useState<{
     x: number;
     y: number;
@@ -36,6 +39,7 @@ export function WorktreeItem({
     setSelectedWorktreePath(worktree.path);
     setSelectedWorktreeName(worktree.branch_name);
     setShowSettings(false);
+    clearAgentDone(worktree.id);
   }, [
     worktree.id,
     worktree.path,
@@ -44,6 +48,7 @@ export function WorktreeItem({
     setSelectedWorktreePath,
     setSelectedWorktreeName,
     setShowSettings,
+    clearAgentDone,
   ]);
 
   const handleContextMenu = useCallback(
@@ -135,6 +140,9 @@ export function WorktreeItem({
         </span>
         <span className="worktree-branch-name">{worktree.branch_name}</span>
         <span className="worktree-indicators">
+          {isAgentDone && (
+            <span className="worktree-agent-done" title="Agent completed" />
+          )}
           <span
             className={`worktree-status-dot ${statusClass}`}
             title={worktree.status}

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -72,6 +72,22 @@ export function MainLayout({
   >(null);
   const [showSettings, setShowSettings] = useState(false);
   const [showRightSidebar, setShowRightSidebar] = useState(true);
+  const [agentDoneWorktreeIds, setAgentDoneWorktreeIds] = useState<Set<number>>(
+    () => new Set(),
+  );
+
+  const markAgentDone = useCallback((id: number) => {
+    setAgentDoneWorktreeIds((prev) => new Set(prev).add(id));
+  }, []);
+
+  const clearAgentDone = useCallback((id: number) => {
+    setAgentDoneWorktreeIds((prev) => {
+      const next = new Set(prev);
+      next.delete(id);
+      return next;
+    });
+  }, []);
+
   const dragging = useRef(false);
   const draggingRight = useRef(false);
 
@@ -156,6 +172,9 @@ export function MainLayout({
         setShowSettings,
         showRightSidebar,
         setShowRightSidebar,
+        agentDoneWorktreeIds,
+        markAgentDone,
+        clearAgentDone,
       }}
     >
       <div className="main-layout">

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -13,6 +13,9 @@ interface UiContextValue {
   setShowSettings: (show: boolean) => void;
   showRightSidebar: boolean;
   setShowRightSidebar: (show: boolean) => void;
+  agentDoneWorktreeIds: Set<number>;
+  markAgentDone: (id: number) => void;
+  clearAgentDone: (id: number) => void;
 }
 
 export const UiContext = createContext<UiContextValue>({
@@ -28,6 +31,9 @@ export const UiContext = createContext<UiContextValue>({
   setShowSettings: () => {},
   showRightSidebar: true,
   setShowRightSidebar: () => {},
+  agentDoneWorktreeIds: new Set(),
+  markAgentDone: () => {},
+  clearAgentDone: () => {},
 });
 
 export function useUiStore() {

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -579,6 +579,30 @@
   box-shadow: 0 0 3px rgba(239, 68, 68, 0.4);
 }
 
+/* ---- Agent-done pulse ---- */
+
+.worktree-agent-done {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background-color: var(--accent);
+  box-shadow: 0 0 5px var(--accent-glow);
+  animation: wt-agent-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes wt-agent-pulse {
+  0%,
+  100% {
+    opacity: 1;
+    box-shadow: 0 0 5px var(--accent-glow);
+  }
+  50% {
+    opacity: 0.6;
+    box-shadow: 0 0 10px var(--accent-glow);
+  }
+}
+
 /* ---- Dirty + Port badges ---- */
 
 .worktree-dirty {


### PR DESCRIPTION
## Summary
- **Idle detection in terminal**: `TerminalInstance` tracks PTY output — after >500 bytes of activity, starts a 4-second idle timer. When it fires, calls `onAgentComplete`.
- **Desktop notification**: `App.tsx` requests `Notification` permission on mount. When the window is not focused and agent completes → fires a native OS notification ("Agent completed in \<worktree\>").
- **In-app toast**: When the window is focused, shows a 5-second overlay banner at the bottom-right.
- **Sidebar badge**: `WorktreeItem` shows a pulsing accent dot when the agent completes. Clears on click.
- `uiStore` + `MainLayout` carry the `agentDoneWorktreeIds` set and `markAgentDone`/`clearAgentDone` helpers.

## Test plan
- Run a long command in a terminal (`sleep 5 && echo done`), switch to another app, confirm desktop notification appears
- Run a command while focused on the terminal tab, confirm in-app toast appears
- Switch to a different worktree while a command runs — the pulsing badge should appear on the first worktree's sidebar item after the command finishes
- Click the worktree item — badge should disappear

Closes #67