### PR TITLE
chore: remove content-toolbar.css stub after shadcn migration

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -70,7 +70,6 @@ import "./styles/browser-events.css";
 import "./styles/database-explorer.css";
 import "./styles/dashboard.css";
 import "./styles/status-bar.css";
-import "./styles/content-toolbar.css";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>

--- a/src/styles/content-toolbar.css
+++ b/src/styles/content-toolbar.css
@@ -1,1 +1,0 @@
-/* Content toolbar styles migrated to Tailwind/shadcn in ContentToolbar.tsx */


### PR DESCRIPTION
## Summary
- Removes `src/styles/content-toolbar.css` — a comment-only stub left behind after ContentToolbar was migrated to Tailwind/shadcn
- Removes its import from `src/main.tsx`

## Audit findings
Ran a full audit of all 86 CSS files in `src/styles/`. This was the only fully dead file (zero CSS rules, just a migration comment). All other CSS files still have active class usage.

The remaining CSS files will be cleaned up progressively as their components complete the shadcn migration.

Closes #61