### PR TITLE
feat: notify user when agent completes work in a worktree

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,11 @@ import { EnvPanel } from "./components/EnvPanel";
 import { ActiveProjectBadge } from "./components/ActiveProjectBadge";
 import { SettingsTab } from "./components/SettingsTab";
 import { TerminalPanel } from "./components/TerminalPanel";
+import {
+  AgentDoneToast,
+  type AgentDoneToastItem,
+} from "./components/AgentDoneToast";
+import { useAgentStore } from "./stores/agentStore";
 import { CommandPalette } from "./components/CommandPalette";
 import { CommandBookmarks } from "./components/CommandBookmarks";
 import { TerminalThemeSelector } from "./components/TerminalThemeSelector";
@@ -141,6 +146,10 @@ function AppContent({
     setShowRightSidebar,
   } = useUiStore();
 
+  // Agent-done notifications — state declared early so hook order is stable.
+  const { markDone, clearDone } = useAgentStore();
+  const [agentToasts, setAgentToasts] = useState<AgentDoneToastItem[]>([]);
+
   const [isGitHubConnected, setIsGitHubConnected] = useState(false);
   useEffect(() => {
     const check = () =>
@@ -231,6 +240,59 @@ function AppContent({
     }
     loadSwitcherData();
   }, [selectedProjectId, selectedWorktreeId]);
+
+  // Agent-done callbacks — declared after allWorktrees to avoid TDZ.
+  const handleAgentDone = useCallback(
+    (cwd: string) => {
+      markDone(cwd);
+      if (cwd === selectedWorktreePath) return;
+      const wt = allWorktrees.find((w) => w.path === cwd);
+      const name = wt?.branch_name ?? cwd.split("/").pop() ?? cwd;
+      const id = `${cwd}-${Date.now()}`;
+      setAgentToasts((prev) => [
+        ...prev,
+        { id, worktreeName: name, cwd, timestamp: Date.now() },
+      ]);
+      if ("Notification" in window) {
+        const fire = () =>
+          new Notification("Agent done", { body: name, silent: false });
+        if (Notification.permission === "granted") {
+          fire();
+        } else if (Notification.permission === "default") {
+          Notification.requestPermission().then((p) => {
+            if (p === "granted") fire();
+          });
+        }
+      }
+    },
+    [markDone, selectedWorktreePath, allWorktrees, setAgentToasts],
+  );
+
+  const handleDismissToast = useCallback((id: string) => {
+    setAgentToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  const handleJumpToast = useCallback(
+    (cwd: string) => {
+      const wt = allWorktrees.find((w) => w.path === cwd);
+      if (wt) {
+        setSelectedProjectId(wt.project_id);
+        setSelectedWorktreeId(wt.id);
+        setSelectedWorktreePath(wt.path);
+        setSelectedWorktreeName(wt.branch_name);
+      }
+      clearDone(cwd);
+      setAgentToasts((prev) => prev.filter((t) => t.cwd !== cwd));
+    },
+    [
+      allWorktrees,
+      clearDone,
+      setSelectedProjectId,
+      setSelectedWorktreeId,
+      setSelectedWorktreePath,
+      setSelectedWorktreeName,
+    ],
+  );
 
   // Stable refs for worktree selection actions
   const selectWorktree = useCallback(
@@ -1023,6 +1085,7 @@ function AppContent({
             cwd={selectedWorktreePath}
             worktreeName={selectedWorktreeName ?? "Shell"}
             themeId={terminalThemeId}
+            onAgentDone={handleAgentDone}
           />
         </>
       ) : (
@@ -1592,6 +1655,11 @@ function AppContent({
           } else if (action === "record") openPanel("terminalRecording");
           else if (action === "tests") openPanel("testRunnerPanel");
         }}
+      />
+      <AgentDoneToast
+        toasts={agentToasts}
+        onDismiss={handleDismissToast}
+        onJump={handleJumpToast}
       />
     </>
   );

--- a/src/components/AgentDoneToast.tsx
+++ b/src/components/AgentDoneToast.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useCallback } from "react";
+import "../styles/agent-toast.css";
+
+export interface AgentDoneToastItem {
+  id: string;
+  worktreeName: string;
+  cwd: string;
+  timestamp: number;
+}
+
+interface AgentDoneToastProps {
+  toasts: AgentDoneToastItem[];
+  onDismiss: (id: string) => void;
+  onJump: (cwd: string) => void;
+}
+
+const AUTO_DISMISS_MS = 6000;
+
+export function AgentDoneToast({
+  toasts,
+  onDismiss,
+  onJump,
+}: AgentDoneToastProps) {
+  // Auto-dismiss each toast after AUTO_DISMISS_MS
+  useEffect(() => {
+    if (toasts.length === 0) return;
+    const oldest = toasts[0];
+    const elapsed = Date.now() - oldest.timestamp;
+    const remaining = Math.max(0, AUTO_DISMISS_MS - elapsed);
+    const timer = setTimeout(() => onDismiss(oldest.id), remaining);
+    return () => clearTimeout(timer);
+  }, [toasts, onDismiss]);
+
+  const handleJump = useCallback(
+    (toast: AgentDoneToastItem) => {
+      onJump(toast.cwd);
+      onDismiss(toast.id);
+    },
+    [onJump, onDismiss],
+  );
+
+  if (toasts.length === 0) return null;
+
+  return (
+    <div className="agent-toast-stack" aria-live="polite">
+      {toasts.map((toast) => (
+        <div key={toast.id} className="agent-toast">
+          <div className="agent-toast__icon">
+            <svg
+              viewBox="0 0 16 16"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M3.5 8.5l3 3 6-7" />
+            </svg>
+          </div>
+          <div className="agent-toast__body">
+            <span className="agent-toast__title">Agent done</span>
+            <span className="agent-toast__name">{toast.worktreeName}</span>
+          </div>
+          <button
+            className="agent-toast__jump"
+            onClick={() => handleJump(toast)}
+            title="Switch to worktree"
+          >
+            Jump
+          </button>
+          <button
+            className="agent-toast__close"
+            onClick={() => onDismiss(toast.id)}
+            aria-label="Dismiss"
+          >
+            ×
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -31,6 +31,7 @@ interface TerminalPanelProps {
   cwd: string;
   worktreeName: string;
   themeId?: string;
+  onAgentDone?: (cwd: string) => void;
 }
 
 let paneCounter = 0;
@@ -72,6 +73,7 @@ export function TerminalPanel({
   cwd,
   worktreeName,
   themeId,
+  onAgentDone,
 }: TerminalPanelProps) {
   // All per-worktree tab states, keyed by cwd path.
   const [pathStates, setPathStates] = useState<Record<string, PathTabState>>(
@@ -371,6 +373,9 @@ export function TerminalPanel({
                       active={isActivePathAndTab && isFocusedPane}
                       visible={isActivePathAndTab}
                       themeId={themeId}
+                      onAgentDone={
+                        onAgentDone ? () => onAgentDone(path) : undefined
+                      }
                     />,
                     container,
                     paneId,
@@ -390,6 +395,7 @@ interface TerminalInstanceProps {
   active: boolean;
   visible?: boolean;
   themeId?: string;
+  onAgentDone?: () => void;
 }
 
 async function loadTerminalSettings(): Promise<{
@@ -426,11 +432,21 @@ function TerminalInstance({
   active,
   visible = true,
   themeId,
+  onAgentDone,
 }: TerminalInstanceProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const termRef = useRef<Terminal | null>(null);
   const ptyRef = useRef<IPty | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
+
+  // Agent-done detection: fires onAgentDone after >500 bytes of output
+  // followed by 2 seconds of silence since the last user keystroke.
+  const outputSinceInputRef = useRef(0);
+  const agentDoneTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const onAgentDoneRef = useRef(onAgentDone);
+  useEffect(() => {
+    onAgentDoneRef.current = onAgentDone;
+  }, [onAgentDone]);
 
   // Create xterm + PTY on mount, destroy on unmount
   useEffect(() => {
@@ -528,6 +544,17 @@ function TerminalInstance({
 
         pty.onData((data: Uint8Array) => {
           term.write(data);
+          // Agent-done detection: accumulate output bytes since last user input.
+          outputSinceInputRef.current += data.length;
+          if (outputSinceInputRef.current > 500) {
+            if (agentDoneTimerRef.current)
+              clearTimeout(agentDoneTimerRef.current);
+            agentDoneTimerRef.current = setTimeout(() => {
+              agentDoneTimerRef.current = null;
+              outputSinceInputRef.current = 0;
+              onAgentDoneRef.current?.();
+            }, 2000);
+          }
         });
 
         pty.onExit(() => {
@@ -536,6 +563,12 @@ function TerminalInstance({
 
         term.onData((data: string) => {
           pty.write(data);
+          // User typed — reset activity so short commands don't trigger notification.
+          outputSinceInputRef.current = 0;
+          if (agentDoneTimerRef.current) {
+            clearTimeout(agentDoneTimerRef.current);
+            agentDoneTimerRef.current = null;
+          }
         });
 
         term.onResize((e) => {
@@ -561,6 +594,7 @@ function TerminalInstance({
     return () => {
       cancelled = true;
       clearTimeout(initTimer);
+      if (agentDoneTimerRef.current) clearTimeout(agentDoneTimerRef.current);
       window.removeEventListener("keydown", preventBrowserNav, true);
       try {
         ptyRef.current?.kill();

--- a/src/components/WorktreeItem.tsx
+++ b/src/components/WorktreeItem.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback } from "react";
 import type { WorktreeInfo, DeleteWarnings } from "../hooks/useWorktrees";
 import { useUiStore } from "../stores/uiStore";
+import { useAgentStore } from "../stores/agentStore";
 import {
   AlertDialog,
   AlertDialogContent,
@@ -28,6 +29,7 @@ export function WorktreeItem({
     setSelectedWorktreeName,
     setShowSettings,
   } = useUiStore();
+  const { donePaths, clearDone } = useAgentStore();
   const isSelected = selectedWorktreeId === worktree.id;
   const [contextMenu, setContextMenu] = useState<{
     x: number;
@@ -42,6 +44,7 @@ export function WorktreeItem({
     setSelectedWorktreePath(worktree.path);
     setSelectedWorktreeName(worktree.branch_name);
     setShowSettings(false);
+    if (worktree.path) clearDone(worktree.path);
   }, [
     worktree.id,
     worktree.path,
@@ -50,6 +53,7 @@ export function WorktreeItem({
     setSelectedWorktreePath,
     setSelectedWorktreeName,
     setShowSettings,
+    clearDone,
   ]);
 
   const handleContextMenu = useCallback(
@@ -105,6 +109,8 @@ export function WorktreeItem({
         ? "wt-status-missing"
         : "wt-status-stopped";
 
+  const agentDone = worktree.path ? donePaths.has(worktree.path) : false;
+
   return (
     <>
       <div
@@ -152,6 +158,11 @@ export function WorktreeItem({
           )}
           {worktree.port && (
             <span className="worktree-port">:{worktree.port}</span>
+          )}
+          {agentDone && !isSelected && (
+            <span className="worktree-agent-done" title="Agent finished">
+              ✓
+            </span>
           )}
         </span>
       </div>

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useRef, useEffect } from "react";
 import { Sidebar } from "../components/Sidebar";
 import { GitHubSidebar } from "../components/GitHubSidebar";
 import { UiContext } from "../stores/uiStore";
+import { AgentContext, useAgentStoreProvider } from "../stores/agentStore";
 import { ErrorBoundary } from "../components/ErrorBoundary";
 
 const SIDEBAR_MIN = 200;
@@ -72,6 +73,7 @@ export function MainLayout({
   >(null);
   const [showSettings, setShowSettings] = useState(false);
   const [showRightSidebar, setShowRightSidebar] = useState(true);
+  const agentStore = useAgentStoreProvider();
   const dragging = useRef(false);
   const draggingRight = useRef(false);
 
@@ -142,49 +144,51 @@ export function MainLayout({
   }, [rightSidebarWidth]);
 
   return (
-    <UiContext.Provider
-      value={{
-        selectedProjectId,
-        setSelectedProjectId,
-        selectedWorktreeId,
-        setSelectedWorktreeId,
-        selectedWorktreePath,
-        setSelectedWorktreePath,
-        selectedWorktreeName,
-        setSelectedWorktreeName,
-        showSettings,
-        setShowSettings,
-        showRightSidebar,
-        setShowRightSidebar,
-      }}
-    >
-      <div className="main-layout">
-        <div className="sidebar-panel" style={{ width: sidebarWidth }}>
-          <ErrorBoundary name="Sidebar">
-            <Sidebar
-              onOpenSearch={onOpenSearch}
-              onOpenAiChat={onOpenAiChat}
-              onOpenNotifications={onOpenNotifications}
-              onOpenSettings={onOpenSettings}
-            />
-          </ErrorBoundary>
+    <AgentContext.Provider value={agentStore}>
+      <UiContext.Provider
+        value={{
+          selectedProjectId,
+          setSelectedProjectId,
+          selectedWorktreeId,
+          setSelectedWorktreeId,
+          selectedWorktreePath,
+          setSelectedWorktreePath,
+          selectedWorktreeName,
+          setSelectedWorktreeName,
+          showSettings,
+          setShowSettings,
+          showRightSidebar,
+          setShowRightSidebar,
+        }}
+      >
+        <div className="main-layout">
+          <div className="sidebar-panel" style={{ width: sidebarWidth }}>
+            <ErrorBoundary name="Sidebar">
+              <Sidebar
+                onOpenSearch={onOpenSearch}
+                onOpenAiChat={onOpenAiChat}
+                onOpenNotifications={onOpenNotifications}
+                onOpenSettings={onOpenSettings}
+              />
+            </ErrorBoundary>
+          </div>
+          <div className="resize-handle" onMouseDown={handleMouseDown} />
+          <div className="content-area">{children}</div>
+          {showRightSidebar && (
+            <>
+              <div
+                className="resize-handle resize-handle--right"
+                onMouseDown={handleRightMouseDown}
+              />
+              <div style={{ width: rightSidebarWidth, flexShrink: 0 }}>
+                <ErrorBoundary name="GitHub Sidebar">
+                  <GitHubSidebar projectId={selectedProjectId} />
+                </ErrorBoundary>
+              </div>
+            </>
+          )}
         </div>
-        <div className="resize-handle" onMouseDown={handleMouseDown} />
-        <div className="content-area">{children}</div>
-        {showRightSidebar && (
-          <>
-            <div
-              className="resize-handle resize-handle--right"
-              onMouseDown={handleRightMouseDown}
-            />
-            <div style={{ width: rightSidebarWidth, flexShrink: 0 }}>
-              <ErrorBoundary name="GitHub Sidebar">
-                <GitHubSidebar projectId={selectedProjectId} />
-              </ErrorBoundary>
-            </div>
-          </>
-        )}
-      </div>
-    </UiContext.Provider>
+      </UiContext.Provider>
+    </AgentContext.Provider>
   );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -71,6 +71,7 @@ import "./styles/database-explorer.css";
 import "./styles/dashboard.css";
 import "./styles/status-bar.css";
 import "./styles/content-toolbar.css";
+import "./styles/agent-toast.css";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>

--- a/src/stores/agentStore.ts
+++ b/src/stores/agentStore.ts
@@ -1,0 +1,36 @@
+import { createContext, useContext, useState, useCallback } from "react";
+
+interface AgentStoreValue {
+  /** Paths (cwd) of worktrees whose agent recently completed. */
+  donePaths: Set<string>;
+  markDone: (cwd: string) => void;
+  clearDone: (cwd: string) => void;
+}
+
+export const AgentContext = createContext<AgentStoreValue>({
+  donePaths: new Set(),
+  markDone: () => {},
+  clearDone: () => {},
+});
+
+export function useAgentStore() {
+  return useContext(AgentContext);
+}
+
+export function useAgentStoreProvider(): AgentStoreValue {
+  const [donePaths, setDonePaths] = useState<Set<string>>(new Set());
+
+  const markDone = useCallback((cwd: string) => {
+    setDonePaths((prev) => new Set(prev).add(cwd));
+  }, []);
+
+  const clearDone = useCallback((cwd: string) => {
+    setDonePaths((prev) => {
+      const next = new Set(prev);
+      next.delete(cwd);
+      return next;
+    });
+  }, []);
+
+  return { donePaths, markDone, clearDone };
+}

--- a/src/styles/agent-toast.css
+++ b/src/styles/agent-toast.css
@@ -1,0 +1,127 @@
+/* ==========================================================
+   Agent Done Toast
+   ========================================================== */
+
+.agent-toast-stack {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  pointer-events: none;
+}
+
+.agent-toast {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+  border-radius: var(--radius-lg);
+  box-shadow:
+    0 8px 24px rgba(0, 0, 0, 0.45),
+    0 0 0 1px rgba(255, 255, 255, 0.04) inset;
+  min-width: 240px;
+  max-width: 320px;
+  pointer-events: all;
+  animation: agent-toast-in 0.2s ease-out;
+}
+
+@keyframes agent-toast-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.97);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+.agent-toast__icon {
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--accent-muted);
+  border-radius: 50%;
+  color: var(--accent);
+}
+
+.agent-toast__icon svg {
+  width: 11px;
+  height: 11px;
+}
+
+.agent-toast__body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.agent-toast__title {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.agent-toast__name {
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-toast__jump {
+  flex-shrink: 0;
+  font-size: 11.5px;
+  font-weight: 500;
+  padding: 3px 8px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: var(--bg-hover);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition:
+    color 0.1s,
+    background-color 0.1s;
+}
+
+.agent-toast__jump:hover {
+  color: var(--text-primary);
+  background: var(--bg-elevated);
+}
+
+.agent-toast__close {
+  flex-shrink: 0;
+  font-size: 15px;
+  line-height: 1;
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition: color 0.1s;
+}
+
+.agent-toast__close:hover {
+  color: var(--text-primary);
+}

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -601,6 +601,13 @@
   line-height: 1.7;
 }
 
+.worktree-agent-done {
+  font-size: 0.65em;
+  font-weight: 700;
+  color: var(--accent);
+  line-height: 1;
+}
+
 /* ==========================================================
    New Worktree Form
    ========================================================== */


### PR DESCRIPTION
## Summary
- Detects when an AI agent finishes running in any terminal (even background worktrees)
- In-app toast notification (bottom-right) with a Jump button to switch directly to that worktree, auto-dismisses in 6s
- System notification via browser Notification API (works in Tauri WKWebView, no Cargo changes needed)
- Sidebar badge on WorktreeItem, cleared when user clicks the worktree

## How detection works
PTY output is monitored in TerminalInstance. After >500 bytes of output since the last user keystroke, a 2-second silence timer fires onAgentDone(cwd). Resets on every keystroke to avoid false positives from short commands.

## New files
- src/stores/agentStore.ts - AgentContext tracking which cwds have pending done-notifications
- src/components/AgentDoneToast.tsx - toast stack, auto-dismisses in 6s
- src/styles/agent-toast.css - toast styles

## Test plan
- Run a command producing >500 bytes in a non-selected worktree, toast appears ~2s after it finishes
- Short commands (ls) do NOT trigger a toast
- Jump button switches to the correct worktree and dismisses the toast
- Badge appears in sidebar, clicking the worktree clears it
- No toast if agent finishes in the currently selected worktree

Closes #67