### PR TITLE
feat: project tab bar for quick switching between projects

### DIFF
--- a/src/components/ProjectTabBar.tsx
+++ b/src/components/ProjectTabBar.tsx
@@ -1,0 +1,67 @@
+import { useCallback, useEffect, useRef } from "react";
+import "../styles/project-tabs.css";
+
+export interface ProjectTab {
+  id: number;
+  name: string;
+}
+
+interface ProjectTabBarProps {
+  tabs: ProjectTab[];
+  activeId: number | null;
+  onSelect: (id: number) => void;
+  onClose: (id: number) => void;
+}
+
+export function ProjectTabBar({
+  tabs,
+  activeId,
+  onSelect,
+  onClose,
+}: ProjectTabBarProps) {
+  const tabsRef = useRef<HTMLDivElement>(null);
+
+  // Scroll active tab into view when it changes
+  useEffect(() => {
+    const el = tabsRef.current?.querySelector(
+      ".project-tab--active",
+    ) as HTMLElement | null;
+    el?.scrollIntoView({ block: "nearest", inline: "nearest" });
+  }, [activeId]);
+
+  const handleClose = useCallback(
+    (e: React.MouseEvent, id: number) => {
+      e.stopPropagation();
+      onClose(id);
+    },
+    [onClose],
+  );
+
+  if (tabs.length === 0) return null;
+
+  return (
+    <div className="project-tab-bar" ref={tabsRef}>
+      {tabs.map((tab) => (
+        <button
+          key={tab.id}
+          className={`project-tab${tab.id === activeId ? " project-tab--active" : ""}`}
+          onClick={() => onSelect(tab.id)}
+          type="button"
+          title={tab.name}
+        >
+          <span className="project-tab__name">{tab.name}</span>
+          {tabs.length > 1 && (
+            <span
+              className="project-tab__close"
+              role="button"
+              aria-label={`Close ${tab.name}`}
+              onClick={(e) => handleClose(e, tab.id)}
+            >
+              ×
+            </span>
+          )}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,8 +1,10 @@
 import { useState, useCallback, useRef, useEffect } from "react";
+import { invoke } from "@tauri-apps/api/core";
 import { Sidebar } from "../components/Sidebar";
 import { GitHubSidebar } from "../components/GitHubSidebar";
 import { UiContext } from "../stores/uiStore";
 import { ErrorBoundary } from "../components/ErrorBoundary";
+import { ProjectTabBar, type ProjectTab } from "../components/ProjectTabBar";
 
 const SIDEBAR_MIN = 200;
 const SIDEBAR_MAX = 480;
@@ -13,6 +15,9 @@ const RIGHT_SIDEBAR_MIN = 200;
 const RIGHT_SIDEBAR_MAX = 500;
 const RIGHT_SIDEBAR_DEFAULT = 280;
 const RIGHT_STORAGE_KEY = "workroot:right-sidebar-width";
+
+const OPEN_TABS_KEY = "workroot:open-project-tabs";
+const TAB_BAR_HEIGHT = 32;
 
 function getSavedWidth(): number {
   try {
@@ -40,6 +45,16 @@ function getSavedRightWidth(): number {
   return RIGHT_SIDEBAR_DEFAULT;
 }
 
+function getSavedOpenTabIds(): number[] {
+  try {
+    const saved = localStorage.getItem(OPEN_TABS_KEY);
+    if (saved) return JSON.parse(saved) as number[];
+  } catch {
+    // ignore
+  }
+  return [];
+}
+
 interface MainLayoutProps {
   children: React.ReactNode;
   onOpenSearch?: () => void;
@@ -58,7 +73,7 @@ export function MainLayout({
   const [sidebarWidth, setSidebarWidth] = useState(getSavedWidth);
   const [rightSidebarWidth, setRightSidebarWidth] =
     useState(getSavedRightWidth);
-  const [selectedProjectId, setSelectedProjectId] = useState<number | null>(
+  const [selectedProjectId, setSelectedProjectIdRaw] = useState<number | null>(
     null,
   );
   const [selectedWorktreeId, setSelectedWorktreeId] = useState<number | null>(
@@ -75,6 +90,86 @@ export function MainLayout({
   const [agentDoneWorktreeIds, setAgentDoneWorktreeIds] = useState<Set<number>>(
     () => new Set(),
   );
+
+  // Project tabs state
+  const [allProjects, setAllProjects] = useState<ProjectTab[]>([]);
+  const [openTabIds, setOpenTabIds] = useState<number[]>(getSavedOpenTabIds);
+
+  // Fetch project list on mount
+  useEffect(() => {
+    invoke<{ id: number; name: string }[]>("list_projects")
+      .then((projects) =>
+        setAllProjects(projects.map((p) => ({ id: p.id, name: p.name }))),
+      )
+      .catch(() => {});
+  }, []);
+
+  // Persist open tab IDs
+  useEffect(() => {
+    try {
+      localStorage.setItem(OPEN_TABS_KEY, JSON.stringify(openTabIds));
+    } catch {
+      // ignore
+    }
+  }, [openTabIds]);
+
+  // Auto-add project to open tabs when selected
+  const setSelectedProjectId = useCallback((id: number | null) => {
+    setSelectedProjectIdRaw(id);
+    if (id !== null) {
+      setOpenTabIds((prev) => (prev.includes(id) ? prev : [...prev, id]));
+    }
+  }, []);
+
+  // The tabs to display: open IDs that still exist in allProjects
+  const visibleTabs = openTabIds
+    .map((id) => allProjects.find((p) => p.id === id))
+    .filter((p): p is ProjectTab => p !== undefined);
+
+  const handleTabSelect = useCallback((id: number) => {
+    setSelectedProjectIdRaw(id);
+    // Reset worktree selection when switching projects
+    setSelectedWorktreeId(null);
+    setSelectedWorktreePath(null);
+    setSelectedWorktreeName(null);
+    setShowSettings(false);
+  }, []);
+
+  const handleTabClose = useCallback(
+    (id: number) => {
+      setOpenTabIds((prev) => prev.filter((tid) => tid !== id));
+      // If closing the active project, switch to the nearest remaining tab
+      setSelectedProjectIdRaw((current) => {
+        if (current !== id) return current;
+        const remaining = openTabIds.filter((tid) => tid !== id);
+        const next = remaining[remaining.length - 1] ?? null;
+        if (next !== current) {
+          setSelectedWorktreeId(null);
+          setSelectedWorktreePath(null);
+          setSelectedWorktreeName(null);
+        }
+        return next;
+      });
+    },
+    [openTabIds],
+  );
+
+  // Keyboard shortcuts: Cmd+1..9 to switch tabs
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey)) return;
+      const num = parseInt(e.key, 10);
+      if (num >= 1 && num <= 9) {
+        const tab = visibleTabs[num - 1];
+        if (tab) {
+          e.preventDefault();
+          handleTabSelect(tab.id);
+        }
+      }
+    };
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [visibleTabs, handleTabSelect]);
 
   const markAgentDone = useCallback((id: number) => {
     setAgentDoneWorktreeIds((prev) => new Set(prev).add(id));
@@ -157,6 +252,8 @@ export function MainLayout({
     }
   }, [rightSidebarWidth]);
 
+  const showTabBar = visibleTabs.length > 0;
+
   return (
     <UiContext.Provider
       value={{
@@ -177,7 +274,25 @@ export function MainLayout({
         clearAgentDone,
       }}
     >
-      <div className="main-layout">
+      {showTabBar && (
+        <ProjectTabBar
+          tabs={visibleTabs}
+          activeId={selectedProjectId}
+          onSelect={handleTabSelect}
+          onClose={handleTabClose}
+        />
+      )}
+      <div
+        className="main-layout"
+        style={
+          showTabBar
+            ? {
+                marginTop: TAB_BAR_HEIGHT,
+                height: `calc(100vh - 24px - ${TAB_BAR_HEIGHT}px)`,
+              }
+            : undefined
+        }
+      >
         <div className="sidebar-panel" style={{ width: sidebarWidth }}>
           <ErrorBoundary name="Sidebar">
             <Sidebar

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -70,6 +70,7 @@ import "./styles/browser-events.css";
 import "./styles/database-explorer.css";
 import "./styles/dashboard.css";
 import "./styles/status-bar.css";
+import "./styles/project-tabs.css";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>

--- a/src/styles/project-tabs.css
+++ b/src/styles/project-tabs.css
@@ -1,0 +1,115 @@
+/* ==========================================================
+   Project Tab Bar
+   ========================================================== */
+
+.project-tab-bar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 32px;
+  z-index: 9998;
+  display: flex;
+  align-items: stretch;
+  background: var(--bg-base);
+  border-bottom: 1px solid var(--border-subtle);
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  -webkit-app-region: drag;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.project-tab-bar::-webkit-scrollbar {
+  display: none;
+}
+
+.project-tab {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 0 12px 0 14px;
+  height: 100%;
+  min-width: 80px;
+  max-width: 180px;
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  border-right: 1px solid var(--border-subtle);
+  border-bottom: 2px solid transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-family: var(--font-sans);
+  font-size: 11.5px;
+  font-weight: 400;
+  text-align: left;
+  transition:
+    color 0.12s,
+    background-color 0.12s;
+  -webkit-app-region: no-drag;
+  position: relative;
+}
+
+.project-tab:hover {
+  color: var(--text-secondary);
+  background: color-mix(in srgb, var(--bg-elevated) 60%, transparent);
+}
+
+.project-tab--active {
+  color: var(--text-primary);
+  font-weight: 500;
+  background: color-mix(in srgb, var(--accent-muted) 40%, transparent);
+  border-bottom-color: var(--accent);
+}
+
+.project-tab--active::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 10px;
+  right: 10px;
+  height: 2px;
+  background: var(--accent);
+  border-radius: 1px 1px 0 0;
+  box-shadow: 0 0 8px var(--accent-glow);
+}
+
+.project-tab__name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  line-height: 1;
+}
+
+.project-tab__close {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 3px;
+  font-size: 14px;
+  line-height: 1;
+  color: var(--text-muted);
+  opacity: 0;
+  transition:
+    opacity 0.1s,
+    color 0.1s,
+    background-color 0.1s;
+  cursor: pointer;
+}
+
+.project-tab:hover .project-tab__close,
+.project-tab--active .project-tab__close {
+  opacity: 1;
+}
+
+.project-tab__close:hover {
+  color: var(--text-primary);
+  background: var(--bg-hover);
+}


### PR DESCRIPTION
## Summary
Adds a compact 32px tab bar at the top of the app for fast project switching.

- Auto-added when you first select a project from the sidebar
- Clicking a tab switches full context and resets the active worktree
- Close button (hover/active) removes a tab; switches to nearest if active
- Persists to localStorage across restarts
- Cmd/Ctrl+1-9 keyboard shortcuts to jump by tab position
- Scrollable horizontally when tabs overflow
- Hidden when no projects are open yet

## Test plan
- [ ] Select a project from sidebar — tab appears in bar
- [ ] Open second project — click tab switches context and resets worktree
- [ ] Close a tab — removed; if active, switches to nearest remaining
- [ ] Relaunch app — open tabs restored from localStorage
- [ ] Cmd+1 / Cmd+2 switches tabs by position

Closes #73