### PR TITLE
feat: multi-agent pipeline panel (#66)

### DIFF
--- a/src-tauri/src/agents/mod.rs
+++ b/src-tauri/src/agents/mod.rs
@@ -1,0 +1,1 @@
+pub mod pipeline;

--- a/src-tauri/src/agents/pipeline.rs
+++ b/src-tauri/src/agents/pipeline.rs
@@ -1,0 +1,486 @@
+use crate::db::AppDb;
+use rusqlite::params;
+use serde::{Deserialize, Serialize};
+use std::process::Stdio;
+use tauri::State;
+use tokio::io::AsyncWriteExt;
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct AgentDef {
+    pub id: i64,
+    pub name: String,
+    pub role: String,
+    pub command: String,
+    pub created_at: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct PipelineDef {
+    pub id: i64,
+    pub name: String,
+    pub generator_id: i64,
+    pub reviewer_id: i64,
+    pub max_iterations: i64,
+    pub created_at: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct PipelineRun {
+    pub id: i64,
+    pub pipeline_id: i64,
+    pub worktree_id: i64,
+    pub task_desc: String,
+    pub status: String,
+    pub iterations: i64,
+    pub output: Vec<StepOutput>,
+    pub started_at: String,
+    pub finished_at: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct StepOutput {
+    pub iteration: u32,
+    pub role: String,
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_code: i32,
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+fn is_approved(reviewer_stdout: &str) -> bool {
+    let lower = reviewer_stdout.to_lowercase();
+    lower.contains("approved")
+        || lower.contains("lgtm")
+        || lower.contains("looks good")
+        || lower.contains("no issues")
+        || lower.contains("no changes needed")
+        || lower.contains("nothing to change")
+        || lower.contains("all good")
+}
+
+fn get_git_diff(worktree_path: &str) -> String {
+    let output = std::process::Command::new("git")
+        .args(["diff", "HEAD"])
+        .current_dir(worktree_path)
+        .output();
+    match output {
+        Ok(o) => String::from_utf8_lossy(&o.stdout).into_owned(),
+        Err(_) => String::new(),
+    }
+}
+
+/// Split a shell command string into argv parts (naive split on whitespace,
+/// honouring quoted strings is not required for v1).
+fn split_command(cmd: &str) -> Vec<String> {
+    cmd.split_whitespace().map(|s| s.to_string()).collect()
+}
+
+// ─── Agent CRUD ──────────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub fn create_agent(
+    db: State<'_, AppDb>,
+    name: String,
+    role: String,
+    command: String,
+) -> Result<AgentDef, String> {
+    if role != "generator" && role != "reviewer" {
+        return Err("role must be 'generator' or 'reviewer'".into());
+    }
+    let conn = db.0.lock().map_err(|e| format!("DB lock: {e}"))?;
+    conn.execute(
+        "INSERT INTO agent_definitions (name, role, command) VALUES (?1, ?2, ?3)",
+        params![name, role, command],
+    )
+    .map_err(|e| format!("DB error: {e}"))?;
+    let id = conn.last_insert_rowid();
+    let agent = conn
+        .query_row(
+            "SELECT id, name, role, command, created_at FROM agent_definitions WHERE id = ?1",
+            params![id],
+            |row| {
+                Ok(AgentDef {
+                    id: row.get(0)?,
+                    name: row.get(1)?,
+                    role: row.get(2)?,
+                    command: row.get(3)?,
+                    created_at: row.get(4)?,
+                })
+            },
+        )
+        .map_err(|e| format!("DB error: {e}"))?;
+    Ok(agent)
+}
+
+#[tauri::command]
+pub fn list_agents(db: State<'_, AppDb>) -> Result<Vec<AgentDef>, String> {
+    let conn = db.0.lock().map_err(|e| format!("DB lock: {e}"))?;
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, name, role, command, created_at FROM agent_definitions ORDER BY created_at DESC",
+        )
+        .map_err(|e| format!("DB error: {e}"))?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok(AgentDef {
+                id: row.get(0)?,
+                name: row.get(1)?,
+                role: row.get(2)?,
+                command: row.get(3)?,
+                created_at: row.get(4)?,
+            })
+        })
+        .map_err(|e| format!("DB error: {e}"))?;
+    rows.collect::<Result<Vec<_>, _>>()
+        .map_err(|e| format!("DB error: {e}"))
+}
+
+#[tauri::command]
+pub fn delete_agent(db: State<'_, AppDb>, id: i64) -> Result<(), String> {
+    let conn = db.0.lock().map_err(|e| format!("DB lock: {e}"))?;
+    conn.execute("DELETE FROM agent_definitions WHERE id = ?1", params![id])
+        .map_err(|e| format!("DB error: {e}"))?;
+    Ok(())
+}
+
+// ─── Pipeline CRUD ───────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub fn create_pipeline(
+    db: State<'_, AppDb>,
+    name: String,
+    generator_id: i64,
+    reviewer_id: i64,
+    max_iterations: i64,
+) -> Result<PipelineDef, String> {
+    let conn = db.0.lock().map_err(|e| format!("DB lock: {e}"))?;
+    conn.execute(
+        "INSERT INTO pipeline_definitions (name, generator_id, reviewer_id, max_iterations)
+         VALUES (?1, ?2, ?3, ?4)",
+        params![name, generator_id, reviewer_id, max_iterations],
+    )
+    .map_err(|e| format!("DB error: {e}"))?;
+    let id = conn.last_insert_rowid();
+    let p = conn
+        .query_row(
+            "SELECT id, name, generator_id, reviewer_id, max_iterations, created_at
+             FROM pipeline_definitions WHERE id = ?1",
+            params![id],
+            |row| {
+                Ok(PipelineDef {
+                    id: row.get(0)?,
+                    name: row.get(1)?,
+                    generator_id: row.get(2)?,
+                    reviewer_id: row.get(3)?,
+                    max_iterations: row.get(4)?,
+                    created_at: row.get(5)?,
+                })
+            },
+        )
+        .map_err(|e| format!("DB error: {e}"))?;
+    Ok(p)
+}
+
+#[tauri::command]
+pub fn list_pipelines(db: State<'_, AppDb>) -> Result<Vec<PipelineDef>, String> {
+    let conn = db.0.lock().map_err(|e| format!("DB lock: {e}"))?;
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, name, generator_id, reviewer_id, max_iterations, created_at
+             FROM pipeline_definitions ORDER BY created_at DESC",
+        )
+        .map_err(|e| format!("DB error: {e}"))?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok(PipelineDef {
+                id: row.get(0)?,
+                name: row.get(1)?,
+                generator_id: row.get(2)?,
+                reviewer_id: row.get(3)?,
+                max_iterations: row.get(4)?,
+                created_at: row.get(5)?,
+            })
+        })
+        .map_err(|e| format!("DB error: {e}"))?;
+    rows.collect::<Result<Vec<_>, _>>()
+        .map_err(|e| format!("DB error: {e}"))
+}
+
+#[tauri::command]
+pub fn delete_pipeline(db: State<'_, AppDb>, id: i64) -> Result<(), String> {
+    let conn = db.0.lock().map_err(|e| format!("DB lock: {e}"))?;
+    conn.execute(
+        "DELETE FROM pipeline_definitions WHERE id = ?1",
+        params![id],
+    )
+    .map_err(|e| format!("DB error: {e}"))?;
+    Ok(())
+}
+
+// ─── Run history ─────────────────────────────────────────────────────────────
+
+#[allow(clippy::too_many_arguments)]
+fn parse_run(
+    id: i64,
+    pipeline_id: i64,
+    worktree_id: i64,
+    task_desc: String,
+    status: String,
+    iterations: i64,
+    output_json: String,
+    started_at: String,
+    finished_at: Option<String>,
+) -> PipelineRun {
+    let output: Vec<StepOutput> = serde_json::from_str(&output_json).unwrap_or_default();
+    PipelineRun {
+        id,
+        pipeline_id,
+        worktree_id,
+        task_desc,
+        status,
+        iterations,
+        output,
+        started_at,
+        finished_at,
+    }
+}
+
+#[tauri::command]
+pub fn list_pipeline_runs(
+    db: State<'_, AppDb>,
+    pipeline_id: i64,
+) -> Result<Vec<PipelineRun>, String> {
+    let conn = db.0.lock().map_err(|e| format!("DB lock: {e}"))?;
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, pipeline_id, worktree_id, task_desc, status, iterations, output,
+                    started_at, finished_at
+             FROM pipeline_runs WHERE pipeline_id = ?1 ORDER BY started_at DESC LIMIT 50",
+        )
+        .map_err(|e| format!("DB error: {e}"))?;
+    let rows = stmt
+        .query_map(params![pipeline_id], |row| {
+            Ok(parse_run(
+                row.get(0)?,
+                row.get(1)?,
+                row.get(2)?,
+                row.get(3)?,
+                row.get(4)?,
+                row.get(5)?,
+                row.get(6)?,
+                row.get(7)?,
+                row.get(8)?,
+            ))
+        })
+        .map_err(|e| format!("DB error: {e}"))?;
+    rows.collect::<Result<Vec<_>, _>>()
+        .map_err(|e| format!("DB error: {e}"))
+}
+
+#[tauri::command]
+pub fn get_pipeline_run(db: State<'_, AppDb>, run_id: i64) -> Result<PipelineRun, String> {
+    let conn = db.0.lock().map_err(|e| format!("DB lock: {e}"))?;
+    conn.query_row(
+        "SELECT id, pipeline_id, worktree_id, task_desc, status, iterations, output,
+                started_at, finished_at
+         FROM pipeline_runs WHERE id = ?1",
+        params![run_id],
+        |row| {
+            Ok(parse_run(
+                row.get(0)?,
+                row.get(1)?,
+                row.get(2)?,
+                row.get(3)?,
+                row.get(4)?,
+                row.get(5)?,
+                row.get(6)?,
+                row.get(7)?,
+                row.get(8)?,
+            ))
+        },
+    )
+    .map_err(|e| format!("DB error: {e}"))
+}
+
+// ─── Pipeline execution ───────────────────────────────────────────────────────
+
+#[tauri::command]
+pub async fn run_pipeline(
+    db: State<'_, AppDb>,
+    pipeline_id: i64,
+    worktree_id: i64,
+    task_desc: String,
+) -> Result<PipelineRun, String> {
+    // Load pipeline + agents
+    let (pipeline, generator, reviewer, worktree_path) = {
+        let conn = db.0.lock().map_err(|e| format!("DB lock: {e}"))?;
+
+        let pipeline = conn
+            .query_row(
+                "SELECT id, name, generator_id, reviewer_id, max_iterations, created_at
+                 FROM pipeline_definitions WHERE id = ?1",
+                params![pipeline_id],
+                |row| {
+                    Ok(PipelineDef {
+                        id: row.get(0)?,
+                        name: row.get(1)?,
+                        generator_id: row.get(2)?,
+                        reviewer_id: row.get(3)?,
+                        max_iterations: row.get(4)?,
+                        created_at: row.get(5)?,
+                    })
+                },
+            )
+            .map_err(|e| format!("Pipeline not found: {e}"))?;
+
+        let load_agent = |agent_id: i64| -> Result<AgentDef, rusqlite::Error> {
+            conn.query_row(
+                "SELECT id, name, role, command, created_at FROM agent_definitions WHERE id = ?1",
+                params![agent_id],
+                |row| {
+                    Ok(AgentDef {
+                        id: row.get(0)?,
+                        name: row.get(1)?,
+                        role: row.get(2)?,
+                        command: row.get(3)?,
+                        created_at: row.get(4)?,
+                    })
+                },
+            )
+        };
+
+        let generator = load_agent(pipeline.generator_id)
+            .map_err(|e| format!("Generator agent not found: {e}"))?;
+        let reviewer = load_agent(pipeline.reviewer_id)
+            .map_err(|e| format!("Reviewer agent not found: {e}"))?;
+
+        let worktree_path: String = conn
+            .query_row(
+                "SELECT path FROM worktrees WHERE id = ?1",
+                params![worktree_id],
+                |row| row.get(0),
+            )
+            .map_err(|e| format!("Worktree not found: {e}"))?;
+
+        (pipeline, generator, reviewer, worktree_path)
+    };
+
+    // Insert initial run row
+    let run_id = {
+        let conn = db.0.lock().map_err(|e| format!("DB lock: {e}"))?;
+        conn.execute(
+            "INSERT INTO pipeline_runs (pipeline_id, worktree_id, task_desc) VALUES (?1, ?2, ?3)",
+            params![pipeline_id, worktree_id, task_desc],
+        )
+        .map_err(|e| format!("DB error: {e}"))?;
+        conn.last_insert_rowid()
+    };
+
+    // Run the pipeline loop
+    let mut steps: Vec<StepOutput> = Vec::new();
+    let mut final_status = "max_iterations".to_string();
+    let max = pipeline.max_iterations as u32;
+    let gen_parts = split_command(&generator.command);
+    let rev_parts = split_command(&reviewer.command);
+
+    for i in 0..max {
+        // ── Generator ──
+        let gen_result = tokio::process::Command::new(&gen_parts[0])
+            .args(&gen_parts[1..])
+            .current_dir(&worktree_path)
+            .env("TASK", &task_desc)
+            .env("ITERATION", i.to_string())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .await;
+
+        let (gen_stdout, gen_stderr, gen_exit) = match gen_result {
+            Ok(o) => (
+                String::from_utf8_lossy(&o.stdout).into_owned(),
+                String::from_utf8_lossy(&o.stderr).into_owned(),
+                o.status.code().unwrap_or(-1),
+            ),
+            Err(e) => (String::new(), format!("Failed to spawn generator: {e}"), -1),
+        };
+
+        steps.push(StepOutput {
+            iteration: i,
+            role: "generator".into(),
+            stdout: gen_stdout.clone(),
+            stderr: gen_stderr,
+            exit_code: gen_exit,
+        });
+
+        // ── Get diff ──
+        let diff = get_git_diff(&worktree_path);
+
+        // ── Reviewer ──
+        let stdin_payload = format!(
+            "=== TASK ===\n{}\n\n=== GENERATOR OUTPUT ===\n{}\n\n=== GIT DIFF ===\n{}",
+            task_desc, gen_stdout, diff
+        );
+
+        let rev_result = async {
+            let mut child = tokio::process::Command::new(&rev_parts[0])
+                .args(&rev_parts[1..])
+                .current_dir(&worktree_path)
+                .env("TASK", &task_desc)
+                .env("ITERATION", i.to_string())
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()?;
+
+            if let Some(mut stdin) = child.stdin.take() {
+                let _ = stdin.write_all(stdin_payload.as_bytes()).await;
+            }
+            child.wait_with_output().await
+        }
+        .await;
+
+        let (rev_stdout, rev_stderr, rev_exit) = match rev_result {
+            Ok(o) => (
+                String::from_utf8_lossy(&o.stdout).into_owned(),
+                String::from_utf8_lossy(&o.stderr).into_owned(),
+                o.status.code().unwrap_or(-1),
+            ),
+            Err(e) => (String::new(), format!("Failed to spawn reviewer: {e}"), -1),
+        };
+
+        let approved = is_approved(&rev_stdout);
+
+        steps.push(StepOutput {
+            iteration: i,
+            role: "reviewer".into(),
+            stdout: rev_stdout,
+            stderr: rev_stderr,
+            exit_code: rev_exit,
+        });
+
+        if approved {
+            final_status = "approved".to_string();
+            break;
+        }
+    }
+
+    // Persist result
+    let output_json = serde_json::to_string(&steps).unwrap_or_else(|_| "[]".into());
+    let iterations = steps.iter().filter(|s| s.role == "generator").count() as i64;
+
+    {
+        let conn = db.0.lock().map_err(|e| format!("DB lock: {e}"))?;
+        conn.execute(
+            "UPDATE pipeline_runs
+             SET status = ?1, iterations = ?2, output = ?3, finished_at = datetime('now')
+             WHERE id = ?4",
+            params![final_status, iterations, output_json, run_id],
+        )
+        .map_err(|e| format!("DB error: {e}"))?;
+    }
+
+    get_pipeline_run(db, run_id)
+}

--- a/src-tauri/src/db/schema.sql
+++ b/src-tauri/src/db/schema.sql
@@ -418,3 +418,41 @@ CREATE TABLE IF NOT EXISTS checkpoints (
     created_at  TEXT NOT NULL DEFAULT (datetime('now'))
 );
 CREATE INDEX IF NOT EXISTS idx_checkpoints_worktree_id ON checkpoints(worktree_id);
+
+-- ============================================================
+-- Multi-Agent Pipeline (Issue #66)
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS agent_definitions (
+    id          INTEGER PRIMARY KEY,
+    name        TEXT NOT NULL,
+    role        TEXT NOT NULL CHECK(role IN ('generator', 'reviewer')),
+    command     TEXT NOT NULL,
+    created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS pipeline_definitions (
+    id              INTEGER PRIMARY KEY,
+    name            TEXT NOT NULL,
+    generator_id    INTEGER NOT NULL REFERENCES agent_definitions(id) ON DELETE RESTRICT,
+    reviewer_id     INTEGER NOT NULL REFERENCES agent_definitions(id) ON DELETE RESTRICT,
+    max_iterations  INTEGER NOT NULL DEFAULT 3,
+    created_at      TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS pipeline_runs (
+    id              INTEGER PRIMARY KEY,
+    pipeline_id     INTEGER NOT NULL REFERENCES pipeline_definitions(id) ON DELETE CASCADE,
+    worktree_id     INTEGER NOT NULL REFERENCES worktrees(id) ON DELETE CASCADE,
+    task_desc       TEXT NOT NULL,
+    status          TEXT NOT NULL DEFAULT 'running'
+                        CHECK(status IN ('running', 'approved', 'failed', 'max_iterations')),
+    iterations      INTEGER NOT NULL DEFAULT 0,
+    output          TEXT NOT NULL DEFAULT '[]',
+    started_at      TEXT NOT NULL DEFAULT (datetime('now')),
+    finished_at     TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_pipeline_runs_pipeline ON pipeline_runs(pipeline_id);
+CREATE INDEX IF NOT EXISTS idx_pipeline_runs_worktree ON pipeline_runs(worktree_id);
+CREATE INDEX IF NOT EXISTS idx_pipeline_runs_started  ON pipeline_runs(started_at);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod agents;
 pub mod ai;
 pub mod backup;
 pub mod bookmarks;
@@ -321,6 +322,15 @@ pub fn run() {
             fileview::get_worktree_file_statuses,
             fileview::read_file_content,
             fileview::open_file_in_editor,
+            agents::pipeline::create_agent,
+            agents::pipeline::list_agents,
+            agents::pipeline::delete_agent,
+            agents::pipeline::create_pipeline,
+            agents::pipeline::list_pipelines,
+            agents::pipeline::delete_pipeline,
+            agents::pipeline::list_pipeline_runs,
+            agents::pipeline::get_pipeline_run,
+            agents::pipeline::run_pipeline,
         ])
         .setup(|app| {
             let app_handle = app.handle().clone();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import { DensityPicker } from "./components/DensityPicker";
 import { CustomCSSEditor } from "./components/CustomCSSEditor";
 import { StashManager } from "./components/StashManager";
 import { CheckpointPanel } from "./components/CheckpointPanel";
+import { MultiAgentPipelinePanel } from "./components/MultiAgentPipelinePanel";
 import { BlameView } from "./components/BlameView";
 import { BranchCompare } from "./components/BranchCompare";
 import { GitHooksManager } from "./components/GitHooksManager";
@@ -860,6 +861,14 @@ function AppContent({
         icon: "\u2338",
         action: () => openPanel("dbExplorer"),
       },
+      {
+        id: "ai:multi-agent-pipeline",
+        label: "Multi-Agent Pipeline",
+        category: "AI",
+        icon: "\u25B6",
+        enabled: () => selectedWorktreeId !== null,
+        action: () => openPanel("multiAgentPipeline"),
+      },
     ];
 
     // Add project switch commands
@@ -1153,6 +1162,12 @@ function AppContent({
         <CheckpointPanel
           worktreeId={selectedWorktreeId}
           onClose={() => closePanel("checkpointManager")}
+        />
+      )}
+      {panels.multiAgentPipeline && selectedWorktreeId !== null && (
+        <MultiAgentPipelinePanel
+          worktreeId={selectedWorktreeId}
+          onClose={() => closePanel("multiAgentPipeline")}
         />
       )}
       {panels.blameView && selectedWorktreeId !== null && (

--- a/src/components/MultiAgentPipelinePanel.tsx
+++ b/src/components/MultiAgentPipelinePanel.tsx
@@ -1,0 +1,590 @@
+import { useState, useEffect, useCallback } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import "../styles/multi-agent-pipeline.css";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+interface AgentDef {
+  id: number;
+  name: string;
+  role: "generator" | "reviewer";
+  command: string;
+  created_at: string;
+}
+
+interface PipelineDef {
+  id: number;
+  name: string;
+  generator_id: number;
+  reviewer_id: number;
+  max_iterations: number;
+  created_at: string;
+}
+
+interface StepOutput {
+  iteration: number;
+  role: string;
+  stdout: string;
+  stderr: string;
+  exit_code: number;
+}
+
+interface PipelineRun {
+  id: number;
+  pipeline_id: number;
+  worktree_id: number;
+  task_desc: string;
+  status: "running" | "approved" | "failed" | "max_iterations";
+  iterations: number;
+  output: StepOutput[];
+  started_at: string;
+  finished_at: string | null;
+}
+
+// ─── Props ───────────────────────────────────────────────────────────────────
+
+interface Props {
+  worktreeId: number;
+  onClose: () => void;
+}
+
+type Tab = "agents" | "pipelines" | "run";
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export function MultiAgentPipelinePanel({ worktreeId, onClose }: Props) {
+  const [tab, setTab] = useState<Tab>("agents");
+
+  // Agents state
+  const [agents, setAgents] = useState<AgentDef[]>([]);
+  const [agentName, setAgentName] = useState("");
+  const [agentRole, setAgentRole] = useState<"generator" | "reviewer">(
+    "generator",
+  );
+  const [agentCommand, setAgentCommand] = useState("");
+  const [agentError, setAgentError] = useState("");
+
+  // Pipelines state
+  const [pipelines, setPipelines] = useState<PipelineDef[]>([]);
+  const [pipelineName, setPipelineName] = useState("");
+  const [generatorId, setGeneratorId] = useState<number | "">("");
+  const [reviewerId, setReviewerId] = useState<number | "">("");
+  const [maxIterations, setMaxIterations] = useState(3);
+  const [pipelineError, setPipelineError] = useState("");
+
+  // Run state
+  const [selectedPipelineId, setSelectedPipelineId] = useState<number | "">("");
+  const [taskDesc, setTaskDesc] = useState("");
+  const [runs, setRuns] = useState<PipelineRun[]>([]);
+  const [activeRun, setActiveRun] = useState<PipelineRun | null>(null);
+  const [expandedStep, setExpandedStep] = useState<number | null>(null);
+  const [running, setRunning] = useState(false);
+  const [runError, setRunError] = useState("");
+
+  // Load agents
+  const loadAgents = useCallback(async () => {
+    try {
+      const result = await invoke<AgentDef[]>("list_agents");
+      setAgents(result);
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  // Load pipelines
+  const loadPipelines = useCallback(async () => {
+    try {
+      const result = await invoke<PipelineDef[]>("list_pipelines");
+      setPipelines(result);
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  // Load runs for selected pipeline
+  const loadRuns = useCallback(async (pipelineId: number) => {
+    try {
+      const result = await invoke<PipelineRun[]>("list_pipeline_runs", {
+        pipelineId,
+      });
+      setRuns(result);
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadAgents();
+    void loadPipelines();
+  }, [loadAgents, loadPipelines]);
+
+  useEffect(() => {
+    if (typeof selectedPipelineId === "number") {
+      void loadRuns(selectedPipelineId);
+    } else {
+      setRuns([]);
+    }
+  }, [selectedPipelineId, loadRuns]);
+
+  // ─── Agent handlers ──────────────────────────────────────────────────────
+
+  async function handleCreateAgent() {
+    setAgentError("");
+    if (!agentName.trim() || !agentCommand.trim()) {
+      setAgentError("Name and command are required.");
+      return;
+    }
+    try {
+      await invoke("create_agent", {
+        name: agentName.trim(),
+        role: agentRole,
+        command: agentCommand.trim(),
+      });
+      setAgentName("");
+      setAgentCommand("");
+      void loadAgents();
+    } catch (e) {
+      setAgentError(String(e));
+    }
+  }
+
+  async function handleDeleteAgent(id: number) {
+    try {
+      await invoke("delete_agent", { id });
+      void loadAgents();
+    } catch {
+      // ignore
+    }
+  }
+
+  // ─── Pipeline handlers ───────────────────────────────────────────────────
+
+  async function handleCreatePipeline() {
+    setPipelineError("");
+    if (!pipelineName.trim() || generatorId === "" || reviewerId === "") {
+      setPipelineError("Name, generator and reviewer are required.");
+      return;
+    }
+    try {
+      await invoke("create_pipeline", {
+        name: pipelineName.trim(),
+        generatorId: Number(generatorId),
+        reviewerId: Number(reviewerId),
+        maxIterations,
+      });
+      setPipelineName("");
+      setGeneratorId("");
+      setReviewerId("");
+      setMaxIterations(3);
+      void loadPipelines();
+    } catch (e) {
+      setPipelineError(String(e));
+    }
+  }
+
+  async function handleDeletePipeline(id: number) {
+    try {
+      await invoke("delete_pipeline", { id });
+      if (selectedPipelineId === id) setSelectedPipelineId("");
+      void loadPipelines();
+    } catch {
+      // ignore
+    }
+  }
+
+  // ─── Run handlers ────────────────────────────────────────────────────────
+
+  async function handleRun() {
+    setRunError("");
+    if (selectedPipelineId === "" || !taskDesc.trim()) {
+      setRunError("Select a pipeline and provide a task description.");
+      return;
+    }
+    setRunning(true);
+    setActiveRun(null);
+    setExpandedStep(null);
+    try {
+      const result = await invoke<PipelineRun>("run_pipeline", {
+        pipelineId: Number(selectedPipelineId),
+        worktreeId,
+        taskDesc: taskDesc.trim(),
+      });
+      setActiveRun(result);
+      void loadRuns(Number(selectedPipelineId));
+    } catch (e) {
+      setRunError(String(e));
+    } finally {
+      setRunning(false);
+    }
+  }
+
+  // ─── Helpers ─────────────────────────────────────────────────────────────
+
+  function statusBadge(status: PipelineRun["status"]) {
+    const cls = `map-badge map-badge--${status}`;
+    const labels: Record<PipelineRun["status"], string> = {
+      running: "Running",
+      approved: "Approved",
+      failed: "Failed",
+      max_iterations: "Max iterations",
+    };
+    return <span className={cls}>{labels[status]}</span>;
+  }
+
+  function agentName_(id: number) {
+    return agents.find((a) => a.id === id)?.name ?? `#${id}`;
+  }
+
+  // ─── Render ──────────────────────────────────────────────────────────────
+
+  return (
+    <div className="map-overlay" onClick={onClose}>
+      <div className="map-dialog" onClick={(e) => e.stopPropagation()}>
+        {/* Header */}
+        <div className="map-header">
+          <span className="map-title">Multi-Agent Pipeline</span>
+          <button className="map-close" onClick={onClose}>
+            ✕
+          </button>
+        </div>
+
+        {/* Tabs */}
+        <div className="map-tabs">
+          {(["agents", "pipelines", "run"] as Tab[]).map((t) => (
+            <button
+              key={t}
+              className={`map-tab ${tab === t ? "map-tab--active" : ""}`}
+              onClick={() => setTab(t)}
+            >
+              {t.charAt(0).toUpperCase() + t.slice(1)}
+            </button>
+          ))}
+        </div>
+
+        <div className="map-body">
+          {/* ── Agents tab ────────────────────────────────────────────────── */}
+          {tab === "agents" && (
+            <div className="map-section">
+              <h3 className="map-section-title">Create Agent</h3>
+              <div className="map-form">
+                <input
+                  className="map-input"
+                  placeholder="Name"
+                  value={agentName}
+                  onChange={(e) => setAgentName(e.target.value)}
+                />
+                <select
+                  className="map-select"
+                  value={agentRole}
+                  onChange={(e) =>
+                    setAgentRole(e.target.value as "generator" | "reviewer")
+                  }
+                >
+                  <option value="generator">Generator</option>
+                  <option value="reviewer">Reviewer</option>
+                </select>
+                <input
+                  className="map-input map-input--wide"
+                  placeholder="Command (e.g. claude --print)"
+                  value={agentCommand}
+                  onChange={(e) => setAgentCommand(e.target.value)}
+                />
+                {agentError && <p className="map-error">{agentError}</p>}
+                <button
+                  className="map-btn map-btn--primary"
+                  onClick={() => void handleCreateAgent()}
+                >
+                  Add Agent
+                </button>
+              </div>
+
+              <h3 className="map-section-title">Agents</h3>
+              {agents.length === 0 ? (
+                <p className="map-empty">No agents defined yet.</p>
+              ) : (
+                <table className="map-table">
+                  <thead>
+                    <tr>
+                      <th>Name</th>
+                      <th>Role</th>
+                      <th>Command</th>
+                      <th></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {agents.map((a) => (
+                      <tr key={a.id}>
+                        <td>{a.name}</td>
+                        <td>
+                          <span className={`map-badge map-badge--${a.role}`}>
+                            {a.role}
+                          </span>
+                        </td>
+                        <td className="map-mono">{a.command}</td>
+                        <td>
+                          <button
+                            className="map-btn map-btn--danger"
+                            onClick={() => void handleDeleteAgent(a.id)}
+                          >
+                            Delete
+                          </button>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </div>
+          )}
+
+          {/* ── Pipelines tab ─────────────────────────────────────────────── */}
+          {tab === "pipelines" && (
+            <div className="map-section">
+              <h3 className="map-section-title">Create Pipeline</h3>
+              <div className="map-form">
+                <input
+                  className="map-input"
+                  placeholder="Pipeline name"
+                  value={pipelineName}
+                  onChange={(e) => setPipelineName(e.target.value)}
+                />
+                <select
+                  className="map-select"
+                  value={generatorId}
+                  onChange={(e) =>
+                    setGeneratorId(
+                      e.target.value === "" ? "" : Number(e.target.value),
+                    )
+                  }
+                >
+                  <option value="">-- Generator agent --</option>
+                  {agents
+                    .filter((a) => a.role === "generator")
+                    .map((a) => (
+                      <option key={a.id} value={a.id}>
+                        {a.name}
+                      </option>
+                    ))}
+                </select>
+                <select
+                  className="map-select"
+                  value={reviewerId}
+                  onChange={(e) =>
+                    setReviewerId(
+                      e.target.value === "" ? "" : Number(e.target.value),
+                    )
+                  }
+                >
+                  <option value="">-- Reviewer agent --</option>
+                  {agents
+                    .filter((a) => a.role === "reviewer")
+                    .map((a) => (
+                      <option key={a.id} value={a.id}>
+                        {a.name}
+                      </option>
+                    ))}
+                </select>
+                <label className="map-label">
+                  Max iterations
+                  <input
+                    className="map-input map-input--sm"
+                    type="number"
+                    min={1}
+                    max={10}
+                    value={maxIterations}
+                    onChange={(e) =>
+                      setMaxIterations(Math.max(1, Number(e.target.value)))
+                    }
+                  />
+                </label>
+                {pipelineError && <p className="map-error">{pipelineError}</p>}
+                <button
+                  className="map-btn map-btn--primary"
+                  onClick={() => void handleCreatePipeline()}
+                >
+                  Add Pipeline
+                </button>
+              </div>
+
+              <h3 className="map-section-title">Pipelines</h3>
+              {pipelines.length === 0 ? (
+                <p className="map-empty">No pipelines defined yet.</p>
+              ) : (
+                <table className="map-table">
+                  <thead>
+                    <tr>
+                      <th>Name</th>
+                      <th>Generator</th>
+                      <th>Reviewer</th>
+                      <th>Max iters</th>
+                      <th></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {pipelines.map((p) => (
+                      <tr key={p.id}>
+                        <td>{p.name}</td>
+                        <td>{agentName_(p.generator_id)}</td>
+                        <td>{agentName_(p.reviewer_id)}</td>
+                        <td>{p.max_iterations}</td>
+                        <td>
+                          <button
+                            className="map-btn map-btn--danger"
+                            onClick={() => void handleDeletePipeline(p.id)}
+                          >
+                            Delete
+                          </button>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </div>
+          )}
+
+          {/* ── Run tab ───────────────────────────────────────────────────── */}
+          {tab === "run" && (
+            <div className="map-section">
+              <h3 className="map-section-title">Run Pipeline</h3>
+              <div className="map-form">
+                <select
+                  className="map-select"
+                  value={selectedPipelineId}
+                  onChange={(e) =>
+                    setSelectedPipelineId(
+                      e.target.value === "" ? "" : Number(e.target.value),
+                    )
+                  }
+                >
+                  <option value="">-- Select pipeline --</option>
+                  {pipelines.map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.name}
+                    </option>
+                  ))}
+                </select>
+                <textarea
+                  className="map-textarea"
+                  placeholder="Describe the task for the generator agent…"
+                  rows={4}
+                  value={taskDesc}
+                  onChange={(e) => setTaskDesc(e.target.value)}
+                />
+                {runError && <p className="map-error">{runError}</p>}
+                <button
+                  className="map-btn map-btn--primary"
+                  onClick={() => void handleRun()}
+                  disabled={running}
+                >
+                  {running ? "Running…" : "Run"}
+                </button>
+              </div>
+
+              {/* Current run result */}
+              {activeRun && (
+                <div className="map-run-result">
+                  <div className="map-run-result-header">
+                    <span>Run #{activeRun.id}</span>
+                    {statusBadge(activeRun.status)}
+                    <span className="map-muted">
+                      {activeRun.iterations} iteration
+                      {activeRun.iterations !== 1 ? "s" : ""}
+                    </span>
+                  </div>
+                  <div className="map-steps">
+                    {activeRun.output.map((step, idx) => (
+                      <div key={idx} className="map-step">
+                        <button
+                          className="map-step-header"
+                          onClick={() =>
+                            setExpandedStep(expandedStep === idx ? null : idx)
+                          }
+                        >
+                          <span className={`map-badge map-badge--${step.role}`}>
+                            {step.role}
+                          </span>
+                          <span>Iteration {step.iteration + 1}</span>
+                          <span className="map-muted">
+                            exit {step.exit_code}
+                          </span>
+                          <span className="map-chevron">
+                            {expandedStep === idx ? "▲" : "▼"}
+                          </span>
+                        </button>
+                        {expandedStep === idx && (
+                          <div className="map-step-body">
+                            {step.stdout && (
+                              <>
+                                <p className="map-step-label">stdout</p>
+                                <pre className="map-pre">{step.stdout}</pre>
+                              </>
+                            )}
+                            {step.stderr && (
+                              <>
+                                <p className="map-step-label map-step-label--err">
+                                  stderr
+                                </p>
+                                <pre className="map-pre map-pre--err">
+                                  {step.stderr}
+                                </pre>
+                              </>
+                            )}
+                          </div>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* History */}
+              {runs.length > 0 && (
+                <>
+                  <h3 className="map-section-title">History</h3>
+                  <table className="map-table">
+                    <thead>
+                      <tr>
+                        <th>ID</th>
+                        <th>Status</th>
+                        <th>Iters</th>
+                        <th>Task</th>
+                        <th>Started</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {runs.map((r) => (
+                        <tr
+                          key={r.id}
+                          className={
+                            activeRun?.id === r.id ? "map-row--active" : ""
+                          }
+                          onClick={() => {
+                            setActiveRun(r);
+                            setExpandedStep(null);
+                          }}
+                          style={{ cursor: "pointer" }}
+                        >
+                          <td>#{r.id}</td>
+                          <td>{statusBadge(r.status)}</td>
+                          <td>{r.iterations}</td>
+                          <td className="map-task-preview">
+                            {r.task_desc.slice(0, 60)}
+                            {r.task_desc.length > 60 ? "…" : ""}
+                          </td>
+                          <td className="map-muted">
+                            {r.started_at.slice(0, 16).replace("T", " ")}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/usePanels.ts
+++ b/src/hooks/usePanels.ts
@@ -71,7 +71,8 @@ export type PanelKey =
   | "dbSchema"
   | "browserEvents"
   | "dbExplorer"
-  | "checkpointManager";
+  | "checkpointManager"
+  | "multiAgentPipeline";
 
 // ─── State ───────────────────────────────────────────────────────────────────
 
@@ -147,6 +148,7 @@ const INITIAL_STATE: PanelState = {
   browserEvents: false,
   dbExplorer: false,
   checkpointManager: false,
+  multiAgentPipeline: false,
 };
 
 // ─── Reducer ─────────────────────────────────────────────────────────────────

--- a/src/styles/multi-agent-pipeline.css
+++ b/src/styles/multi-agent-pipeline.css
@@ -1,0 +1,415 @@
+/* Multi-Agent Pipeline Panel */
+
+.map-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.map-dialog {
+  background: var(--color-bg-secondary, #1e1e2e);
+  border: 1px solid var(--color-border, #313244);
+  border-radius: 8px;
+  width: min(820px, 95vw);
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.4);
+}
+
+/* Header */
+.map-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--color-border, #313244);
+  flex-shrink: 0;
+}
+
+.map-title {
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--color-text-primary, #cdd6f4);
+}
+
+.map-close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text-muted, #6c7086);
+  font-size: 14px;
+  padding: 4px 6px;
+  border-radius: 4px;
+  line-height: 1;
+}
+
+.map-close:hover {
+  background: var(--color-bg-hover, #313244);
+  color: var(--color-text-primary, #cdd6f4);
+}
+
+/* Tabs */
+.map-tabs {
+  display: flex;
+  gap: 2px;
+  padding: 8px 16px 0;
+  border-bottom: 1px solid var(--color-border, #313244);
+  flex-shrink: 0;
+}
+
+.map-tab {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  padding: 6px 12px;
+  font-size: 13px;
+  color: var(--color-text-muted, #6c7086);
+  margin-bottom: -1px;
+  border-radius: 4px 4px 0 0;
+  transition: color 0.15s;
+}
+
+.map-tab:hover {
+  color: var(--color-text-primary, #cdd6f4);
+}
+
+.map-tab--active {
+  color: var(--color-accent, #89b4fa);
+  border-bottom-color: var(--color-accent, #89b4fa);
+}
+
+/* Body */
+.map-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+}
+
+/* Section */
+.map-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.map-section-title {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted, #6c7086);
+  margin: 0;
+}
+
+/* Form */
+.map-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: flex-end;
+}
+
+.map-input {
+  background: var(--color-bg-primary, #181825);
+  border: 1px solid var(--color-border, #313244);
+  border-radius: 4px;
+  color: var(--color-text-primary, #cdd6f4);
+  font-size: 13px;
+  padding: 6px 10px;
+  min-width: 160px;
+  outline: none;
+}
+
+.map-input:focus {
+  border-color: var(--color-accent, #89b4fa);
+}
+
+.map-input--wide {
+  flex: 1;
+  min-width: 260px;
+}
+
+.map-input--sm {
+  width: 64px;
+  min-width: unset;
+  margin-left: 6px;
+}
+
+.map-select {
+  background: var(--color-bg-primary, #181825);
+  border: 1px solid var(--color-border, #313244);
+  border-radius: 4px;
+  color: var(--color-text-primary, #cdd6f4);
+  font-size: 13px;
+  padding: 6px 10px;
+  min-width: 180px;
+  outline: none;
+  cursor: pointer;
+}
+
+.map-select:focus {
+  border-color: var(--color-accent, #89b4fa);
+}
+
+.map-label {
+  font-size: 12px;
+  color: var(--color-text-muted, #6c7086);
+  display: flex;
+  align-items: center;
+}
+
+.map-textarea {
+  background: var(--color-bg-primary, #181825);
+  border: 1px solid var(--color-border, #313244);
+  border-radius: 4px;
+  color: var(--color-text-primary, #cdd6f4);
+  font-size: 13px;
+  padding: 8px 10px;
+  width: 100%;
+  resize: vertical;
+  outline: none;
+  font-family: inherit;
+}
+
+.map-textarea:focus {
+  border-color: var(--color-accent, #89b4fa);
+}
+
+/* Buttons */
+.map-btn {
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 6px 12px;
+  transition: opacity 0.15s;
+  white-space: nowrap;
+}
+
+.map-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.map-btn--primary {
+  background: var(--color-accent, #89b4fa);
+  color: #1e1e2e;
+}
+
+.map-btn--primary:hover:not(:disabled) {
+  opacity: 0.85;
+}
+
+.map-btn--danger {
+  background: var(--color-red, #f38ba8);
+  color: #1e1e2e;
+  font-size: 11px;
+  padding: 4px 8px;
+}
+
+.map-btn--danger:hover {
+  opacity: 0.85;
+}
+
+/* Table */
+.map-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.map-table th {
+  text-align: left;
+  padding: 6px 10px;
+  color: var(--color-text-muted, #6c7086);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  border-bottom: 1px solid var(--color-border, #313244);
+}
+
+.map-table td {
+  padding: 8px 10px;
+  color: var(--color-text-primary, #cdd6f4);
+  border-bottom: 1px solid var(--color-border, #1e1e2e);
+  vertical-align: middle;
+}
+
+.map-table tr:hover td {
+  background: var(--color-bg-hover, #313244);
+}
+
+.map-row--active td {
+  background: rgba(137, 180, 250, 0.08);
+}
+
+/* Badges */
+.map-badge {
+  display: inline-block;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 500;
+  padding: 2px 6px;
+}
+
+.map-badge--generator {
+  background: rgba(137, 180, 250, 0.2);
+  color: #89b4fa;
+}
+
+.map-badge--reviewer {
+  background: rgba(166, 227, 161, 0.2);
+  color: #a6e3a1;
+}
+
+.map-badge--approved {
+  background: rgba(166, 227, 161, 0.2);
+  color: #a6e3a1;
+}
+
+.map-badge--failed {
+  background: rgba(243, 139, 168, 0.2);
+  color: #f38ba8;
+}
+
+.map-badge--running {
+  background: rgba(249, 226, 175, 0.2);
+  color: #f9e2af;
+}
+
+.map-badge--max_iterations {
+  background: rgba(203, 166, 247, 0.2);
+  color: #cba6f7;
+}
+
+/* Misc */
+.map-mono {
+  font-family: monospace;
+  font-size: 12px;
+}
+
+.map-muted {
+  color: var(--color-text-muted, #6c7086);
+  font-size: 12px;
+}
+
+.map-empty {
+  color: var(--color-text-muted, #6c7086);
+  font-size: 13px;
+  font-style: italic;
+  margin: 0;
+}
+
+.map-error {
+  color: var(--color-red, #f38ba8);
+  font-size: 12px;
+  margin: 0;
+  width: 100%;
+}
+
+.map-task-preview {
+  max-width: 280px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Run result */
+.map-run-result {
+  border: 1px solid var(--color-border, #313244);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.map-run-result-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  background: var(--color-bg-primary, #181825);
+  border-bottom: 1px solid var(--color-border, #313244);
+  font-size: 13px;
+  color: var(--color-text-primary, #cdd6f4);
+}
+
+/* Steps */
+.map-steps {
+  display: flex;
+  flex-direction: column;
+}
+
+.map-step {
+  border-bottom: 1px solid var(--color-border, #1e1e2e);
+}
+
+.map-step:last-child {
+  border-bottom: none;
+}
+
+.map-step-header {
+  width: 100%;
+  background: none;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  text-align: left;
+  color: var(--color-text-primary, #cdd6f4);
+  font-size: 13px;
+  transition: background 0.1s;
+}
+
+.map-step-header:hover {
+  background: var(--color-bg-hover, #313244);
+}
+
+.map-chevron {
+  margin-left: auto;
+  font-size: 10px;
+  color: var(--color-text-muted, #6c7086);
+}
+
+.map-step-body {
+  background: var(--color-bg-primary, #181825);
+  padding: 10px 12px;
+}
+
+.map-step-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: var(--color-text-muted, #6c7086);
+  margin: 0 0 4px;
+}
+
+.map-step-label--err {
+  color: var(--color-red, #f38ba8);
+}
+
+.map-pre {
+  background: var(--color-bg-secondary, #1e1e2e);
+  border: 1px solid var(--color-border, #313244);
+  border-radius: 4px;
+  padding: 8px;
+  font-size: 12px;
+  font-family: monospace;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--color-text-primary, #cdd6f4);
+  margin: 0 0 8px;
+}
+
+.map-pre--err {
+  color: var(--color-red, #f38ba8);
+}


### PR DESCRIPTION
## Summary

- **Backend (Rust)**: Three new SQLite tables (`agent_definitions`, `pipeline_definitions`, `pipeline_runs`) with full CRUD. `run_pipeline` async command loops generator→reviewer up to `max_iterations`, passing task + generator output + git diff to the reviewer via stdin, and stops when the reviewer output contains an approval signal (LGTM, approved, looks good, etc.)
- **Frontend (React)**: `MultiAgentPipelinePanel` with three tabs — Agents (create/delete generators and reviewers), Pipelines (compose agents into named pipelines with configurable iteration cap), and Run (execute a pipeline against the current worktree, view step-by-step stdout/stderr with collapsible sections, browse history)
- **Wiring**: `multiAgentPipeline` added to `usePanels`, command palette entry under AI category, conditional render in `App.tsx`

## Test plan

- [ ] Run `cargo check` + `cargo clippy` — no errors or warnings
- [ ] Run `npm run typecheck` + `npm run lint` + `npm run format:check` — all pass
- [ ] Create a generator agent (e.g. `echo`) and a reviewer agent (e.g. `echo approved`)
- [ ] Create a pipeline with those agents and run it — should finish with status `approved` after 1 iteration
- [ ] Create a pipeline where reviewer never approves — should finish with status `max_iterations` after N iterations
- [ ] History table populates and clicking a row shows the run detail