### PR TITLE
fix: resolve cleanup variable scoping bug in StatusBar clock effect

### DIFF
--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -36,13 +36,13 @@ export function StatusBar({
     const now = new Date();
     const msToNextMinute =
       (60 - now.getSeconds()) * 1000 - now.getMilliseconds();
+    let cleanup: (() => void) | undefined;
     const timeout = setTimeout(() => {
       update();
       const interval = setInterval(update, 60_000);
       cleanup = () => clearInterval(interval);
     }, msToNextMinute);
 
-    let cleanup: (() => void) | undefined;
     return () => {
       clearTimeout(timeout);
       cleanup?.();


### PR DESCRIPTION
## Summary
- Moves the `cleanup` variable declaration before the `setTimeout` call in the clock effect so it is properly initialized when the callback assigns to it.
- Previously, if the component unmounted before the timeout fired, `cleanup` was `undefined` and the interval was never cleared, causing a memory leak.

Fixes #122

## Test plan
- [ ] Verify the clock updates correctly on the minute boundary
- [ ] Mount and quickly unmount the StatusBar to confirm no lingering intervals