### PR TITLE
fix: clear copy timeouts on unmount (ClipboardHistory, RequestInspector)

### DIFF
--- a/src/components/ClipboardHistory.tsx
+++ b/src/components/ClipboardHistory.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { Dialog, DialogContent } from "./ui/dialog";
 
@@ -47,6 +47,13 @@ export function ClipboardHistory({ onClose }: ClipboardHistoryProps) {
   const [expandedId, setExpandedId] = useState<number | null>(null);
   const [copiedId, setCopiedId] = useState<number | null>(null);
   const [confirmClear, setConfirmClear] = useState(false);
+  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+    };
+  }, []);
 
   const loadEntries = useCallback(async () => {
     setLoading(true);
@@ -74,7 +81,8 @@ export function ClipboardHistory({ onClose }: ClipboardHistoryProps) {
     try {
       await navigator.clipboard.writeText(entry.content);
       setCopiedId(entry.id);
-      setTimeout(() => setCopiedId(null), 1500);
+      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+      copyTimeoutRef.current = setTimeout(() => setCopiedId(null), 1500);
     } catch {
       // copy failed
     }

--- a/src/components/RequestInspector.tsx
+++ b/src/components/RequestInspector.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 
 interface TrafficEntry {
   id: number;
@@ -54,12 +54,20 @@ function buildCurl(entry: TrafficEntry): string {
 export function RequestInspector({ entry }: RequestInspectorProps) {
   const [tab, setTab] = useState<"request" | "response">("response");
   const [copied, setCopied] = useState(false);
+  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+    };
+  }, []);
 
   const copyAsCurl = async () => {
     try {
       await navigator.clipboard.writeText(buildCurl(entry));
       setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+      copyTimeoutRef.current = setTimeout(() => setCopied(false), 2000);
     } catch {
       // Clipboard not available
     }


### PR DESCRIPTION
## Summary
- Store `setTimeout` return values in refs and clear them on component unmount via `useEffect` cleanup in both `ClipboardHistory` and `RequestInspector`
- Prevents React "setState on unmounted component" warnings when components unmount before the copy-confirmation timeout fires
- Also clears any pending timeout before starting a new one on repeated clicks

Closes #123

## Test plan
- [ ] Open ClipboardHistory, copy an entry, close the dialog before 1.5s — no console warning
- [ ] Open RequestInspector, click "Copy as cURL", navigate away before 2s — no console warning
- [ ] Rapid-click copy multiple times — only the last timeout fires