### PR TITLE
fix: reset CreatePRPanel form state on open/close cycles

### DIFF
--- a/src/components/CreatePRPanel.tsx
+++ b/src/components/CreatePRPanel.tsx
@@ -34,6 +34,14 @@ export function CreatePRPanel({ worktreeId, branch }: CreatePRPanelProps) {
 
   const init = useCallback(async () => {
     setLoading(true);
+    setTitle("");
+    setBody("");
+    setDraft(false);
+    setExistingPR(null);
+    setCreatedPR(null);
+    setError(null);
+    setCreating(false);
+    setGeneratingDesc(false);
     try {
       const [existing, defaultBranch, template] = await Promise.all([
         invoke<ExistingPR | null>("get_pr_for_branch", { worktreeId }),


### PR DESCRIPTION
## Summary
- Resets all form state (`title`, `body`, `draft`, `existingPR`, `createdPR`, `error`, `creating`, `generatingDesc`) at the start of the `init` callback in `CreatePRPanel.tsx`
- Prevents stale data from persisting when the panel is closed and reopened

## Test plan
- [ ] Open CreatePRPanel, partially fill the form, close it, reopen — fields should be blank/default
- [ ] Open CreatePRPanel for a branch with an existing PR — existing PR data loads correctly
- [ ] Create a PR through the panel — flow works end-to-end

Fixes #129