### PR TITLE
fix: roll back optimistic toggle on failure in PluginManager

### DIFF
--- a/src/components/PluginManager.tsx
+++ b/src/components/PluginManager.tsx
@@ -41,15 +41,20 @@ export function PluginManager({ onClose }: PluginManagerProps) {
   const handleToggle = useCallback(
     async (pluginId: string, enabled: boolean) => {
       setTogglingId(pluginId);
+
+      // Optimistic update: flip the UI immediately
+      setPlugins((prev) =>
+        prev.map((p) => (p.id === pluginId ? { ...p, enabled: !enabled } : p)),
+      );
+
       try {
         await invoke("toggle_plugin", { pluginId, enabled: !enabled });
-        setPlugins((prev) =>
-          prev.map((p) =>
-            p.id === pluginId ? { ...p, enabled: !enabled } : p,
-          ),
-        );
       } catch (e) {
-        setError(String(e));
+        // Roll back to previous state on failure
+        setPlugins((prev) =>
+          prev.map((p) => (p.id === pluginId ? { ...p, enabled } : p)),
+        );
+        setError(`Failed to toggle plugin: ${String(e)}`);
       }
       setTogglingId(null);
     },


### PR DESCRIPTION
## Summary
- Fixes #125 — PluginManager optimistic toggle was not rolled back on failure
- The toggle handler now applies the UI update immediately (optimistic) and reverts to the previous `enabled` state if the `invoke()` call fails
- Displays a descriptive error message to the user on failure

## Test plan
- [ ] Toggle a plugin with a working backend — should toggle normally
- [ ] Simulate a backend failure (e.g. kill Tauri plugin host) — toggle should snap back to its previous state and show an error banner