### PR TITLE
fix: allow dismissing OnboardingWizard (close button, backdrop, Escape)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1434,9 +1434,15 @@ function AppContent({
         </div>
       )}
       {panels.onboarding && (
-        <div className="panel-overlay">
-          <div className="panel-dialog panel-dialog--wide">
-            <OnboardingWizard onComplete={() => closePanel("onboarding")} />
+        <div className="panel-overlay" onClick={() => closePanel("onboarding")}>
+          <div
+            className="panel-dialog panel-dialog--wide"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <OnboardingWizard
+              onComplete={() => closePanel("onboarding")}
+              onClose={() => closePanel("onboarding")}
+            />
           </div>
         </div>
       )}

--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import "../styles/onboarding.css";
 import { Dialog, DialogContent } from "./ui/dialog";
@@ -7,17 +7,35 @@ import { Input } from "./ui/input";
 
 interface OnboardingWizardProps {
   onComplete: () => void;
+  onClose?: () => void;
 }
 
 type Step = "welcome" | "github" | "project" | "done";
 
-export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
+export function OnboardingWizard({
+  onComplete,
+  onClose,
+}: OnboardingWizardProps) {
   const [step, setStep] = useState<Step>("welcome");
   const [authStatus, setAuthStatus] = useState<
     "idle" | "pending" | "done" | "error"
   >("idle");
   const [projectPath, setProjectPath] = useState("");
   const [projectError, setProjectError] = useState("");
+
+  const handleClose = useCallback(() => {
+    if (onClose) onClose();
+  }, [onClose]);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        handleClose();
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [handleClose]);
 
   const handleAuth = async () => {
     setAuthStatus("pending");
@@ -60,6 +78,28 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
   return (
     <Dialog open>
       <DialogContent className="onboarding-card">
+        {onClose && (
+          <button
+            onClick={handleClose}
+            aria-label="Close"
+            className="onboarding-close-btn"
+            style={{
+              position: "absolute",
+              top: "12px",
+              right: "12px",
+              background: "none",
+              border: "none",
+              cursor: "pointer",
+              fontSize: "1.25rem",
+              lineHeight: 1,
+              padding: "4px 8px",
+              borderRadius: "4px",
+              color: "var(--foreground, #888)",
+            }}
+          >
+            &times;
+          </button>
+        )}
         {step === "welcome" && (
           <>
             <h2 className="onboarding-title">Welcome to Workroot</h2>


### PR DESCRIPTION
## Summary
- Add `onClose` prop to `OnboardingWizard` component
- Add a close (x) button in the top-right corner of the wizard card
- Add Escape key handler to dismiss the wizard
- Add backdrop click handler on the overlay wrapper in `App.tsx`

Closes #127

## Test plan
- [ ] Open onboarding wizard and verify the x button appears and dismisses it
- [ ] Click the backdrop (dark overlay) outside the dialog and verify it dismisses
- [ ] Press Escape while the wizard is open and verify it dismisses
- [ ] Complete the wizard normally and verify `onComplete` still works