### PR TITLE
fix: add confirmation dialog before deleting env profile

### DIFF
--- a/src/components/ProfileSelector.tsx
+++ b/src/components/ProfileSelector.tsx
@@ -22,6 +22,7 @@ export function ProfileSelector({
 }: ProfileSelectorProps) {
   const [showCreate, setShowCreate] = useState(false);
   const [newName, setNewName] = useState("");
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
 
   const handleCreate = useCallback(
     (e: React.FormEvent) => {
@@ -44,8 +45,13 @@ export function ProfileSelector({
 
   const handleDelete = useCallback(() => {
     if (activeProfileId === null) return;
+    if (!confirmingDelete) {
+      setConfirmingDelete(true);
+      return;
+    }
     onDelete(activeProfileId);
-  }, [activeProfileId, onDelete]);
+    setConfirmingDelete(false);
+  }, [activeProfileId, onDelete, confirmingDelete]);
 
   return (
     <div className="profile-selector">
@@ -123,8 +129,16 @@ export function ProfileSelector({
                   onClick={handleDelete}
                 >
                   <TrashIcon />
-                  Delete
+                  {confirmingDelete ? "Confirm delete?" : "Delete"}
                 </button>
+                {confirmingDelete && (
+                  <button
+                    className="profile-popover-item"
+                    onClick={() => setConfirmingDelete(false)}
+                  >
+                    Cancel
+                  </button>
+                )}
               </Popover.Content>
             </Popover.Portal>
           </Popover.Root>


### PR DESCRIPTION
## Summary
- Adds an inline confirmation step to the delete profile button in `ProfileSelector.tsx`
- First click changes button text to "Confirm delete?" and shows a Cancel option
- Second click actually performs the deletion
- Prevents accidental profile deletions

Closes #111

## Test plan
- [ ] Open the env profile popover menu
- [ ] Click "Delete" and verify it changes to "Confirm delete?" without deleting
- [ ] Click "Cancel" and verify it resets back to "Delete"
- [ ] Click "Delete" then "Confirm delete?" and verify the profile is deleted