### PR TITLE
fix: discard stale UnifiedSearch results (race condition)

### DIFF
--- a/src/components/UnifiedSearch.tsx
+++ b/src/components/UnifiedSearch.tsx
@@ -106,6 +106,7 @@ export function UnifiedSearch({
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const searchGenRef = useRef(0);
 
   const recentSearches = useMemo(
     () => (query ? [] : getRecentSearches()),
@@ -139,17 +140,22 @@ export function UnifiedSearch({
     }
 
     setSearching(true);
+    const generation = ++searchGenRef.current;
     debounceRef.current = setTimeout(async () => {
       try {
         const searchResults = await invoke<SearchResult[]>("unified_search", {
           query: trimmed,
         });
+        if (generation !== searchGenRef.current) return;
         setResults(searchResults);
         setSelectedIndex(0);
       } catch {
+        if (generation !== searchGenRef.current) return;
         setResults([]);
       } finally {
-        setSearching(false);
+        if (generation === searchGenRef.current) {
+          setSearching(false);
+        }
       }
     }, DEBOUNCE_MS);
 


### PR DESCRIPTION
## Summary
- Adds a `searchGenRef` (useRef counter) that increments on every new search query
- After `invoke` resolves, checks whether the generation still matches before updating state
- Stale results from slower previous searches are silently discarded, preventing out-of-order overwrites

Closes #119

## Test plan
- [ ] Type quickly in the unified search box — only the final query's results should appear
- [ ] Verify the spinner clears correctly after the last search completes
- [ ] Confirm clearing the input resets results as before