### PR TITLE
fix: prevent race condition in AI chat sidebar health checks

### DIFF
--- a/src/components/AiChatSidebar.tsx
+++ b/src/components/AiChatSidebar.tsx
@@ -40,6 +40,7 @@ export function AiChatSidebar({ open, onClose }: AiChatSidebarProps) {
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  const healthCheckGenRef = useRef(0);
 
   // Auto-scroll to bottom on new messages
   useEffect(() => {
@@ -67,12 +68,15 @@ export function AiChatSidebar({ open, onClose }: AiChatSidebarProps) {
   }, [selectedModel]);
 
   const checkHealth = useCallback(async () => {
+    const gen = ++healthCheckGenRef.current;
     setConnectionStatus("checking");
     try {
       await invoke("ai_check_health");
+      if (gen !== healthCheckGenRef.current) return;
       setConnectionStatus("connected");
       loadModels();
     } catch {
+      if (gen !== healthCheckGenRef.current) return;
       setConnectionStatus("disconnected");
       setModels([]);
     }


### PR DESCRIPTION
## Summary
- Adds a generation counter ref (`healthCheckGenRef`) to `AiChatSidebar.tsx` so that when rapid open/close toggles fire multiple concurrent `ai_check_health` / `ai_chat_list_models` calls, only the latest one updates state
- After each `await`, the handler checks whether its generation still matches the current ref value; stale results are silently discarded

Closes #120

## Test plan
- [ ] Open and close the AI chat sidebar rapidly several times
- [ ] Verify only one "checking" -> "connected"/"disconnected" transition occurs (no flickering)
- [ ] Confirm normal open-then-use flow still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)