### PR TITLE
fix: guard GitHub auth polling against unmount race condition

### DIFF
--- a/src/components/GitHubSidebar.tsx
+++ b/src/components/GitHubSidebar.tsx
@@ -188,6 +188,20 @@ export function GitHubSidebar({ projectId }: GitHubSidebarProps) {
   const [refreshing, setRefreshing] = useState(false);
 
   const intervalRef = useRef<ReturnType<typeof setInterval>>(undefined);
+  const mountedRef = useRef(true);
+  const activeTabRef = useRef<Tab>(activeTab);
+
+  // Keep activeTabRef in sync
+  useEffect(() => {
+    activeTabRef.current = activeTab;
+  }, [activeTab]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   /* ---- Fetch data for the active tab ---- */
   const fetchData = useCallback(
@@ -247,6 +261,7 @@ export function GitHubSidebar({ projectId }: GitHubSidebarProps) {
     setSignInError(null);
     try {
       const dc = await invoke<DeviceCodeInfo>("github_start_device_flow");
+      if (!mountedRef.current) return;
       setDeviceCode(dc);
       setSigningIn(false);
       invoke("github_poll_for_token", {
@@ -254,19 +269,22 @@ export function GitHubSidebar({ projectId }: GitHubSidebarProps) {
         interval: dc.interval,
       })
         .then(() => {
+          if (!mountedRef.current) return;
           setDeviceCode(null);
           setAuthError(false);
-          fetchData(activeTab);
+          fetchData(activeTabRef.current);
         })
         .catch((err: unknown) => {
+          if (!mountedRef.current) return;
           setDeviceCode(null);
           setSignInError(String(err));
         });
     } catch (err: unknown) {
+      if (!mountedRef.current) return;
       setSigningIn(false);
       setSignInError(String(err));
     }
-  }, [activeTab, fetchData]);
+  }, [fetchData]);
 
   const handlePatSubmit = useCallback(async () => {
     if (!patInput.trim()) return;

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
 
 interface GitHubUser {
@@ -34,9 +34,12 @@ export function useAuth() {
     isPolling: false,
   });
 
+  const mountedRef = useRef(true);
+
   const checkAuth = useCallback(async () => {
     try {
       const user = await invoke<GitHubUser | null>("github_get_user");
+      if (!mountedRef.current) return;
       setState((prev) => ({
         ...prev,
         isAuthenticated: user !== null,
@@ -45,6 +48,7 @@ export function useAuth() {
         error: null,
       }));
     } catch {
+      if (!mountedRef.current) return;
       setState((prev) => ({
         ...prev,
         isAuthenticated: false,
@@ -58,11 +62,19 @@ export function useAuth() {
     checkAuth();
   }, [checkAuth]);
 
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
   const loginWithPat = useCallback(async (token: string) => {
     setState((prev) => ({ ...prev, error: null, isLoading: true }));
     try {
       await invoke("github_store_pat", { token });
+      if (!mountedRef.current) return;
       const user = await invoke<GitHubUser | null>("github_get_user");
+      if (!mountedRef.current) return;
       if (user) {
         setState((prev) => ({
           ...prev,
@@ -79,6 +91,7 @@ export function useAuth() {
         }));
       }
     } catch (err: unknown) {
+      if (!mountedRef.current) return;
       setState((prev) => ({
         ...prev,
         error: String(err),
@@ -106,7 +119,9 @@ export function useAuth() {
         interval: deviceCode.interval,
       })
         .then(async () => {
+          if (!mountedRef.current) return;
           const user = await invoke<GitHubUser | null>("github_get_user");
+          if (!mountedRef.current) return;
           setState((prev) => ({
             ...prev,
             isAuthenticated: true,
@@ -117,6 +132,7 @@ export function useAuth() {
           }));
         })
         .catch((err: unknown) => {
+          if (!mountedRef.current) return;
           setState((prev) => ({
             ...prev,
             error: String(err),


### PR DESCRIPTION
## Summary
- Add `mountedRef` to `useAuth.ts` and `GitHubSidebar.tsx` to prevent `setState` calls after component unmount
- Guard all async callbacks (polling `.then`/`.catch`, `checkAuth`, `loginWithPat`) with mounted checks
- Replace stale `activeTab` closure capture in `handleDeviceFlow` with `activeTabRef` so polling always uses the current tab value

Closes #118

## Test plan
- [ ] Start device flow auth, then navigate away before polling completes — verify no React warnings about setState on unmounted component
- [ ] Complete device flow auth normally — verify it still works end to end
- [ ] Switch tabs while polling is active — verify `fetchData` uses the current tab, not the stale one

🤖 Generated with [Claude Code](https://claude.com/claude-code)