### PR TITLE
fix: worktree delete overlay, terminal resize, UI cleanup

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -189,9 +189,7 @@ function AppContent({
         });
       }
     } else {
-      // Auto-open the diff panel so the user can review changes immediately.
-      setContentTab("changes");
-      openPanelRef.current("gitDiff");
+      // Show toast with a "Review Changes" button instead of auto-opening.
       setAgentDoneToast(name);
     }
   }, [markAgentDone]);

--- a/src/components/ContentToolbar.tsx
+++ b/src/components/ContentToolbar.tsx
@@ -10,25 +10,6 @@ interface ContentToolbarProps {
 
 const TABS = [
   {
-    id: "terminal",
-    label: "Terminal",
-    icon: (
-      <svg
-        viewBox="0 0 16 16"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        className="size-3.5 shrink-0"
-      >
-        <rect x="1.5" y="2.5" width="13" height="11" rx="1.5" />
-        <path d="M4.5 6l2.5 2-2.5 2" />
-        <path d="M8.5 10.5h3" />
-      </svg>
-    ),
-  },
-  {
     id: "changes",
     label: "Changes",
     icon: (

--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -668,5 +668,20 @@ function TerminalInstance({
     return () => window.removeEventListener("resize", handleResize);
   }, [visible]);
 
+  // Refit when container size changes (e.g. sidebar toggled)
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el || !visible) return;
+    const ro = new ResizeObserver(() => {
+      try {
+        fitAddonRef.current?.fit();
+      } catch {
+        // ignore
+      }
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [visible]);
+
   return <div className="terminal-container" ref={containerRef} />;
 }

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -32,7 +32,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogOverlay />
     <AlertDialogPrimitive.Content
       ref={ref}
-      className={cn(className)}
+      className={cn("fixed z-[9999]", className)}
       {...props}
     >
       {children}

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -889,7 +889,7 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  z-index: 1000;
+  z-index: 10001;
   background: var(--bg-primary);
   border: 1px solid var(--border);
   border-radius: 8px;


### PR DESCRIPTION
## Summary
- Raise delete-confirm-dialog z-index from 1000 to 10001 so it renders above panel overlays when deleting a worktree
- Add explicit z-index to AlertDialog content for proper stacking context
- Add ResizeObserver to TerminalPanel so terminal refits when sidebar is toggled (fixes terminal not expanding)
- Remove Terminal tab from content toolbar (terminal always shows underneath, the tab was redundant)
- Stop auto-opening changes/diff panel on agent complete — the toast with "Review Changes" button is sufficient

## Test plan
- [ ] Delete a worktree — confirm dialog should appear above everything
- [ ] Toggle GitHub sidebar — terminal should resize to fill available space
- [ ] Verify Terminal tab is gone from toolbar
- [ ] Agent complete should show toast only, not auto-switch to changes tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)