### PR TITLE
fix: always show confirmation dialog when deleting a worktree

### DIFF
--- a/src/components/WorktreeItem.tsx
+++ b/src/components/WorktreeItem.tsx
@@ -61,7 +61,7 @@ export function WorktreeItem({
     y: number;
   } | null>(null);
   const [deleteConfirm, setDeleteConfirm] = useState<{
-    warnings: DeleteWarnings;
+    warnings: DeleteWarnings | null;
   } | null>(null);
 
   const handleClick = useCallback(() => {
@@ -111,12 +111,8 @@ export function WorktreeItem({
   const handleDeleteClick = useCallback(async () => {
     setContextMenu(null);
     const warnings = await onCheckWarnings(worktree.id);
-    if (warnings && (warnings.is_dirty || warnings.unpushed_commits > 0)) {
-      setDeleteConfirm({ warnings });
-    } else {
-      onDelete(worktree.id);
-    }
-  }, [worktree.id, onDelete, onCheckWarnings]);
+    setDeleteConfirm({ warnings: warnings ?? null });
+  }, [worktree.id, onCheckWarnings]);
 
   const handleConfirmDelete = useCallback(() => {
     setDeleteConfirm(null);
@@ -225,23 +221,25 @@ export function WorktreeItem({
       >
         <AlertDialogContent className="delete-confirm-dialog">
           <div className="delete-confirm-title">Delete worktree?</div>
-          {deleteConfirm && (
-            <div className="delete-confirm-warnings">
-              {deleteConfirm.warnings.is_dirty && (
-                <div className="delete-confirm-warning">
-                  Has uncommitted changes
-                </div>
-              )}
-              {deleteConfirm.warnings.unpushed_commits > 0 && (
-                <div className="delete-confirm-warning">
-                  {deleteConfirm.warnings.unpushed_commits} unpushed{" "}
-                  {deleteConfirm.warnings.unpushed_commits === 1
-                    ? "commit"
-                    : "commits"}
-                </div>
-              )}
-            </div>
-          )}
+          {deleteConfirm?.warnings &&
+            (deleteConfirm.warnings.is_dirty ||
+              deleteConfirm.warnings.unpushed_commits > 0) && (
+              <div className="delete-confirm-warnings">
+                {deleteConfirm.warnings.is_dirty && (
+                  <div className="delete-confirm-warning">
+                    Has uncommitted changes
+                  </div>
+                )}
+                {deleteConfirm.warnings.unpushed_commits > 0 && (
+                  <div className="delete-confirm-warning">
+                    {deleteConfirm.warnings.unpushed_commits} unpushed{" "}
+                    {deleteConfirm.warnings.unpushed_commits === 1
+                      ? "commit"
+                      : "commits"}
+                  </div>
+                )}
+              </div>
+            )}
           <div className="delete-confirm-actions">
             <AlertDialogCancel
               className="delete-confirm-btn cancel"
@@ -253,7 +251,11 @@ export function WorktreeItem({
               className="delete-confirm-btn confirm"
               onClick={handleConfirmDelete}
             >
-              Delete Anyway
+              {deleteConfirm?.warnings &&
+              (deleteConfirm.warnings.is_dirty ||
+                deleteConfirm.warnings.unpushed_commits > 0)
+                ? "Delete Anyway"
+                : "Delete"}
             </AlertDialogAction>
           </div>
         </AlertDialogContent>


### PR DESCRIPTION
## Summary
- The delete confirmation dialog was only shown for dirty/unpushed worktrees. Clean worktrees were deleted immediately with no confirmation, making accidental deletion too easy.
- Now the AlertDialog is always displayed. Warnings (uncommitted changes, unpushed commits) are still shown when present; otherwise the user sees a simple "Delete worktree?" prompt with a "Delete" button instead of "Delete Anyway".

Fixes #103

## Test plan
- [ ] Right-click a clean worktree and click "Delete Worktree" -- confirmation dialog should appear
- [ ] Right-click a dirty worktree and click "Delete Worktree" -- confirmation dialog should appear with warning text and "Delete Anyway" button
- [ ] Cancel button dismisses the dialog without deleting
- [ ] Confirm button deletes the worktree