### PR TITLE
fix: terminal takes full height and no mid-height auto-scroll

### DIFF
--- a/src/styles/terminal.css
+++ b/src/styles/terminal.css
@@ -5,7 +5,8 @@
 .terminal-fullscreen {
   display: flex;
   flex-direction: column;
-  height: 100%;
+  flex: 1;
+  min-height: 0;
   width: 100%;
   background-color: var(--bg-base);
 }
@@ -194,6 +195,7 @@
 .terminal-container {
   flex: 1;
   min-height: 0;
+  overflow: hidden;
   padding: 4px 6px 4px 4px;
 }
 


### PR DESCRIPTION
## Summary
- Replace `height: 100%` with `flex: 1` + `min-height: 0` on `.terminal-fullscreen` so the terminal properly fills remaining space in the flex column layout instead of overflowing
- Add `overflow: hidden` on `.terminal-container` to prevent the xterm viewport from causing unexpected auto-scroll behavior at mid-height

## Test plan
- [ ] Open any worktree terminal and verify it fills the full available height
- [ ] Scroll through terminal output and confirm no unexpected auto-scroll snapping to mid-height
- [ ] Split panes and verify each pane fills its allocated space correctly
- [ ] Resize the window and confirm the terminal resizes properly

Fixes #130