### PR TITLE
fix: settings page shows blurred/blank content

### DIFF
--- a/src/styles/settings-page.css
+++ b/src/styles/settings-page.css
@@ -3,6 +3,11 @@
    ========================================================== */
 
 .settings-page__panel {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 9999;
   width: 820px;
   max-width: calc(100vw - 60px);
   height: 600px;
@@ -22,11 +27,11 @@
 @keyframes settings-page-panel-in {
   from {
     opacity: 0;
-    transform: scale(0.97);
+    transform: translate(-50%, -50%) scale(0.97);
   }
   to {
     opacity: 1;
-    transform: scale(1);
+    transform: translate(-50%, -50%) scale(1);
   }
 }
 


### PR DESCRIPTION
## Summary
- Fixes #134 — Settings page shows blurred/blank app content
- The settings dialog panel (`.settings-page__panel`) had no `position` or `z-index`, so it rendered behind the `DialogOverlay` (z-index 9998 with `backdrop-blur-sm`), making the entire app appear blurred with no visible settings content
- Added `position: fixed`, centering via `translate(-50%, -50%)`, and `z-index: 9999` so the panel renders above the overlay
- Updated the entrance animation keyframes to preserve the centering transform

## Test plan
- [ ] Open the Settings page from the command palette or nav
- [ ] Verify settings content is fully visible and not blurred
- [ ] Verify the backdrop overlay still appears behind the dialog
- [ ] Navigate between settings sections (General, AI, Appearance, etc.)
- [ ] Close settings and verify normal app state is restored