### PR TITLE
fix: add responsive max-width to GitHub sidebar (#115)

### DIFF
--- a/src/styles/github-sidebar.css
+++ b/src/styles/github-sidebar.css
@@ -9,6 +9,7 @@
   flex-direction: column;
   height: 100%;
   width: 280px;
+  max-width: calc(100vw - 40px);
   background-color: var(--bg-surface);
   border-left: 1px solid var(--border-subtle);
   flex-shrink: 0;


### PR DESCRIPTION
## Summary
- Adds `max-width: calc(100vw - 40px)` to the `.gh-sidebar` rule in `github-sidebar.css`, preventing the 280px fixed-width panel from overflowing on narrow viewports.
- The other five panels mentioned in #115 (ai-chat, todo-panel, test-runner-panel, unified-search, command-palette) already had this fix applied.

Closes #115

## Test plan
- [ ] Resize browser window below 320px wide and confirm the GitHub sidebar shrinks instead of overflowing
- [ ] Verify the other five panels (AI Chat, Todo Kanban, Test Runner, Unified Search, Command Palette) still behave correctly on narrow viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)