### PR TITLE
fix: preserve terminal sessions when switching views or branches

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -174,6 +174,15 @@ function AppContent({
   selectedWorktreeIdRef.current = selectedWorktreeId;
   selectedWorktreeNameRef.current = selectedWorktreeName;
 
+  // Remember the last valid worktree path/name so TerminalPanel stays
+  // mounted (and PTY sessions survive) when navigating to Home or Settings.
+  const lastWorktreePathRef = useRef(selectedWorktreePath);
+  const lastWorktreeNameRef = useRef(selectedWorktreeName);
+  if (selectedWorktreePath) {
+    lastWorktreePathRef.current = selectedWorktreePath;
+    lastWorktreeNameRef.current = selectedWorktreeName;
+  }
+
   const openPanelRef = useRef(openPanel);
   openPanelRef.current = openPanel;
 
@@ -1064,22 +1073,7 @@ function AppContent({
     <>
       {showSettings ? (
         <SettingsTab />
-      ) : selectedWorktreePath ? (
-        <>
-          <ContentToolbar
-            activeTab={contentTab}
-            onTabChange={handleContentTabChange}
-            worktreeName={selectedWorktreeName ?? "Shell"}
-            projectName={selectedProjectName ?? undefined}
-          />
-          <TerminalPanel
-            cwd={selectedWorktreePath}
-            worktreeName={selectedWorktreeName ?? "Shell"}
-            themeId={terminalThemeId}
-            onAgentComplete={handleAgentComplete}
-          />
-        </>
-      ) : (
+      ) : !selectedWorktreePath ? (
         <div className="content-scroll">
           <div className="content-inner">
             <Dashboard
@@ -1093,6 +1087,38 @@ function AppContent({
               <EnvPanel projectId={selectedProjectId} />
             )}
           </div>
+        </div>
+      ) : null}
+      {/* TerminalPanel is rendered outside the ternary so it stays mounted
+          (and PTY sessions stay alive) when the user navigates to Home or
+          Settings. We hide it via display:none when it isn't the active view. */}
+      {lastWorktreePathRef.current && (
+        <div
+          style={{
+            display: !showSettings && selectedWorktreePath ? "flex" : "none",
+            width: "100%",
+            height: "100%",
+            flexDirection: "column",
+            flex: 1,
+            minHeight: 0,
+          }}
+        >
+          <ContentToolbar
+            activeTab={contentTab}
+            onTabChange={handleContentTabChange}
+            worktreeName={
+              selectedWorktreeName ?? lastWorktreeNameRef.current ?? "Shell"
+            }
+            projectName={selectedProjectName ?? undefined}
+          />
+          <TerminalPanel
+            cwd={lastWorktreePathRef.current}
+            worktreeName={
+              selectedWorktreeName ?? lastWorktreeNameRef.current ?? "Shell"
+            }
+            themeId={terminalThemeId}
+            onAgentComplete={handleAgentComplete}
+          />
         </div>
       )}
       <StatusBar

--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -629,9 +629,12 @@ function TerminalInstance({
       ptyRef.current = null;
       fitAddonRef.current = null;
     };
-  }, [cwd, themeId]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- themeId is
+    // intentionally excluded: theme changes are handled by the effect below
+    // without destroying/recreating the PTY session.
+  }, [cwd]);
 
-  // Update theme when themeId prop changes
+  // Update theme when themeId prop changes (without recreating the PTY)
   useEffect(() => {
     if (!termRef.current || !themeId) return;
     const t = getThemeById(themeId);


### PR DESCRIPTION
## Summary
- Moves `TerminalPanel` outside the conditional ternary in `App.tsx` so it stays mounted (hidden via `display:none`) when navigating to Home or Settings, preventing PTY session destruction
- Removes `themeId` from `TerminalInstance`'s PTY-initialization `useEffect` dependencies — theme changes are already handled by a dedicated effect that updates the xterm theme without recreating the PTY process
- Uses refs (`lastWorktreePathRef`, `lastWorktreeNameRef`) to remember the last valid worktree path/name so the terminal can be restored when returning

## Test plan
- [ ] Open a terminal in a worktree, run a command, navigate to Home, then back — terminal output should still be visible
- [ ] Open terminals in multiple worktrees, switch between them — all sessions should persist
- [ ] Change the terminal theme in settings — existing sessions should update theme without resetting
- [ ] Create multiple terminal tabs, switch worktrees, switch back — all tabs and their content should be preserved

Closes #132