### PR TITLE
fix: preserve terminal when opening settings, guard resize observer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1019,10 +1019,7 @@ function AppContent({
     openAiChat: () => openPanel("aiChat"),
     openNotifications: () => openPanel("notifications"),
     openSettings: () => {
-      setShowSettings(true);
-      setSelectedWorktreeId(null);
-      setSelectedWorktreePath(null);
-      setSelectedWorktreeName(null);
+      openPanel("settingsPage");
     },
   };
 

--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -675,7 +675,10 @@ function TerminalInstance({
   useEffect(() => {
     const el = containerRef.current;
     if (!el || !visible) return;
-    const ro = new ResizeObserver(() => {
+    const ro = new ResizeObserver((entries) => {
+      // Skip refit when container is hidden (display:none gives zero size)
+      const { width, height } = entries[0].contentRect;
+      if (width === 0 || height === 0) return;
       try {
         fitAddonRef.current?.fit();
       } catch {


### PR DESCRIPTION
## Summary
- Settings gear icon now opens the full SettingsPage modal overlay instead of replacing the content area with SettingsTab. This preserves terminal sessions since the terminal stays mounted behind the modal.
- Guard the ResizeObserver callback to skip `fit()` when the container has zero dimensions (happens when terminal is hidden via `display:none`), preventing scroll/layout issues when returning to the terminal.

## Test plan
- [ ] Click settings gear — full settings modal should appear over the terminal
- [ ] Close settings — terminal should still have its previous state/output
- [ ] Toggle sidebar — terminal should resize correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)