### PR TITLE
fix: suppress agent-done toast when viewing terminal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -186,6 +186,9 @@ function AppContent({
   const openPanelRef = useRef(openPanel);
   openPanelRef.current = openPanel;
 
+  const contentTabRef = useRef(contentTab);
+  contentTabRef.current = contentTab;
+
   const handleAgentComplete = useCallback(() => {
     const id = selectedWorktreeIdRef.current;
     const name = selectedWorktreeNameRef.current ?? "Terminal";
@@ -197,8 +200,9 @@ function AppContent({
           silent: false,
         });
       }
-    } else {
-      // Show toast with a "Review Changes" button instead of auto-opening.
+    } else if (contentTabRef.current !== "terminal") {
+      // Only show toast if the user isn't already viewing the terminal —
+      // if they're watching the agent's output, the notification is redundant.
       setAgentDoneToast(name);
     }
   }, [markAgentDone]);


### PR DESCRIPTION
## Summary
- Skip the "agent done" toast when the user is already focused on the terminal tab for the active worktree
- The notification is redundant since the user can see the agent's output directly
- Browser notifications still fire when the app is not focused (user is away)

Closes #175

## Test plan
- [ ] Run an agent in a worktree while viewing its terminal — no toast should appear
- [ ] Switch to a different tab (e.g. git diff) then let agent complete — toast should appear
- [ ] Unfocus the app and let agent complete — browser notification should still fire