### PR TITLE
feat: add drag-and-drop file support to terminal panel

### DIFF
--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -5,6 +5,7 @@ import { FitAddon } from "@xterm/addon-fit";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { invoke } from "@tauri-apps/api/core";
+import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { spawn } from "tauri-pty";
 import type { IPty } from "tauri-pty";
 import { getThemeById, DEFAULT_THEME_ID } from "../lib/terminalThemes";
@@ -447,6 +448,7 @@ function TerminalInstance({
   const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const onAgentCompleteRef = useRef(onAgentComplete);
   onAgentCompleteRef.current = onAgentComplete;
+  const [dragOver, setDragOver] = useState(false);
 
   // Create xterm + PTY on mount, destroy on unmount
   useEffect(() => {
@@ -610,9 +612,32 @@ function TerminalInstance({
       }
     }, 100);
 
+    // Tauri native drag-drop listener — writes dropped file paths to the PTY.
+    let unlistenDrop: (() => void) | null = null;
+
+    getCurrentWebview()
+      .onDragDropEvent((event) => {
+        if (event.payload.type === "over") {
+          setDragOver(true);
+        } else if (event.payload.type === "drop") {
+          setDragOver(false);
+          const paths = event.payload.paths;
+          if (paths.length > 0 && ptyRef.current && active) {
+            const pathStr = paths.map((p: string) => `"${p}"`).join(" ");
+            ptyRef.current.write(pathStr);
+          }
+        } else if (event.payload.type === "leave") {
+          setDragOver(false);
+        }
+      })
+      .then((unlisten) => {
+        unlistenDrop = unlisten;
+      });
+
     return () => {
       cancelled = true;
       clearTimeout(initTimer);
+      unlistenDrop?.();
       if (idleTimerRef.current) {
         clearTimeout(idleTimerRef.current);
         idleTimerRef.current = null;
@@ -689,5 +714,10 @@ function TerminalInstance({
     return () => ro.disconnect();
   }, [visible]);
 
-  return <div className="terminal-container" ref={containerRef} />;
+  return (
+    <div
+      className={`terminal-container${dragOver ? " terminal-drag-over" : ""}`}
+      ref={containerRef}
+    />
+  );
 }

--- a/src/styles/terminal.css
+++ b/src/styles/terminal.css
@@ -199,6 +199,12 @@
   padding: 4px 6px 4px 4px;
 }
 
+.terminal-container.terminal-drag-over {
+  outline: 2px dashed var(--accent);
+  outline-offset: -2px;
+  background: color-mix(in srgb, var(--accent) 5%, transparent);
+}
+
 .terminal-container .xterm {
   height: 100%;
 }


### PR DESCRIPTION
## Summary
- Listen for Tauri native `tauri://drag-drop` events via `getCurrentWebview().onDragDropEvent()` and write dropped file paths (quoted, space-separated) to the active terminal's PTY
- Add `dragOver` state and a `.terminal-drag-over` CSS class for a visual dashed-border overlay during drag-over
- Only write to the PTY when the terminal instance is the active one

## Test plan
- [ ] Drag a file from the OS file manager into the terminal panel and verify the quoted path appears at the cursor
- [ ] Drag multiple files and verify all paths appear space-separated
- [ ] Verify the dashed border overlay appears on drag-over and disappears on drag-leave
- [ ] Verify that dropping onto an inactive terminal pane does not write to the PTY