### PR TITLE
ui: add author, contact, and support to About page

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,6 +2,8 @@
 name = "workroot"
 version = "0.1.10"
 edition = "2021"
+authors = ["Saurav Panda <saurav@workroot.dev>"]
+description = "A local-first developer workspace for managing projects, terminals, and Git workflows."
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -39,6 +39,8 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ],
+    "copyright": "© 2024-2026 Saurav Panda. All rights reserved.",
+    "shortDescription": "A local-first developer workspace for managing projects, terminals, and Git workflows.",
     "macOS": {
       "minimumSystemVersion": "10.15"
     },

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -660,6 +660,37 @@ export function SettingsPage({ onClose }: SettingsPageProps) {
             </div>
 
             <div className="settings-page__field">
+              <div className="settings-page__field-label">Author</div>
+              <p className="settings-page__field-desc">Saurav Panda</p>
+            </div>
+
+            <div className="settings-page__field">
+              <div className="settings-page__field-label">Contact</div>
+              <p className="settings-page__field-desc">
+                <a
+                  href="mailto:saurav@workroot.dev"
+                  style={{ color: "var(--color-accent, #58a6ff)" }}
+                >
+                  saurav@workroot.dev
+                </a>
+              </p>
+            </div>
+
+            <div className="settings-page__field">
+              <div className="settings-page__field-label">Support</div>
+              <p className="settings-page__field-desc">
+                <a
+                  href="https://github.com/sauravpanda/workroot/issues/new"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={{ color: "var(--color-accent, #58a6ff)" }}
+                >
+                  Create a support ticket on GitHub
+                </a>
+              </p>
+            </div>
+
+            <div className="settings-page__field">
               <div className="settings-page__field-label">Source Code</div>
               <p className="settings-page__field-desc">
                 <a


### PR DESCRIPTION
## Summary
- Add author name (Saurav Panda) to Settings > About
- Add contact email link
- Add "Create a support ticket on GitHub" link pointing to issues/new
- Add copyright and description to Tauri bundle config
- Add authors/description to Cargo.toml

Closes #182

## Test plan
- [ ] Open Settings > About — verify author, contact, and support fields show
- [ ] Click contact email — should open mail client
- [ ] Click support link — should open GitHub new issue page
- [ ] macOS About menu should show copyright info