### PR TITLE
fix: distinguish network errors from auth failures in GitHub check

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -150,7 +150,19 @@ function AppContent({
     const check = () =>
       invoke<boolean>("github_check_auth")
         .then(setIsGitHubConnected)
-        .catch(() => setIsGitHubConnected(false));
+        .catch((err: unknown) => {
+          // Only mark as disconnected for auth failures, not network errors
+          const msg = String(err).toLowerCase();
+          if (
+            msg.includes("network") ||
+            msg.includes("fetch") ||
+            msg.includes("timeout")
+          ) {
+            // Network error — keep the previous auth state
+            return;
+          }
+          setIsGitHubConnected(false);
+        });
     check();
     const id = setInterval(check, 30_000);
     return () => clearInterval(id);

--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -414,24 +414,22 @@ async function loadTerminalSettings(): Promise<{
     ? "powershell.exe"
     : "/bin/zsh";
 
-  try {
-    const [shellSetting, initSetting, themeSetting] = await Promise.all([
-      invoke<string | null>("get_setting", { key: "terminal_shell" }),
-      invoke<string | null>("get_setting", { key: "terminal_init_command" }),
-      invoke<string | null>("get_setting", { key: "terminal_theme" }),
-    ]);
-    return {
-      shell: shellSetting?.trim() || defaultShell,
-      initCommand: initSetting?.trim() || null,
-      theme: getThemeById(themeSetting?.trim() || DEFAULT_THEME_ID),
-    };
-  } catch {
-    return {
-      shell: defaultShell,
-      initCommand: null,
-      theme: getThemeById(DEFAULT_THEME_ID),
-    };
-  }
+  const [shellResult, initResult, themeResult] = await Promise.allSettled([
+    invoke<string | null>("get_setting", { key: "terminal_shell" }),
+    invoke<string | null>("get_setting", { key: "terminal_init_command" }),
+    invoke<string | null>("get_setting", { key: "terminal_theme" }),
+  ]);
+  return {
+    shell:
+      (shellResult.status === "fulfilled" && shellResult.value?.trim()) ||
+      defaultShell,
+    initCommand:
+      (initResult.status === "fulfilled" && initResult.value?.trim()) || null,
+    theme: getThemeById(
+      (themeResult.status === "fulfilled" && themeResult.value?.trim()) ||
+        DEFAULT_THEME_ID,
+    ),
+  };
 }
 
 // Patterns that suggest the agent is waiting for user input.

--- a/src/components/WorktreeItem.tsx
+++ b/src/components/WorktreeItem.tsx
@@ -174,7 +174,10 @@ export function WorktreeItem({
         </span>
         <span className="worktree-indicators">
           {isAgentNeedsAttention && !isAgentDone && (
-            <span className="worktree-agent-attention" title="Needs attention" />
+            <span
+              className="worktree-agent-attention"
+              title="Needs attention"
+            />
           )}
           {isAgentDone && (
             <span className="worktree-agent-done" title="Agent completed" />

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -90,9 +90,9 @@ export function MainLayout({
   const [agentDoneWorktreeIds, setAgentDoneWorktreeIds] = useState<Set<number>>(
     () => new Set(),
   );
-  const [agentNeedsAttentionIds, setAgentNeedsAttentionIds] = useState<Set<number>>(
-    () => new Set(),
-  );
+  const [agentNeedsAttentionIds, setAgentNeedsAttentionIds] = useState<
+    Set<number>
+  >(() => new Set());
 
   // Project tabs state
   const [allProjects, setAllProjects] = useState<ProjectTab[]>([]);

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -679,7 +679,8 @@
 }
 
 @keyframes wt-agent-attention {
-  0%, 100% {
+  0%,
+  100% {
     opacity: 1;
     box-shadow: 0 0 5px rgba(245, 158, 11, 0.6);
   }


### PR DESCRIPTION
## Summary
- GitHub auth check now preserves previous auth state on network errors instead of marking as disconnected
- Terminal settings loading uses `Promise.allSettled` so one failed setting doesn't reset all to defaults

## Test plan
- [ ] Verify GitHub auth indicator remains correct during normal operation
- [ ] Simulate network disruption and verify auth state is preserved
- [ ] Verify terminal settings load correctly when one setting is missing

Closes #195