### PR TITLE
fix: bound log capture, add watcher cleanup, log startup errors

### DIFF
--- a/src-tauri/src/filewatcher/tracker.rs
+++ b/src-tauri/src/filewatcher/tracker.rs
@@ -19,6 +19,20 @@ impl FileWatcherRegistry {
     }
 }
 
+impl FileWatcherRegistry {
+    /// Remove all watchers, releasing OS file descriptors.
+    pub fn stop_all(&self) {
+        if let Ok(mut watchers) = self.watchers.lock() {
+            watchers.clear();
+        }
+    }
+
+    /// Number of active watchers (for diagnostics).
+    pub fn count(&self) -> usize {
+        self.watchers.lock().map(|w| w.len()).unwrap_or(0)
+    }
+}
+
 impl Default for FileWatcherRegistry {
     fn default() -> Self {
         Self::new()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -350,13 +350,17 @@ pub fn run() {
             // Start the reverse proxy on port 3000
             let proxy_handle = app.handle().clone();
             tauri::async_runtime::spawn(async move {
+                eprintln!("[startup] Starting reverse proxy on port 3000...");
                 proxy::server::start_proxy(proxy_handle).await;
+                eprintln!("[startup] Reverse proxy exited unexpectedly");
             });
 
             // Start the HTTP forward proxy on port 8888
             let fwd_proxy_handle = app.handle().clone();
             tauri::async_runtime::spawn(async move {
+                eprintln!("[startup] Starting forward proxy on port 8888...");
                 network::proxy::start_forward_proxy(fwd_proxy_handle).await;
+                eprintln!("[startup] Forward proxy exited unexpectedly");
             });
 
             // Start the MCP server on port 4444
@@ -367,13 +371,17 @@ pub fn run() {
                 .app_data_dir()
                 .unwrap_or_else(|_| std::path::PathBuf::from("."));
             tauri::async_runtime::spawn(async move {
+                eprintln!("[startup] Starting MCP server on port 4444...");
                 mcp::server::start_mcp_server(mcp_handle, mcp_data_dir).await;
+                eprintln!("[startup] MCP server exited unexpectedly");
             });
 
             // Start the webhook receiver on port 9999
             let webhook_handle = app.handle().clone();
             tauri::async_runtime::spawn(async move {
+                eprintln!("[startup] Starting webhook server on port 9999...");
                 webhooks::start_webhook_server(webhook_handle).await;
+                eprintln!("[startup] Webhook server exited unexpectedly");
             });
 
             tray::setup_tray(app)?;

--- a/src-tauri/src/process/lifecycle.rs
+++ b/src-tauri/src/process/lifecycle.rs
@@ -79,6 +79,10 @@ pub fn monitor_process(
     let stdout = child.stdout.take();
     let stderr = child.stderr.take();
 
+    // Maximum log lines stored per stream per process launch to prevent
+    // unbounded memory growth from noisy subprocesses.
+    const MAX_LOG_LINES: u64 = 50_000;
+
     // Start log capture tasks
     if let Some(out) = stdout {
         let app = app_handle.clone();
@@ -86,8 +90,21 @@ pub fn monitor_process(
             use tokio::io::{AsyncBufReadExt, BufReader};
             let reader = BufReader::new(out);
             let mut lines = reader.lines();
+            let mut count: u64 = 0;
             while let Ok(Some(line)) = lines.next_line().await {
-                super::logs::store_and_emit(&app, process_id, "stdout", &line);
+                count += 1;
+                if count == MAX_LOG_LINES {
+                    super::logs::store_and_emit(
+                        &app,
+                        process_id,
+                        "stdout",
+                        "[log capture limit reached — further output truncated]",
+                    );
+                }
+                if count <= MAX_LOG_LINES {
+                    super::logs::store_and_emit(&app, process_id, "stdout", &line);
+                }
+                // Continue reading (to drain the pipe) but don't store
             }
         });
     }
@@ -98,8 +115,20 @@ pub fn monitor_process(
             use tokio::io::{AsyncBufReadExt, BufReader};
             let reader = BufReader::new(err);
             let mut lines = reader.lines();
+            let mut count: u64 = 0;
             while let Ok(Some(line)) = lines.next_line().await {
-                super::logs::store_and_emit(&app, process_id, "stderr", &line);
+                count += 1;
+                if count == MAX_LOG_LINES {
+                    super::logs::store_and_emit(
+                        &app,
+                        process_id,
+                        "stderr",
+                        "[log capture limit reached — further output truncated]",
+                    );
+                }
+                if count <= MAX_LOG_LINES {
+                    super::logs::store_and_emit(&app, process_id, "stderr", &line);
+                }
             }
         });
     }
@@ -244,15 +273,27 @@ pub fn monitor_process(
                         registry.register(process_id, pid);
                     }
 
-                    // Capture new stdout/stderr
+                    // Capture new stdout/stderr (with same bounds as initial capture)
                     if let Some(out) = new_child.stdout.take() {
                         let app2 = app.clone();
                         tokio::spawn(async move {
                             use tokio::io::{AsyncBufReadExt, BufReader};
                             let reader = BufReader::new(out);
                             let mut lines = reader.lines();
+                            let mut count: u64 = 0;
                             while let Ok(Some(line)) = lines.next_line().await {
-                                super::logs::store_and_emit(&app2, process_id, "stdout", &line);
+                                count += 1;
+                                if count == MAX_LOG_LINES {
+                                    super::logs::store_and_emit(
+                                        &app2,
+                                        process_id,
+                                        "stdout",
+                                        "[log capture limit reached — further output truncated]",
+                                    );
+                                }
+                                if count <= MAX_LOG_LINES {
+                                    super::logs::store_and_emit(&app2, process_id, "stdout", &line);
+                                }
                             }
                         });
                     }
@@ -262,8 +303,20 @@ pub fn monitor_process(
                             use tokio::io::{AsyncBufReadExt, BufReader};
                             let reader = BufReader::new(err);
                             let mut lines = reader.lines();
+                            let mut count: u64 = 0;
                             while let Ok(Some(line)) = lines.next_line().await {
-                                super::logs::store_and_emit(&app2, process_id, "stderr", &line);
+                                count += 1;
+                                if count == MAX_LOG_LINES {
+                                    super::logs::store_and_emit(
+                                        &app2,
+                                        process_id,
+                                        "stderr",
+                                        "[log capture limit reached — further output truncated]",
+                                    );
+                                }
+                                if count <= MAX_LOG_LINES {
+                                    super::logs::store_and_emit(&app2, process_id, "stderr", &line);
+                                }
                             }
                         });
                     }

--- a/src/components/WorktreeItem.tsx
+++ b/src/components/WorktreeItem.tsx
@@ -174,7 +174,10 @@ export function WorktreeItem({
         </span>
         <span className="worktree-indicators">
           {isAgentNeedsAttention && !isAgentDone && (
-            <span className="worktree-agent-attention" title="Needs attention" />
+            <span
+              className="worktree-agent-attention"
+              title="Needs attention"
+            />
           )}
           {isAgentDone && (
             <span className="worktree-agent-done" title="Agent completed" />

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -90,9 +90,9 @@ export function MainLayout({
   const [agentDoneWorktreeIds, setAgentDoneWorktreeIds] = useState<Set<number>>(
     () => new Set(),
   );
-  const [agentNeedsAttentionIds, setAgentNeedsAttentionIds] = useState<Set<number>>(
-    () => new Set(),
-  );
+  const [agentNeedsAttentionIds, setAgentNeedsAttentionIds] = useState<
+    Set<number>
+  >(() => new Set());
 
   // Project tabs state
   const [allProjects, setAllProjects] = useState<ProjectTab[]>([]);

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -679,7 +679,8 @@
 }
 
 @keyframes wt-agent-attention {
-  0%, 100% {
+  0%,
+  100% {
     opacity: 1;
     box-shadow: 0 0 5px rgba(245, 158, 11, 0.6);
   }


### PR DESCRIPTION
## Summary
- Cap log capture at 50,000 lines per stream per process to prevent unbounded memory growth from noisy subprocesses
- Add `stop_all()` and `count()` methods to `FileWatcherRegistry` for cleanup and diagnostics
- Add startup logging for reverse proxy, forward proxy, MCP server, and webhook server — log when they exit unexpectedly

## Test plan
- [ ] Start a process that outputs >50k lines and verify logs are capped with a truncation message
- [ ] Verify normal log capture still works for typical processes
- [ ] Verify startup services log their initialization

Closes #205