### PR TITLE
fix: use async docker commands with timeouts, reduce blocking sleep

### DIFF
--- a/src-tauri/src/docker/monitor.rs
+++ b/src-tauri/src/docker/monitor.rs
@@ -1,5 +1,6 @@
 use serde::Serialize;
-use std::process::Command;
+use std::time::Duration;
+use tokio::process::Command;
 
 #[derive(Debug, Serialize)]
 pub struct ContainerStats {
@@ -14,15 +15,20 @@ pub struct ContainerStats {
 /// Get resource usage stats for all running containers.
 #[tauri::command]
 pub async fn get_container_stats() -> Result<Vec<ContainerStats>, String> {
-    let output = Command::new("docker")
-        .args([
-            "stats",
-            "--no-stream",
-            "--format",
-            "{{.ID}}\t{{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}\t{{.MemPerc}}\t{{.NetIO}}",
-        ])
-        .output()
-        .map_err(|e| format!("Run docker stats: {}", e))?;
+    let output = tokio::time::timeout(
+        Duration::from_secs(10),
+        Command::new("docker")
+            .args([
+                "stats",
+                "--no-stream",
+                "--format",
+                "{{.ID}}\t{{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}\t{{.MemPerc}}\t{{.NetIO}}",
+            ])
+            .output(),
+    )
+    .await
+    .map_err(|_| "docker stats timed out after 10 seconds".to_string())?
+    .map_err(|e| format!("Run docker stats: {}", e))?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -59,10 +65,15 @@ pub async fn get_container_stats() -> Result<Vec<ContainerStats>, String> {
 #[tauri::command]
 pub async fn get_container_logs(container_id: String, tail: Option<u32>) -> Result<String, String> {
     let tail_str = tail.unwrap_or(100).to_string();
-    let output = Command::new("docker")
-        .args(["logs", "--tail", &tail_str, &container_id])
-        .output()
-        .map_err(|e| format!("Run docker logs: {}", e))?;
+    let output = tokio::time::timeout(
+        Duration::from_secs(10),
+        Command::new("docker")
+            .args(["logs", "--tail", &tail_str, &container_id])
+            .output(),
+    )
+    .await
+    .map_err(|_| "docker logs timed out after 10 seconds".to_string())?
+    .map_err(|e| format!("Run docker logs: {}", e))?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -107,10 +118,13 @@ pub async fn container_action(container_id: String, action: String) -> Result<()
 
     args.push(&container_id);
 
-    let output = Command::new("docker")
-        .args(&args)
-        .output()
-        .map_err(|e| format!("Run docker {}: {}", cmd, e))?;
+    let output = tokio::time::timeout(
+        Duration::from_secs(30),
+        Command::new("docker").args(&args).output(),
+    )
+    .await
+    .map_err(|_| format!("docker {} timed out after 30 seconds", cmd))?
+    .map_err(|e| format!("Run docker {}: {}", cmd, e))?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);

--- a/src-tauri/src/process/lifecycle.rs
+++ b/src-tauri/src/process/lifecycle.rs
@@ -296,8 +296,9 @@ fn kill_process_by_pid(pid: u32) {
         let nix_pid = Pid::from_raw(pid as i32);
         let _ = kill(nix_pid, Signal::SIGTERM);
 
-        // Brief wait then force kill
-        std::thread::sleep(std::time::Duration::from_millis(500));
+        // Brief wait then force kill — kept short to avoid blocking the
+        // tokio runtime when called from async contexts.
+        std::thread::sleep(std::time::Duration::from_millis(100));
         if kill(nix_pid, None).is_ok() {
             let _ = kill(nix_pid, Signal::SIGKILL);
         }

--- a/src/components/WorktreeItem.tsx
+++ b/src/components/WorktreeItem.tsx
@@ -174,7 +174,10 @@ export function WorktreeItem({
         </span>
         <span className="worktree-indicators">
           {isAgentNeedsAttention && !isAgentDone && (
-            <span className="worktree-agent-attention" title="Needs attention" />
+            <span
+              className="worktree-agent-attention"
+              title="Needs attention"
+            />
           )}
           {isAgentDone && (
             <span className="worktree-agent-done" title="Agent completed" />

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -90,9 +90,9 @@ export function MainLayout({
   const [agentDoneWorktreeIds, setAgentDoneWorktreeIds] = useState<Set<number>>(
     () => new Set(),
   );
-  const [agentNeedsAttentionIds, setAgentNeedsAttentionIds] = useState<Set<number>>(
-    () => new Set(),
-  );
+  const [agentNeedsAttentionIds, setAgentNeedsAttentionIds] = useState<
+    Set<number>
+  >(() => new Set());
 
   // Project tabs state
   const [allProjects, setAllProjects] = useState<ProjectTab[]>([]);

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -679,7 +679,8 @@
 }
 
 @keyframes wt-agent-attention {
-  0%, 100% {
+  0%,
+  100% {
     opacity: 1;
     box-shadow: 0 0 5px rgba(245, 158, 11, 0.6);
   }


### PR DESCRIPTION
## Summary
- Replace `std::process::Command` with `tokio::process::Command` in docker/monitor.rs
- Add 10s timeout to `docker stats` and `docker logs`, 30s for container actions
- Reduce blocking sleep in `kill_process_by_pid` from 500ms to 100ms

## Test plan
- [ ] Verify docker stats, logs, and container actions still work
- [ ] Test behavior when Docker daemon is unresponsive (should timeout rather than hang)

Closes #204