### PR TITLE
perf: reuse shared reqwest::Client across all HTTP requests

### DIFF
--- a/src-tauri/src/ai/assist.rs
+++ b/src-tauri/src/ai/assist.rs
@@ -36,7 +36,7 @@ async fn generate(
         stream: false,
     };
 
-    let client = reqwest::Client::new();
+    let client = crate::http_client::shared_client();
     let response = client
         .post(&url)
         .json(&body)

--- a/src-tauri/src/ai/chat.rs
+++ b/src-tauri/src/ai/chat.rs
@@ -90,7 +90,7 @@ pub async fn ai_chat_send(
         stream: false,
     };
 
-    let client = reqwest::Client::new();
+    let client = crate::http_client::shared_client();
     let response = client
         .post(&url)
         .json(&body)
@@ -125,7 +125,7 @@ pub async fn ai_chat_send(
 pub async fn ai_chat_list_models(endpoint: Option<String>) -> Result<Vec<String>, String> {
     let url = endpoint.unwrap_or_else(|| DEFAULT_TAGS_ENDPOINT.to_string());
 
-    let client = reqwest::Client::new();
+    let client = crate::http_client::shared_client();
     let response = client
         .get(&url)
         .send()

--- a/src-tauri/src/http_client.rs
+++ b/src-tauri/src/http_client.rs
@@ -1,0 +1,19 @@
+use std::sync::OnceLock;
+
+static HTTP_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+static NO_PROXY_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+
+/// Returns a shared `reqwest::Client` that reuses connections across requests.
+pub fn shared_client() -> &'static reqwest::Client {
+    HTTP_CLIENT.get_or_init(reqwest::Client::new)
+}
+
+/// Returns a shared `reqwest::Client` configured to bypass proxy settings.
+pub fn shared_no_proxy_client() -> &'static reqwest::Client {
+    NO_PROXY_CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .no_proxy()
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new())
+    })
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,6 +15,7 @@ pub mod fileview;
 pub mod filewatcher;
 pub mod git;
 pub mod github;
+pub mod http_client;
 pub mod mcp;
 pub mod memory;
 pub mod metrics;

--- a/src-tauri/src/network/proxy.rs
+++ b/src-tauri/src/network/proxy.rs
@@ -162,11 +162,8 @@ async fn handle_forward(
         Some(truncate_body(&body_bytes))
     };
 
-    // Forward the request
-    let client = reqwest::Client::builder()
-        .no_proxy()
-        .build()
-        .unwrap_or_else(|_| reqwest::Client::new());
+    // Forward the request (shared client reuses connections)
+    let client = crate::http_client::shared_no_proxy_client();
 
     let mut builder = client.request(
         reqwest::Method::from_bytes(method.as_bytes()).unwrap_or(reqwest::Method::GET),

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -240,8 +240,8 @@ async fn forward_http_request(
         }
     };
 
-    // Forward with reqwest
-    let client = reqwest::Client::new();
+    // Forward with reqwest (shared client reuses connections)
+    let client = crate::http_client::shared_client();
     let mut builder = client.request(
         reqwest::Method::from_bytes(method.as_str().as_bytes()).unwrap_or(reqwest::Method::GET),
         &target_uri,

--- a/src-tauri/src/vault/share.rs
+++ b/src-tauri/src/vault/share.rs
@@ -94,7 +94,7 @@ pub async fn export_profile_to_gist(
 
     let token = auth::get_token()?.ok_or("Not authenticated with GitHub")?;
 
-    let client = reqwest::Client::new();
+    let client = crate::http_client::shared_client();
     let resp = client
         .post("https://api.github.com/gists")
         .header("Authorization", format!("Bearer {}", token))
@@ -143,7 +143,7 @@ pub async fn import_profile_from_gist(
 ) -> Result<i64, String> {
     let token = auth::get_token()?.ok_or("Not authenticated with GitHub")?;
 
-    let client = reqwest::Client::new();
+    let client = crate::http_client::shared_client();
     let resp = client
         .get(format!("https://api.github.com/gists/{}", gist_id))
         .header("Authorization", format!("Bearer {}", token))
@@ -212,7 +212,7 @@ pub async fn import_profile_from_gist(
 pub async fn list_shared_gists() -> Result<Vec<SharedGist>, String> {
     let token = auth::get_token()?.ok_or("Not authenticated with GitHub")?;
 
-    let client = reqwest::Client::new();
+    let client = crate::http_client::shared_client();
     let resp = client
         .get("https://api.github.com/gists")
         .header("Authorization", format!("Bearer {}", token))


### PR DESCRIPTION
## Summary
- Add `http_client` module with `OnceLock`-based shared `reqwest::Client` instances
- Replace 8 call sites that created `reqwest::Client::new()` per request
- Provides `shared_client()` for general use and `shared_no_proxy_client()` for direct connections
- Connection pools, DNS caches, and TLS sessions are now reused across requests

Closes #203

## Test plan
- [ ] Verify reverse proxy forwards requests correctly
- [ ] Verify AI chat (Ollama) requests work
- [ ] Verify gist share/import/list operations work
- [ ] Verify network proxy capture works