### PR TITLE
a11y: add aria-labels to icon-only buttons

### DIFF
--- a/src/components/AiChatSidebar.tsx
+++ b/src/components/AiChatSidebar.tsx
@@ -191,6 +191,7 @@ export function AiChatSidebar({ open, onClose }: AiChatSidebarProps) {
             className="ai-chat__icon-btn"
             onClick={handleClearChat}
             title="Clear chat"
+            aria-label="Clear chat history"
           >
             <TrashIcon />
           </button>
@@ -198,10 +199,16 @@ export function AiChatSidebar({ open, onClose }: AiChatSidebarProps) {
             className="ai-chat__icon-btn"
             onClick={() => setShowSettings(!showSettings)}
             title="Settings"
+            aria-label="Toggle AI chat settings"
           >
             <GearIcon />
           </button>
-          <button className="ai-chat__icon-btn" onClick={onClose} title="Close">
+          <button
+            className="ai-chat__icon-btn"
+            onClick={onClose}
+            title="Close"
+            aria-label="Close AI chat"
+          >
             <CloseIcon />
           </button>
         </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -226,6 +226,7 @@ export function Sidebar({
           className="sidebar-toolbar-btn"
           onClick={onOpenSearch}
           title="Search"
+          aria-label="Search files"
         >
           <Search className="size-4" />
         </Button>
@@ -236,6 +237,7 @@ export function Sidebar({
           className="sidebar-toolbar-btn"
           onClick={onOpenAiChat}
           title="AI Chat"
+          aria-label="Open AI chat"
         >
           <MessageCircle className="size-4" />
         </Button>
@@ -248,6 +250,7 @@ export function Sidebar({
           className="sidebar-toolbar-btn"
           onClick={onOpenNotifications}
           title="Notifications"
+          aria-label="View notifications"
         >
           <Bell className="size-4" />
         </Button>
@@ -258,6 +261,7 @@ export function Sidebar({
           className="sidebar-toolbar-btn"
           onClick={onOpenSettings}
           title="Settings"
+          aria-label="Open settings"
         >
           <Sun className="size-4" />
         </Button>


### PR DESCRIPTION
## Summary
- Add `aria-label` to icon-only buttons in Sidebar (search, AI chat, notifications, settings)
- Add `aria-label` to icon-only buttons in AiChatSidebar (clear, settings, close)

## Test plan
- [ ] Verify buttons still function correctly
- [ ] Test with a screen reader to confirm labels are announced

Closes #187