### PR TITLE
fix: race condition in ProxyState and unwrap() in proxy response path

### DIFF
--- a/src-tauri/src/mcp/tools/proxy.rs
+++ b/src-tauri/src/mcp/tools/proxy.rs
@@ -19,7 +19,7 @@ pub fn get_active_proxy(app: &AppHandle) -> Result<Value, String> {
         }));
     }
 
-    let worktree_id = proxy.active_worktree_id.lock().map(|w| *w).unwrap_or(None);
+    let worktree_id = proxy.get_active_worktree_id();
 
     let db = app.state::<AppDb>();
     let conn = db.0.lock().map_err(|e| format!("DB lock error: {}", e))?;

--- a/src-tauri/src/proxy/mod.rs
+++ b/src-tauri/src/proxy/mod.rs
@@ -1,42 +1,55 @@
 pub mod server;
 pub mod switch;
 
-use std::sync::atomic::{AtomicU16, Ordering};
+use std::sync::atomic::AtomicU16;
 use std::sync::Mutex;
+
+/// Active project routing info, updated atomically.
+struct ActiveRoute {
+    port: u16,
+    worktree_id: Option<i64>,
+}
 
 /// Shared proxy state: the port of the currently active project.
 /// 0 means no project is active.
 pub struct ProxyState {
-    pub active_port: AtomicU16,
-    pub active_worktree_id: Mutex<Option<i64>>,
+    /// Port + worktree ID are stored together under a single lock to
+    /// prevent readers from seeing a half-updated state.
+    active: Mutex<ActiveRoute>,
     pub proxy_running: AtomicU16, // actual port proxy is bound to (3000 if success, 0 if not running)
 }
 
 impl ProxyState {
     pub fn new() -> Self {
         Self {
-            active_port: AtomicU16::new(0),
-            active_worktree_id: Mutex::new(None),
+            active: Mutex::new(ActiveRoute {
+                port: 0,
+                worktree_id: None,
+            }),
             proxy_running: AtomicU16::new(0),
         }
     }
 
     pub fn set_active(&self, port: u16, worktree_id: i64) {
-        self.active_port.store(port, Ordering::Relaxed);
-        if let Ok(mut wt) = self.active_worktree_id.lock() {
-            *wt = Some(worktree_id);
+        if let Ok(mut route) = self.active.lock() {
+            route.port = port;
+            route.worktree_id = Some(worktree_id);
         }
     }
 
     pub fn clear_active(&self) {
-        self.active_port.store(0, Ordering::Relaxed);
-        if let Ok(mut wt) = self.active_worktree_id.lock() {
-            *wt = None;
+        if let Ok(mut route) = self.active.lock() {
+            route.port = 0;
+            route.worktree_id = None;
         }
     }
 
     pub fn get_active_port(&self) -> u16 {
-        self.active_port.load(Ordering::Relaxed)
+        self.active.lock().map(|r| r.port).unwrap_or(0)
+    }
+
+    pub fn get_active_worktree_id(&self) -> Option<i64> {
+        self.active.lock().ok().and_then(|r| r.worktree_id)
     }
 }
 

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -208,7 +208,7 @@ async fn handle_websocket_upgrade(
         .header(hyper::header::CONNECTION, "Upgrade")
         .header(hyper::header::UPGRADE, "websocket")
         .body(http_body_util::Full::new(hyper::body::Bytes::new()))
-        .unwrap())
+        .unwrap_or_else(|_| error_response(StatusCode::INTERNAL_SERVER_ERROR, "Failed to build WebSocket upgrade response")))
 }
 
 /// Forwards a regular HTTP request to the target port.
@@ -294,7 +294,12 @@ fn error_response(status: StatusCode, message: &str) -> Response<BoxBody> {
         .body(http_body_util::Full::new(hyper::body::Bytes::from(
             message.to_string(),
         )))
-        .unwrap()
+        .unwrap_or_else(|_| {
+            // Last-resort fallback if even the error response builder fails
+            Response::new(http_body_util::Full::new(hyper::body::Bytes::from(
+                "Internal Server Error",
+            )))
+        })
 }
 
 /// Tauri command: get proxy status.
@@ -302,7 +307,7 @@ fn error_response(status: StatusCode, message: &str) -> Response<BoxBody> {
 pub fn get_proxy_status(state: State<'_, ProxyState>) -> Result<ProxyInfo, String> {
     let port = state.proxy_running.load(Ordering::Relaxed);
     let active_port = state.get_active_port();
-    let worktree_id = state.active_worktree_id.lock().map(|w| *w).unwrap_or(None);
+    let worktree_id = state.get_active_worktree_id();
 
     Ok(ProxyInfo {
         running: port > 0,

--- a/src-tauri/src/proxy/switch.rs
+++ b/src-tauri/src/proxy/switch.rs
@@ -59,7 +59,7 @@ pub fn get_active_project(
     db: State<'_, AppDb>,
     proxy: State<'_, ProxyState>,
 ) -> Result<Option<ActiveProjectInfo>, String> {
-    let worktree_id = proxy.active_worktree_id.lock().map(|w| *w).unwrap_or(None);
+    let worktree_id = proxy.get_active_worktree_id();
 
     let worktree_id = match worktree_id {
         Some(id) => id,


### PR DESCRIPTION
## Summary
- Combine `active_port` and `active_worktree_id` under a single Mutex to prevent inconsistent reads mid-update
- Replace `.unwrap()` on `Response::builder()` with `.unwrap_or_else()` returning 500 error instead of panicking
- Add `get_active_worktree_id()` accessor and update all call sites

Closes #206

## Test plan
- [ ] Verify proxy routing works correctly when switching projects
- [ ] Verify proxy status endpoint returns consistent port+worktree data
- [ ] Verify malformed WebSocket upgrade doesn't crash the app