### PR TITLE
fix: add keyboard support to interactive div elements

### DIFF
--- a/src/components/ClipboardHistory.tsx
+++ b/src/components/ClipboardHistory.tsx
@@ -167,7 +167,16 @@ export function ClipboardHistory({ onClose }: ClipboardHistoryProps) {
                 <div
                   key={entry.id}
                   className={`cliph-item ${isCopied ? "cliph-item-copied" : ""}`}
+                  role="button"
+                  tabIndex={0}
+                  aria-label={`Copy: ${entry.content.slice(0, 50)}`}
                   onClick={() => handleCopy(entry)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      handleCopy(entry);
+                    }
+                  }}
                 >
                   <div className="cliph-item-top">
                     <pre className="cliph-preview">

--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -201,11 +201,26 @@ export function OnboardingWizard({
           </>
         )}
 
-        <div className="onboarding-steps">
+        <div
+          className="onboarding-steps"
+          role="tablist"
+          aria-label="Setup steps"
+        >
           {(["welcome", "github", "project", "done"] as Step[]).map((s) => (
             <span
               key={s}
+              role="tab"
+              tabIndex={0}
+              aria-selected={s === step}
+              aria-label={`Step: ${s}`}
               className={`onboarding-dot ${s === step ? "onboarding-dot-active" : ""}`}
+              onClick={() => setStep(s)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  setStep(s);
+                }
+              }}
             />
           ))}
         </div>


### PR DESCRIPTION
## Summary
- Added `role="button"`, `tabIndex={0}`, `aria-label`, and `onKeyDown` (Enter/Space) handler to clipboard history items in `ClipboardHistory.tsx`
- Made onboarding step indicator dots interactive with `role="tab"`, `tabIndex={0}`, `aria-selected`, `aria-label`, `onClick`, and `onKeyDown` handlers in `OnboardingWizard.tsx`
- Dashboard cards and theme/density pickers already had proper keyboard support (buttons or existing handlers)

## Test plan
- [ ] Verify clipboard history items can be focused and activated with Enter/Space keys
- [ ] Verify onboarding step dots can be focused and navigated with Enter/Space keys
- [ ] Verify no visual regressions in ClipboardHistory or OnboardingWizard

Closes #188