### PR TITLE
fix: establish consistent z-index hierarchy for UI layers

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -478,7 +478,7 @@ button:disabled {
 .panel-overlay {
   position: fixed;
   inset: 0;
-  z-index: 10000;
+  z-index: 9500;
   background: rgba(6, 6, 8, 0.65);
   backdrop-filter: blur(12px) saturate(0.8);
   -webkit-backdrop-filter: blur(12px) saturate(0.8);

--- a/src/styles/activity-timeline.css
+++ b/src/styles/activity-timeline.css
@@ -7,7 +7,7 @@
   inset: 0;
   background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(4px);
-  z-index: 9998;
+  z-index: 9000;
   animation: cmd-backdrop-in 0.12s ease-out;
 }
 
@@ -25,7 +25,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/ai-chat.css
+++ b/src/styles/ai-chat.css
@@ -15,7 +15,7 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  z-index: 9999;
+  z-index: 9001;
   animation: ai-chat-slide-in 0.3s ease-out;
 }
 

--- a/src/styles/analytics-dashboard.css
+++ b/src/styles/analytics-dashboard.css
@@ -7,7 +7,7 @@
   inset: 0;
   background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(4px);
-  z-index: 9998;
+  z-index: 9000;
   animation: cmd-backdrop-in 0.12s ease-out;
 }
 
@@ -25,7 +25,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/app-performance.css
+++ b/src/styles/app-performance.css
@@ -16,7 +16,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/app-theme-picker.css
+++ b/src/styles/app-theme-picker.css
@@ -16,7 +16,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/backup-restore.css
+++ b/src/styles/backup-restore.css
@@ -7,7 +7,7 @@
   inset: 0;
   background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(4px);
-  z-index: 9998;
+  z-index: 9000;
   animation: cmd-backdrop-in 0.12s ease-out;
 }
 
@@ -25,7 +25,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/benchmark-dashboard.css
+++ b/src/styles/benchmark-dashboard.css
@@ -7,7 +7,7 @@
   inset: 0;
   background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(4px);
-  z-index: 9998;
+  z-index: 9000;
   animation: cmd-backdrop-in 0.12s ease-out;
 }
 
@@ -25,7 +25,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/blame-view.css
+++ b/src/styles/blame-view.css
@@ -7,7 +7,7 @@
   inset: 0;
   background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(4px);
-  z-index: 9998;
+  z-index: 9000;
   animation: cmd-backdrop-in 0.12s ease-out;
 }
 
@@ -25,7 +25,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/branch-compare.css
+++ b/src/styles/branch-compare.css
@@ -7,7 +7,7 @@
   inset: 0;
   background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(4px);
-  z-index: 9998;
+  z-index: 9000;
   animation: cmd-backdrop-in 0.12s ease-out;
 }
 
@@ -25,7 +25,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/checkpoint-panel.css
+++ b/src/styles/checkpoint-panel.css
@@ -7,7 +7,7 @@
   inset: 0;
   background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(4px);
-  z-index: 9998;
+  z-index: 9000;
   animation: cmd-backdrop-in 0.12s ease-out;
 }
 
@@ -25,7 +25,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/clipboard-history.css
+++ b/src/styles/clipboard-history.css
@@ -16,7 +16,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/command-bookmarks.css
+++ b/src/styles/command-bookmarks.css
@@ -16,7 +16,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/command-palette.css
+++ b/src/styles/command-palette.css
@@ -25,7 +25,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9100;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/conflict-resolver.css
+++ b/src/styles/conflict-resolver.css
@@ -7,7 +7,7 @@
   inset: 0;
   background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(4px);
-  z-index: 9998;
+  z-index: 9000;
   animation: cmd-backdrop-in 0.12s ease-out;
 }
 
@@ -25,7 +25,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/container-monitor.css
+++ b/src/styles/container-monitor.css
@@ -7,7 +7,7 @@
   inset: 0;
   background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(4px);
-  z-index: 9998;
+  z-index: 9000;
   animation: cmd-backdrop-in 0.12s ease-out;
 }
 
@@ -25,7 +25,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/coverage-report.css
+++ b/src/styles/coverage-report.css
@@ -16,7 +16,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/custom-css-editor.css
+++ b/src/styles/custom-css-editor.css
@@ -7,7 +7,7 @@
   inset: 0;
   background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(4px);
-  z-index: 9998;
+  z-index: 9000;
   animation: cmd-backdrop-in 0.12s ease-out;
 }
 
@@ -25,7 +25,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/density-picker.css
+++ b/src/styles/density-picker.css
@@ -7,7 +7,7 @@
   inset: 0;
   background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(4px);
-  z-index: 9998;
+  z-index: 9000;
   animation: cmd-backdrop-in 0.12s ease-out;
 }
 
@@ -25,7 +25,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/dependency-analyzer.css
+++ b/src/styles/dependency-analyzer.css
@@ -16,7 +16,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/directory-stats.css
+++ b/src/styles/directory-stats.css
@@ -16,7 +16,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/docker-images.css
+++ b/src/styles/docker-images.css
@@ -7,7 +7,7 @@
   inset: 0;
   background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(4px);
-  z-index: 9998;
+  z-index: 9000;
   animation: cmd-backdrop-in 0.12s ease-out;
 }
 
@@ -25,7 +25,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/docker-panel.css
+++ b/src/styles/docker-panel.css
@@ -16,7 +16,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/dora-metrics.css
+++ b/src/styles/dora-metrics.css
@@ -16,7 +16,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/env-diff.css
+++ b/src/styles/env-diff.css
@@ -7,7 +7,7 @@
   inset: 0;
   background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(4px);
-  z-index: 9998;
+  z-index: 9000;
   animation: cmd-backdrop-in 0.12s ease-out;
 }
 
@@ -25,7 +25,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/file-explorer.css
+++ b/src/styles/file-explorer.css
@@ -9,7 +9,7 @@
   inset: 0;
   background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(4px);
-  z-index: 9998;
+  z-index: 9000;
   animation: cmd-backdrop-in 0.12s ease-out;
 }
 
@@ -29,7 +29,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/flaky-tests.css
+++ b/src/styles/flaky-tests.css
@@ -16,7 +16,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/git-analytics.css
+++ b/src/styles/git-analytics.css
@@ -7,7 +7,7 @@
   inset: 0;
   background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(4px);
-  z-index: 9998;
+  z-index: 9000;
   animation: cmd-backdrop-in 0.12s ease-out;
 }
 
@@ -25,7 +25,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/git-hooks.css
+++ b/src/styles/git-hooks.css
@@ -7,7 +7,7 @@
   inset: 0;
   background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(4px);
-  z-index: 9998;
+  z-index: 9000;
   animation: cmd-backdrop-in 0.12s ease-out;
 }
 
@@ -25,7 +25,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/git-log.css
+++ b/src/styles/git-log.css
@@ -16,7 +16,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/license-report.css
+++ b/src/styles/license-report.css
@@ -7,7 +7,7 @@
   inset: 0;
   background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(4px);
-  z-index: 9998;
+  z-index: 9000;
   animation: cmd-backdrop-in 0.12s ease-out;
 }
 
@@ -25,7 +25,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/notification-center.css
+++ b/src/styles/notification-center.css
@@ -12,7 +12,7 @@
   background-color: var(--bg-surface);
   border-left: 1px solid var(--border);
   box-shadow: -8px 0 32px rgba(0, 0, 0, 0.4);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/plugin-manager.css
+++ b/src/styles/plugin-manager.css
@@ -7,7 +7,7 @@
   inset: 0;
   background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(4px);
-  z-index: 9998;
+  z-index: 9000;
   animation: cmd-backdrop-in 0.12s ease-out;
 }
 
@@ -25,7 +25,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/plugin-runtime.css
+++ b/src/styles/plugin-runtime.css
@@ -16,7 +16,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/port-scanner.css
+++ b/src/styles/port-scanner.css
@@ -7,7 +7,7 @@
   inset: 0;
   background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(4px);
-  z-index: 9998;
+  z-index: 9000;
   animation: cmd-backdrop-in 0.12s ease-out;
 }
 
@@ -25,7 +25,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/project-overview.css
+++ b/src/styles/project-overview.css
@@ -7,7 +7,7 @@
   inset: 0;
   background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(4px);
-  z-index: 9998;
+  z-index: 9000;
   animation: cmd-backdrop-in 0.12s ease-out;
 }
 
@@ -25,7 +25,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/project-tabs.css
+++ b/src/styles/project-tabs.css
@@ -8,7 +8,7 @@
   left: 0;
   right: 0;
   height: 32px;
-  z-index: 9998;
+  z-index: 9000;
   display: flex;
   align-items: stretch;
   background: var(--bg-base);

--- a/src/styles/quick-switcher.css
+++ b/src/styles/quick-switcher.css
@@ -8,7 +8,7 @@
   background: rgba(0, 0, 0, 0.55);
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
-  z-index: 9998;
+  z-index: 9000;
   display: flex;
   align-items: flex-start;
   justify-content: center;

--- a/src/styles/secret-scanner.css
+++ b/src/styles/secret-scanner.css
@@ -7,7 +7,7 @@
   inset: 0;
   background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(4px);
-  z-index: 9998;
+  z-index: 9000;
   animation: cmd-backdrop-in 0.12s ease-out;
 }
 
@@ -25,7 +25,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/security-audit.css
+++ b/src/styles/security-audit.css
@@ -7,7 +7,7 @@
   inset: 0;
   background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(4px);
-  z-index: 9998;
+  z-index: 9000;
   animation: cmd-backdrop-in 0.12s ease-out;
 }
 
@@ -25,7 +25,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/security-headers.css
+++ b/src/styles/security-headers.css
@@ -7,7 +7,7 @@
   inset: 0;
   background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(4px);
-  z-index: 9998;
+  z-index: 9000;
   animation: cmd-backdrop-in 0.12s ease-out;
 }
 
@@ -25,7 +25,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/settings-page.css
+++ b/src/styles/settings-page.css
@@ -7,7 +7,7 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  z-index: 9999;
+  z-index: 9001;
   width: 820px;
   max-width: calc(100vw - 60px);
   height: 600px;

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -4,7 +4,8 @@
 
 .main-layout {
   display: flex;
-  height: calc(100vh - 24px);
+  height: 100vh;
+  padding-bottom: 24px;
   overflow: hidden;
 }
 
@@ -913,7 +914,7 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  z-index: 10001;
+  z-index: 9501;
   background: var(--bg-primary);
   border: 1px solid var(--border);
   border-radius: 8px;

--- a/src/styles/snippet-manager.css
+++ b/src/styles/snippet-manager.css
@@ -7,7 +7,7 @@
   inset: 0;
   background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(4px);
-  z-index: 9998;
+  z-index: 9000;
   animation: cmd-backdrop-in 0.12s ease-out;
 }
 
@@ -25,7 +25,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/ssh-manager.css
+++ b/src/styles/ssh-manager.css
@@ -20,7 +20,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/stash-manager.css
+++ b/src/styles/stash-manager.css
@@ -7,7 +7,7 @@
   inset: 0;
   background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(4px);
-  z-index: 9998;
+  z-index: 9000;
   animation: cmd-backdrop-in 0.12s ease-out;
 }
 
@@ -25,7 +25,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/status-bar.css
+++ b/src/styles/status-bar.css
@@ -18,7 +18,7 @@
     var(--bg-base) 100%
   );
   border-top: 1px solid var(--border-subtle);
-  z-index: 9999;
+  z-index: 100;
   user-select: none;
   -webkit-user-select: none;
 }

--- a/src/styles/tag-manager.css
+++ b/src/styles/tag-manager.css
@@ -7,7 +7,7 @@
   inset: 0;
   background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(4px);
-  z-index: 9998;
+  z-index: 9000;
   animation: cmd-backdrop-in 0.12s ease-out;
 }
 
@@ -25,7 +25,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/task-graph.css
+++ b/src/styles/task-graph.css
@@ -7,7 +7,7 @@
   inset: 0;
   background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(4px);
-  z-index: 9998;
+  z-index: 9000;
   animation: cmd-backdrop-in 0.12s ease-out;
 }
 
@@ -25,7 +25,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/task-history.css
+++ b/src/styles/task-history.css
@@ -7,7 +7,7 @@
   inset: 0;
   background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(4px);
-  z-index: 9998;
+  z-index: 9000;
   animation: cmd-backdrop-in 0.12s ease-out;
 }
 
@@ -25,7 +25,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/task-runner.css
+++ b/src/styles/task-runner.css
@@ -16,7 +16,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/task-scheduler.css
+++ b/src/styles/task-scheduler.css
@@ -16,7 +16,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/terminal-recording.css
+++ b/src/styles/terminal-recording.css
@@ -7,7 +7,7 @@
   inset: 0;
   background: rgba(0, 0, 0, 0.7);
   backdrop-filter: blur(4px);
-  z-index: 9998;
+  z-index: 9000;
   animation: cmd-backdrop-in 0.12s ease-out;
 }
 
@@ -25,7 +25,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.7),
     0 0 0 1px rgba(255, 255, 255, 0.03);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/terminal-themes.css
+++ b/src/styles/terminal-themes.css
@@ -16,7 +16,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/test-runner-panel.css
+++ b/src/styles/test-runner-panel.css
@@ -7,7 +7,7 @@
   inset: 0;
   background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(4px);
-  z-index: 9998;
+  z-index: 9000;
   animation: cmd-backdrop-in 0.12s ease-out;
 }
 
@@ -25,7 +25,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/theme-editor.css
+++ b/src/styles/theme-editor.css
@@ -16,7 +16,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/todo-panel.css
+++ b/src/styles/todo-panel.css
@@ -7,7 +7,7 @@
   inset: 0;
   background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(4px);
-  z-index: 9998;
+  z-index: 9000;
   animation: cmd-backdrop-in 0.12s ease-out;
 }
 
@@ -25,7 +25,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/unified-search.css
+++ b/src/styles/unified-search.css
@@ -8,7 +8,7 @@
   background: rgba(0, 0, 0, 0.55);
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
-  z-index: 9998;
+  z-index: 9000;
   display: flex;
   align-items: flex-start;
   justify-content: center;

--- a/src/styles/web-vitals.css
+++ b/src/styles/web-vitals.css
@@ -7,7 +7,7 @@
   inset: 0;
   background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(4px);
-  z-index: 9998;
+  z-index: 9000;
   animation: cmd-backdrop-in 0.12s ease-out;
 }
 
@@ -25,7 +25,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/webhook-events.css
+++ b/src/styles/webhook-events.css
@@ -7,7 +7,7 @@
   inset: 0;
   background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(4px);
-  z-index: 9998;
+  z-index: 9000;
   animation: cmd-backdrop-in 0.12s ease-out;
 }
 
@@ -25,7 +25,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/workspace-manager.css
+++ b/src/styles/workspace-manager.css
@@ -7,7 +7,7 @@
   inset: 0;
   background: rgba(0, 0, 0, 0.6);
   backdrop-filter: blur(4px);
-  z-index: 9998;
+  z-index: 9000;
   animation: cmd-backdrop-in 0.12s ease-out;
 }
 
@@ -25,7 +25,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9999;
+  z-index: 9001;
   display: flex;
   flex-direction: column;
   overflow: hidden;


### PR DESCRIPTION
## Summary
- **Status bar** z-index lowered from 9999 to 100 so it no longer competes with modals
- **Modal backdrops** standardized to z-index 9000, **modal panels** to 9001 across all 60+ CSS files
- **Command palette** elevated to z-index 9100 so it always appears above other modals (including settings)
- **Panel overlay / confirm dialogs** set to 9500/9501 so they layer correctly above modals
- **Main layout** height changed from `calc(100vh - 24px)` to `100vh` with `padding-bottom: 24px`, since the fixed status bar does not affect document flow

### Z-index hierarchy (low to high)
| Layer | z-index |
|---|---|
| Status bar | 100 |
| Context menus | 999–1000 |
| Modal backdrops | 9000 |
| Modal panels (settings, theme editor, etc.) | 9001 |
| Command palette | 9100 |
| Panel overlay (confirmation dialogs) | 9500 |
| Delete confirm dialog | 9501 |

## Test plan
- [ ] Open the app and verify the status bar renders below all modals
- [ ] Open Settings, then trigger Command Palette (Cmd+K) — palette should appear above settings
- [ ] Open Quick Switcher — verify it displays correctly and backdrop covers the status bar
- [ ] Open a confirmation dialog from within a modal — confirm it layers on top
- [ ] Verify no 24px gap appears at the bottom of the main layout

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)