### PR TITLE
fix: make Cmd+Shift+W case-insensitive for close pane

### DIFF
--- a/src/components/TerminalSplitPane.tsx
+++ b/src/components/TerminalSplitPane.tsx
@@ -349,7 +349,11 @@ export function useSplitPaneShortcuts(
         return;
       }
       // Cmd+Shift+W = close focused pane
-      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === "W") {
+      if (
+        (e.metaKey || e.ctrlKey) &&
+        e.shiftKey &&
+        e.key.toUpperCase() === "W"
+      ) {
         e.preventDefault();
         onClosePane?.();
         return;


### PR DESCRIPTION
## Summary
- Use `e.key.toUpperCase() === "W"` instead of `e.key === "W"` for the close-pane shortcut, fixing reliability across keyboard layouts and Caps Lock state

## Test plan
- [ ] Verify Cmd+Shift+W closes the focused terminal pane
- [ ] Test with Caps Lock on/off

Closes #192