### PR TITLE
fix: add aria-labels to icon-only buttons

### DIFF
--- a/src/components/AiChatSidebar.tsx
+++ b/src/components/AiChatSidebar.tsx
@@ -347,6 +347,7 @@ export function AiChatSidebar({ open, onClose }: AiChatSidebarProps) {
               !input.trim() || loading || connectionStatus !== "connected"
             }
             title="Send message"
+            aria-label="Send message"
           >
             <SendIcon />
           </button>

--- a/src/components/QuickActions.tsx
+++ b/src/components/QuickActions.tsx
@@ -102,6 +102,7 @@ export function QuickActions({
                 className="group/btn relative flex cursor-pointer flex-col items-center gap-0.5 rounded-sm border-none bg-transparent px-2 py-1.5 transition-[transform,background-color] duration-150 hover:scale-[1.2] hover:-translate-y-0.5 hover:bg-white/[0.06] active:scale-[1.05] active:translate-y-0"
                 onClick={() => onAction(action.id)}
                 title={action.label}
+                aria-label={action.label}
               >
                 <span className="text-[1.1em] leading-none text-[var(--text-primary)] transition-colors duration-100 group-hover/btn:text-[var(--accent)]">
                   {action.icon}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -151,6 +151,7 @@ export function Sidebar({
             size="icon-xs"
             onClick={handleAddProject}
             title="Add local project"
+            aria-label="Add local project"
             className="text-text-muted hover:bg-accent-muted hover:text-accent hover:border-accent/20 border border-transparent"
           >
             <Plus className="size-3.5" />
@@ -160,6 +161,7 @@ export function Sidebar({
             size="icon-xs"
             onClick={handleToggleSettings}
             title="Settings"
+            aria-label="Settings"
             className={
               showSettings
                 ? "bg-accent text-bg-base border-accent shadow-[0_0_8px_var(--color-accent-muted)]"


### PR DESCRIPTION
## Summary
- Add `aria-label` attributes to icon-only buttons that were missing them in `Sidebar.tsx`, `AiChatSidebar.tsx`, and `QuickActions.tsx`
- Uses existing `title` text as the aria-label value for consistency
- Improves accessibility for screen readers on all icon-only interactive elements

Closes #187

## Test plan
- [ ] Verify all icon-only buttons have aria-labels via browser dev tools or axe audit
- [ ] Confirm no visual regressions in sidebar, AI chat, and quick actions dock
- [ ] Run screen reader to verify labels are announced correctly