### PR TITLE
fix: filter GitHub sidebar PRs to current repository only

### DIFF
--- a/src/components/GitHubSidebar.tsx
+++ b/src/components/GitHubSidebar.tsx
@@ -190,11 +190,23 @@ export function GitHubSidebar({ projectId }: GitHubSidebarProps) {
   const intervalRef = useRef<ReturnType<typeof setInterval>>(undefined);
   const mountedRef = useRef(true);
   const activeTabRef = useRef<Tab>(activeTab);
+  const projectIdRef = useRef(projectId);
 
   // Keep activeTabRef in sync
   useEffect(() => {
     activeTabRef.current = activeTab;
   }, [activeTab]);
+
+  // Clear stale data when the project changes so we never show PRs/issues
+  // from a previously selected repo (fixes #177).
+  useEffect(() => {
+    projectIdRef.current = projectId;
+    setPulls([]);
+    setIssues([]);
+    setEvents([]);
+    setError(null);
+    setAuthError(false);
+  }, [projectId]);
 
   // Cleanup on unmount
   useEffect(() => {
@@ -208,6 +220,10 @@ export function GitHubSidebar({ projectId }: GitHubSidebarProps) {
     async (tab: Tab, showSpinner = true) => {
       if (projectId === null) return;
 
+      // Capture the project id at call time so we can discard stale responses
+      // when the user switches projects while a request is in-flight.
+      const requestProjectId = projectId;
+
       if (showSpinner) setLoading(true);
       setError(null);
       setAuthError(false);
@@ -218,6 +234,7 @@ export function GitHubSidebar({ projectId }: GitHubSidebarProps) {
             const data = await invoke<RepoPull[]>("list_repo_pulls", {
               projectId,
             });
+            if (projectIdRef.current !== requestProjectId) return;
             setPulls(data);
             break;
           }
@@ -225,6 +242,7 @@ export function GitHubSidebar({ projectId }: GitHubSidebarProps) {
             const data = await invoke<RepoIssue[]>("list_repo_issues", {
               projectId,
             });
+            if (projectIdRef.current !== requestProjectId) return;
             setIssues(data);
             break;
           }
@@ -232,19 +250,24 @@ export function GitHubSidebar({ projectId }: GitHubSidebarProps) {
             const data = await invoke<RepoEvent[]>("get_repo_activity", {
               projectId,
             });
+            if (projectIdRef.current !== requestProjectId) return;
             setEvents(data);
             break;
           }
         }
       } catch (err) {
+        // Discard errors from requests for a project we've already navigated away from
+        if (projectIdRef.current !== requestProjectId) return;
         if (isAuthError(err)) {
           setAuthError(true);
         } else {
           setError(String(err));
         }
       } finally {
-        setLoading(false);
-        setRefreshing(false);
+        if (projectIdRef.current === requestProjectId) {
+          setLoading(false);
+          setRefreshing(false);
+        }
       }
     },
     [projectId],


### PR DESCRIPTION
## Summary
- Clear cached PR/issue/activity data immediately when the user switches projects, preventing stale data from a previously selected repo from being displayed
- Guard against in-flight API responses from a prior project overwriting the current project's data (race condition when switching projects quickly)

Closes #177

## Test plan
- [ ] Open a project with PRs, switch to a different project, verify sidebar shows only the new project's PRs (not the old ones)
- [ ] Quickly toggle between projects and confirm no cross-repo data leaks
- [ ] Verify loading state shows while fetching after a project switch