### PR TITLE
fix: distinguish network errors from logged-out in GitHub auth

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -378,23 +378,35 @@ function AppContent({
     markAgentNeedsAttention,
   } = useUiStore();
 
-  const [isGitHubConnected, setIsGitHubConnected] = useState(false);
+  const [gitHubAuthStatus, setGitHubAuthStatus] = useState<
+    "connected" | "disconnected" | "network-error"
+  >("disconnected");
   useEffect(() => {
+    const isNetworkError = (err: unknown): boolean => {
+      const msg = String(err).toLowerCase();
+      return (
+        msg.includes("network") ||
+        msg.includes("fetch") ||
+        msg.includes("timeout") ||
+        msg.includes("econnrefused") ||
+        msg.includes("enotfound") ||
+        msg.includes("err_network") ||
+        msg.includes("socket") ||
+        msg.includes("dns") ||
+        msg.includes("abort")
+      );
+    };
     const check = () =>
       invoke<boolean>("github_check_auth")
-        .then(setIsGitHubConnected)
+        .then((authed) =>
+          setGitHubAuthStatus(authed ? "connected" : "disconnected"),
+        )
         .catch((err: unknown) => {
-          // Only mark as disconnected for auth failures, not network errors
-          const msg = String(err).toLowerCase();
-          if (
-            msg.includes("network") ||
-            msg.includes("fetch") ||
-            msg.includes("timeout")
-          ) {
-            // Network error — keep the previous auth state
-            return;
+          if (isNetworkError(err)) {
+            setGitHubAuthStatus("network-error");
+          } else {
+            setGitHubAuthStatus("disconnected");
           }
-          setIsGitHubConnected(false);
         });
     check();
     const id = setInterval(check, 30_000);
@@ -1385,7 +1397,7 @@ function AppContent({
       <StatusBar
         projectName={selectedProjectName}
         branchName={selectedWorktreeName}
-        isGitHubConnected={isGitHubConnected}
+        gitHubAuthStatus={gitHubAuthStatus}
       />
       <CommandPalette
         open={panels.palette}

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -8,7 +8,7 @@ import "../styles/status-bar.css";
 interface StatusBarProps {
   projectName: string | null;
   branchName: string | null;
-  isGitHubConnected: boolean;
+  gitHubAuthStatus: "connected" | "disconnected" | "network-error";
 }
 
 /* ------------------------------------------------------------------ */
@@ -23,10 +23,22 @@ function formatTime(date: Date): string {
 /*  Component                                                          */
 /* ------------------------------------------------------------------ */
 
+const authDotClass: Record<StatusBarProps["gitHubAuthStatus"], string> = {
+  connected: "status-bar-dot--connected",
+  disconnected: "status-bar-dot--disconnected",
+  "network-error": "status-bar-dot--network-error",
+};
+
+const authLabel: Record<StatusBarProps["gitHubAuthStatus"], string> = {
+  connected: "Connected",
+  disconnected: "Disconnected",
+  "network-error": "Network Error",
+};
+
 export function StatusBar({
   projectName,
   branchName,
-  isGitHubConnected,
+  gitHubAuthStatus,
 }: StatusBarProps) {
   const [time, setTime] = useState(() => formatTime(new Date()));
 
@@ -85,14 +97,10 @@ export function StatusBar({
       <div className="status-bar-right">
         <span className="status-bar-item">
           <span
-            className={`status-bar-dot ${
-              isGitHubConnected
-                ? "status-bar-dot--connected"
-                : "status-bar-dot--disconnected"
-            }`}
+            className={`status-bar-dot ${authDotClass[gitHubAuthStatus]}`}
           />
           <span className="status-bar-connection">
-            {isGitHubConnected ? "Connected" : "Disconnected"}
+            {authLabel[gitHubAuthStatus]}
           </span>
         </span>
         <span className="status-bar-item">

--- a/src/styles/status-bar.css
+++ b/src/styles/status-bar.css
@@ -111,6 +111,22 @@
   box-shadow: none;
 }
 
+.status-bar-dot--network-error {
+  background-color: var(--warning, #eab308);
+  box-shadow: 0 0 5px rgba(234, 179, 8, 0.5);
+  animation: sb-network-error-pulse 2s ease-in-out infinite;
+}
+
+@keyframes sb-network-error-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+}
+
 .status-bar-connection {
   font-size: 12px;
   letter-spacing: 0.01em;


### PR DESCRIPTION
## Summary

- Replaces the binary `isGitHubConnected` boolean with a tri-state `gitHubAuthStatus` (`"connected"` | `"disconnected"` | `"network-error"`) so the UI can distinguish genuine auth failures from transient network issues
- Expands the network error detection to cover additional patterns (ECONNREFUSED, ENOTFOUND, ERR_NETWORK, socket, DNS, abort)
- Adds a yellow pulsing "Network Error" indicator in the status bar instead of incorrectly showing "Disconnected"

Closes #195

## Test plan

- [ ] Verify normal GitHub auth flow still shows "Connected" / green dot
- [ ] Verify logging out shows "Disconnected" / grey dot
- [ ] Simulate a network failure (e.g. disable WiFi) and confirm the status bar shows "Network Error" with a yellow pulsing dot instead of "Disconnected"
- [ ] Confirm that when the network recovers, the next 30s interval poll restores the correct auth state