### PR TITLE
fix: reset git log pagination on search

### DIFF
--- a/src/components/GitLogViewer.tsx
+++ b/src/components/GitLogViewer.tsx
@@ -98,8 +98,8 @@ export function GitLogViewer({ worktreeId, onClose }: GitLogViewerProps) {
   }, [page, loadLog]);
 
   const handleSearch = useCallback(async () => {
+    setPage(0);
     if (!search.trim()) {
-      setPage(0);
       loadLog(0, false);
       return;
     }
@@ -203,6 +203,12 @@ export function GitLogViewer({ worktreeId, onClose }: GitLogViewerProps) {
                             <span className="gitlog-detail-label">Author:</span>
                             <span className="gitlog-detail-value">
                               {commit.author} &lt;{commit.email}&gt;
+                            </span>
+                          </div>
+                          <div className="gitlog-detail-row">
+                            <span className="gitlog-detail-label">Date:</span>
+                            <span className="gitlog-detail-value">
+                              {new Date(commit.date).toLocaleString()}
                             </span>
                           </div>
                           {commit.parent_ids.length > 0 && (


### PR DESCRIPTION
## Summary
- Reset `page` to 0 at the start of `handleSearch` in `GitLogViewer.tsx` so pagination state is always cleared when switching between search and browse mode
- Added a Date row to expanded commit details showing the full localized timestamp

## Test plan
- [ ] Open Git Log viewer, load more commits (page > 0), then search — verify results start from the beginning
- [ ] Clear search and verify browse mode reloads from page 0
- [ ] Expand a commit and verify the Date row appears with a readable timestamp

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)