### PR TITLE
fix: trigger xterm refit on split pane resize

### DIFF
--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -328,7 +328,8 @@ export function TerminalPanel({
                         // Create a stable container for this pane on first use.
                         if (!paneContainersRef.current.has(paneId)) {
                           const div = document.createElement("div");
-                          div.style.cssText = "width:100%;height:100%;";
+                          div.style.cssText =
+                            "width:100%;height:100%;display:flex;flex-direction:column;";
                           paneContainersRef.current.set(paneId, div);
                           triggerUpdate();
                         }

--- a/src/components/TerminalSplitPane.tsx
+++ b/src/components/TerminalSplitPane.tsx
@@ -194,6 +194,8 @@ function SplitContainer({
         document.body.style.userSelect = "";
         document.removeEventListener("mousemove", handleMouseMove);
         document.removeEventListener("mouseup", handleMouseUp);
+        // Trigger xterm refit on all visible terminal instances
+        window.dispatchEvent(new Event("resize"));
       };
 
       document.addEventListener("mousemove", handleMouseMove);


### PR DESCRIPTION
## Summary
- Dispatch a `window` `resize` event at the end of `handleMouseUp` in `TerminalSplitPane.tsx` so each `TerminalInstance`'s existing resize listener calls `fitAddon.fit()` after split-pane drag ends
- Add `display:flex;flex-direction:column` to the per-pane portal container div in `TerminalPanel.tsx` so the `terminal-container` child properly fills its parent

## Test plan
- [ ] Open a terminal and split it horizontally or vertically
- [ ] Drag the split divider to resize panes
- [ ] Verify terminal text reflows correctly after resize (no overlap or incorrect wrapping)
- [ ] Verify cols/rows update in both panes after drag completes

Closes #191