### PR TITLE
fix: surface Docker and clone operation errors to users

### DIFF
--- a/src/components/DockerPanel.tsx
+++ b/src/components/DockerPanel.tsx
@@ -30,24 +30,27 @@ export function DockerPanel({ cwd, onClose }: DockerPanelProps) {
   const [loading, setLoading] = useState(true);
   const [tab, setTab] = useState<"containers" | "compose">("containers");
   const [actionLoading, setActionLoading] = useState<string | null>(null);
+  const [dockerError, setDockerError] = useState<string | null>(null);
 
   const loadData = useCallback(async () => {
     setLoading(true);
+    setDockerError(null);
     try {
       const isAvailable = await invoke<boolean>("detect_docker");
       setAvailable(isAvailable);
       if (isAvailable) {
-        const [ctrs, svcs] = await Promise.all([
+        const [ctrs, svcs] = await Promise.allSettled([
           invoke<ContainerInfo[]>("list_containers"),
-          invoke<ComposeService[]>("list_compose_services", { cwd }).catch(
-            () => [] as ComposeService[],
-          ),
+          invoke<ComposeService[]>("list_compose_services", { cwd }),
         ]);
-        setContainers(ctrs);
-        setComposeServices(svcs);
+        setContainers(ctrs.status === "fulfilled" ? ctrs.value : []);
+        setComposeServices(svcs.status === "fulfilled" ? svcs.value : []);
       }
-    } catch {
+    } catch (err) {
       setAvailable(false);
+      setDockerError(
+        err instanceof Error ? err.message : "Failed to detect Docker",
+      );
     }
     setLoading(false);
   }, [cwd]);
@@ -62,8 +65,10 @@ export function DockerPanel({ cwd, onClose }: DockerPanelProps) {
       try {
         await invoke(`${action}_container`, { containerId });
         await loadData();
-      } catch {
-        // action failed
+      } catch (err) {
+        setDockerError(
+          err instanceof Error ? err.message : `Failed to ${action} container`,
+        );
       }
       setActionLoading(null);
     },
@@ -99,6 +104,18 @@ export function DockerPanel({ cwd, onClose }: DockerPanelProps) {
             </button>
           </div>
         </div>
+
+        {dockerError && (
+          <div
+            style={{
+              color: "var(--error)",
+              padding: "8px 12px",
+              fontSize: "0.85em",
+            }}
+          >
+            {dockerError}
+          </div>
+        )}
 
         <div className="docker-body">
           {loading ? (

--- a/src/components/RepoList.tsx
+++ b/src/components/RepoList.tsx
@@ -21,6 +21,7 @@ export function RepoList() {
   const [confirmingDeleteId, setConfirmingDeleteId] = useState<number | null>(
     null,
   );
+  const [actionError, setActionError] = useState<string | null>(null);
 
   const registeredPaths = useMemo(
     () => new Set(projects.map((p) => p.local_path)),
@@ -39,34 +40,62 @@ export function RepoList() {
   }, [githubRepos, search]);
 
   const handleAddLocal = async () => {
-    const selected = await open({ directory: true, multiple: false });
-    if (selected) {
-      await registerLocal(selected);
+    setActionError(null);
+    try {
+      const selected = await open({ directory: true, multiple: false });
+      if (selected) {
+        await registerLocal(selected);
+      }
+    } catch (err) {
+      setActionError(
+        err instanceof Error ? err.message : "Failed to register local project",
+      );
     }
   };
 
   const handleClone = async (repo: GitHubRepo) => {
-    if (!cloneDir) {
-      const dir = await open({ directory: true, multiple: false });
-      if (!dir) return;
-      setCloneDir(dir);
-      setCloningRepo(repo.full_name);
-      await cloneAndRegister(repo.clone_url, repo.name, dir, repo.html_url);
+    setActionError(null);
+    try {
+      if (!cloneDir) {
+        const dir = await open({ directory: true, multiple: false });
+        if (!dir) return;
+        setCloneDir(dir);
+        setCloningRepo(repo.full_name);
+        await cloneAndRegister(repo.clone_url, repo.name, dir, repo.html_url);
+        setCloningRepo(null);
+      } else {
+        setCloningRepo(repo.full_name);
+        await cloneAndRegister(
+          repo.clone_url,
+          repo.name,
+          cloneDir,
+          repo.html_url,
+        );
+        setCloningRepo(null);
+      }
+    } catch (err) {
       setCloningRepo(null);
-    } else {
-      setCloningRepo(repo.full_name);
-      await cloneAndRegister(
-        repo.clone_url,
-        repo.name,
-        cloneDir,
-        repo.html_url,
+      setActionError(
+        err instanceof Error ? err.message : `Failed to clone ${repo.name}`,
       );
-      setCloningRepo(null);
     }
   };
 
   return (
     <div className="repo-list">
+      {actionError && (
+        <div
+          style={{
+            color: "var(--error)",
+            padding: "8px 12px",
+            fontSize: "0.85em",
+            cursor: "pointer",
+          }}
+          onClick={() => setActionError(null)}
+        >
+          {actionError}
+        </div>
+      )}
       <div className="repo-tabs">
         <button
           className={`repo-tab ${view === "projects" ? "active" : ""}`}


### PR DESCRIPTION
## Summary
- DockerPanel: Add error state, use `Promise.allSettled`, show error messages on action failures
- RepoList: Wrap `handleAddLocal` and `handleClone` in try/catch, display inline error messages

## Test plan
- [ ] Verify Docker operations still work when Docker is running
- [ ] Verify error messages appear when operations fail
- [ ] Verify clone errors display feedback

Closes #193