### PR TITLE
perf: memoize context provider values to prevent cascading re-renders

### DIFF
--- a/src/contexts/ErrorContext.tsx
+++ b/src/contexts/ErrorContext.tsx
@@ -2,6 +2,7 @@ import {
   createContext,
   useCallback,
   useContext,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -63,12 +64,13 @@ export function ErrorProvider({ children }: { children: React.ReactNode }) {
     setErrors([]);
   }, []);
 
+  const value = useMemo(
+    () => ({ errors, reportError, dismissError, clearErrors }),
+    [errors, reportError, dismissError, clearErrors],
+  );
+
   return (
-    <ErrorContext.Provider
-      value={{ errors, reportError, dismissError, clearErrors }}
-    >
-      {children}
-    </ErrorContext.Provider>
+    <ErrorContext.Provider value={value}>{children}</ErrorContext.Provider>
   );
 }
 


### PR DESCRIPTION
## Summary
- Wrap `ErrorContext.Provider` value in `useMemo` to prevent creating a new object reference on every render, which was causing all consumers to re-render unnecessarily
- `UiContext.Provider` in `MainLayout.tsx` was already memoized; this fix addresses the remaining unmemoized context provider

## Test plan
- [ ] Verify error reporting/dismissing still works correctly
- [ ] Confirm React DevTools Profiler shows fewer re-renders on `ErrorContext` consumers when unrelated state changes

Closes #207