### PR TITLE
feat: highlight sidebar when agent needs attention or is done

### DIFF
--- a/src/components/WorktreeItem.tsx
+++ b/src/components/WorktreeItem.tsx
@@ -174,13 +174,47 @@ export function WorktreeItem({
         </span>
         <span className="worktree-indicators">
           {isAgentNeedsAttention && !isAgentDone && (
-            <span
-              className="worktree-agent-attention"
-              title="Needs attention"
-            />
+            <span className="worktree-agent-attention" title="Needs attention">
+              <svg
+                width="10"
+                height="10"
+                viewBox="0 0 10 10"
+                fill="none"
+                aria-hidden="true"
+              >
+                <circle cx="5" cy="5" r="5" fill="currentColor" />
+                <text
+                  x="5"
+                  y="7.5"
+                  textAnchor="middle"
+                  fontSize="7"
+                  fontWeight="bold"
+                  fill="var(--bg-base)"
+                >
+                  !
+                </text>
+              </svg>
+            </span>
           )}
           {isAgentDone && (
-            <span className="worktree-agent-done" title="Agent completed" />
+            <span className="worktree-agent-done" title="Agent completed">
+              <svg
+                width="10"
+                height="10"
+                viewBox="0 0 10 10"
+                fill="none"
+                aria-hidden="true"
+              >
+                <circle cx="5" cy="5" r="5" fill="currentColor" />
+                <path
+                  d="M3 5.2L4.5 6.7L7 3.5"
+                  stroke="var(--bg-base)"
+                  strokeWidth="1.3"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </span>
           )}
           <span
             className={`worktree-status-dot ${statusClass}`}

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -643,51 +643,53 @@
   box-shadow: 0 0 3px rgba(239, 68, 68, 0.4);
 }
 
-/* ---- Agent-done pulse ---- */
+/* ---- Agent-done badge (checkmark) ---- */
 
 .worktree-agent-done {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   flex-shrink: 0;
-  background-color: var(--accent);
-  box-shadow: 0 0 5px var(--accent-glow);
-  animation: wt-agent-pulse 1.5s ease-in-out infinite;
+  color: var(--accent);
+  filter: drop-shadow(0 0 3px var(--accent-glow));
+  animation: wt-agent-done-flash 1.5s ease-out forwards;
 }
 
-@keyframes wt-agent-pulse {
-  0%,
+@keyframes wt-agent-done-flash {
+  0% {
+    filter: drop-shadow(0 0 8px var(--accent-glow))
+      drop-shadow(0 0 14px var(--accent-glow));
+    transform: scale(1.5);
+  }
+  40% {
+    filter: drop-shadow(0 0 5px var(--accent-glow));
+    transform: scale(1);
+  }
   100% {
-    opacity: 1;
-    box-shadow: 0 0 5px var(--accent-glow);
-  }
-  50% {
-    opacity: 0.6;
-    box-shadow: 0 0 10px var(--accent-glow);
+    filter: drop-shadow(0 0 3px var(--accent-glow));
+    transform: scale(1);
   }
 }
 
-/* ---- Agent needs-attention pulse ---- */
+/* ---- Agent needs-attention badge (!) ---- */
 
 .worktree-agent-attention {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   flex-shrink: 0;
-  background-color: var(--warning);
-  box-shadow: 0 0 5px rgba(245, 158, 11, 0.6);
+  color: var(--warning);
+  filter: drop-shadow(0 0 3px rgba(245, 158, 11, 0.6));
   animation: wt-agent-attention 1s ease-in-out infinite;
 }
 
 @keyframes wt-agent-attention {
   0%,
   100% {
-    opacity: 1;
-    box-shadow: 0 0 5px rgba(245, 158, 11, 0.6);
+    filter: drop-shadow(0 0 3px rgba(245, 158, 11, 0.6));
   }
   50% {
-    opacity: 0.5;
-    box-shadow: 0 0 12px rgba(245, 158, 11, 0.8);
+    filter: drop-shadow(0 0 10px rgba(245, 158, 11, 0.8));
   }
 }
 


### PR DESCRIPTION
## Summary
- Replace plain colored dots with icon badges for sidebar agent status indicators
- "Done" state now shows a **green checkmark** with a flash-to-settle animation (bright glow scales down and settles)
- "Needs attention" state now shows an **amber pulsing `!` badge** for clearer urgency
- Clicking a worktree still clears both indicators

## Files changed
- `src/components/WorktreeItem.tsx` — inline SVG icons (checkmark for done, `!` for attention) instead of empty `<span>` dots
- `src/styles/sidebar.css` — new `wt-agent-done-flash` keyframe animation; updated badge styles from circle dots to icon containers

## Test plan
- [ ] Trigger an agent completion (let a terminal command run and idle) — verify green checkmark appears with flash animation
- [ ] Trigger attention-needed (agent prompts for input) — verify amber `!` badge pulses
- [ ] Click the highlighted worktree — verify both indicators clear
- [ ] Verify indicators do not appear for normal worktree status (active/stopped/missing)

Closes #176