### PR TITLE
perf: reuse reqwest::Client in reverse proxy

### DIFF
--- a/src-tauri/src/perf/vitals.rs
+++ b/src-tauri/src/perf/vitals.rs
@@ -28,7 +28,10 @@ pub struct VitalsHistory {
 /// First tries `npx lighthouse` with headless Chrome. If that is unavailable,
 /// falls back to a simple HTTP GET and measures TTFB.
 #[tauri::command]
-pub async fn run_lighthouse_audit(url: String) -> Result<WebVitalsReport, String> {
+pub async fn run_lighthouse_audit(
+    http: tauri::State<'_, crate::HttpClient>,
+    url: String,
+) -> Result<WebVitalsReport, String> {
     let now = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
 
     // Try running lighthouse via npx
@@ -77,11 +80,8 @@ pub async fn run_lighthouse_audit(url: String) -> Result<WebVitalsReport, String
         _ => {
             // Fallback: measure TTFB with a simple GET request
             let start = std::time::Instant::now();
-            let client = reqwest::Client::builder()
-                .timeout(std::time::Duration::from_secs(10))
-                .build()
-                .map_err(|e| format!("HTTP client build failed: {e}"))?;
-            let resp = client
+            let resp = http
+                .0
                 .get(&url)
                 .send()
                 .await

--- a/src-tauri/src/plugins/runtime.rs
+++ b/src-tauri/src/plugins/runtime.rs
@@ -181,12 +181,13 @@ pub async fn execute_plugin(
 
 /// Download a plugin manifest from a URL and create its directory structure.
 #[tauri::command]
-pub async fn install_plugin_from_url(cwd: String, url: String) -> Result<PluginManifest, String> {
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(10))
-        .build()
-        .map_err(|e| format!("HTTP client build failed: {e}"))?;
-    let body = client
+pub async fn install_plugin_from_url(
+    http: tauri::State<'_, crate::HttpClient>,
+    cwd: String,
+    url: String,
+) -> Result<PluginManifest, String> {
+    let body = http
+        .0
         .get(&url)
         .send()
         .await

--- a/src-tauri/src/security/headers.rs
+++ b/src-tauri/src/security/headers.rs
@@ -42,14 +42,12 @@ const SECURITY_HEADERS: &[ExpectedHeader] = &[
 
 /// Check a URL for security headers.
 #[tauri::command]
-pub async fn check_security_headers(url: String) -> Result<Vec<HeaderCheck>, String> {
-    let client = reqwest::Client::builder()
-        .redirect(reqwest::redirect::Policy::limited(5))
-        .timeout(std::time::Duration::from_secs(10))
-        .build()
-        .map_err(|e| format!("HTTP client: {}", e))?;
-
-    let response = client
+pub async fn check_security_headers(
+    http: tauri::State<'_, crate::HttpClient>,
+    url: String,
+) -> Result<Vec<HeaderCheck>, String> {
+    let response = http
+        .0
         .get(&url)
         .send()
         .await


### PR DESCRIPTION
## Summary
- Replaces per-request `reqwest::Client` construction with the shared `HttpClient` managed state in `plugins/runtime.rs`, `perf/vitals.rs`, and `security/headers.rs`
- The shared client (already created at app startup in `lib.rs`) provides connection pooling, DNS caching, and reduced allocations

## Test plan
- [ ] Verify `install_plugin_from_url` command still downloads plugin manifests
- [ ] Verify `run_lighthouse_audit` fallback TTFB measurement still works
- [ ] Verify `check_security_headers` command still returns header checks
- [ ] Confirm `cargo check` passes cleanly

Closes #203