### PR TITLE
fix: resolve race condition in ProxyState

### DIFF
--- a/src-tauri/src/network/proxy.rs
+++ b/src-tauri/src/network/proxy.rs
@@ -21,6 +21,7 @@ fn no_proxy_client() -> &'static reqwest::Client {
     NO_PROXY_CLIENT.get_or_init(|| {
         reqwest::Client::builder()
             .no_proxy()
+            .timeout(std::time::Duration::from_secs(30))
             .build()
             .unwrap_or_else(|_| reqwest::Client::new())
     })
@@ -136,7 +137,12 @@ async fn handle_connect(req: Request<Incoming>) -> Result<Response<BoxBody>, hyp
     Ok(Response::builder()
         .status(StatusCode::OK)
         .body(http_body_util::Full::new(hyper::body::Bytes::new()))
-        .unwrap())
+        .unwrap_or_else(|_| {
+            error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to build CONNECT tunnel response",
+            )
+        }))
 }
 
 /// Forward an HTTP request, capturing request and response for logging.
@@ -294,5 +300,11 @@ fn error_response(status: StatusCode, message: &str) -> Response<BoxBody> {
         .body(http_body_util::Full::new(hyper::body::Bytes::from(
             message.to_string(),
         )))
-        .unwrap()
+        .unwrap_or_else(|_| {
+            // Fallback: bare 500 response with no headers — should never happen
+            // since we control status and header values above.
+            Response::new(http_body_util::Full::new(hyper::body::Bytes::from(
+                "Internal Server Error",
+            )))
+        })
 }


### PR DESCRIPTION
## Summary
- Add 30-second timeout to `no_proxy_client()` in `network/proxy.rs` to prevent indefinite hangs on slow upstream responses
- Replace `.unwrap()` with `.unwrap_or_else()` in CONNECT tunnel response builder and `error_response()` to prevent panics from crashing the app on the hot proxy path
- The `ProxyState` race condition (separate `AtomicU16` + `Mutex`) and the reverse proxy `unwrap()` calls were already fixed in prior commits; this PR addresses the remaining instances in the forward proxy (`network/proxy.rs`)

## Test plan
- [ ] Verify forward proxy (`network/proxy.rs`) handles CONNECT requests without panicking on malformed responses
- [ ] Verify forward proxy requests time out after 30 seconds instead of hanging indefinitely
- [ ] Verify existing reverse proxy behavior is unchanged

Closes #206