### PR TITLE
fix: resolve overlay z-index, terminal loading, and sidebar collapse bugs

### DIFF
--- a/src/components/GitHubSidebar.tsx
+++ b/src/components/GitHubSidebar.tsx
@@ -41,6 +41,7 @@ type Tab = "prs" | "issues" | "activity";
 
 interface GitHubSidebarProps {
   projectId: number | null;
+  width?: number;
 }
 
 /* ------------------------------------------------------------------ */
@@ -165,7 +166,7 @@ interface DeviceCodeInfo {
   interval: number;
 }
 
-export function GitHubSidebar({ projectId }: GitHubSidebarProps) {
+export function GitHubSidebar({ projectId, width }: GitHubSidebarProps) {
   const [activeTab, setActiveTab] = useState<Tab>("prs");
   const [collapsed, setCollapsed] = useState(false);
 
@@ -359,7 +360,7 @@ export function GitHubSidebar({ projectId }: GitHubSidebarProps) {
   /* ---- Null project ---- */
   if (projectId === null) {
     return (
-      <div className="gh-sidebar">
+      <div className="gh-sidebar" style={width ? { width } : undefined}>
         <div className="gh-sidebar__header">
           <span className="gh-sidebar__title">GitHub</span>
           <div className="gh-sidebar__header-actions">
@@ -378,7 +379,7 @@ export function GitHubSidebar({ projectId }: GitHubSidebarProps) {
   }
 
   return (
-    <div className="gh-sidebar">
+    <div className="gh-sidebar" style={width ? { width } : undefined}>
       {/* Header */}
       <div className="gh-sidebar__header">
         <span className="gh-sidebar__title">GitHub</span>

--- a/src/components/KeyboardShortcuts.tsx
+++ b/src/components/KeyboardShortcuts.tsx
@@ -54,11 +54,11 @@ interface KeyboardShortcutsProps {
 export function KeyboardShortcuts({ onClose }: KeyboardShortcutsProps) {
   return (
     <div
-      className="fixed inset-0 z-[9998] bg-black/60 backdrop-blur-sm [animation:cmd-backdrop-in_0.12s_ease-out]"
+      className="fixed inset-0 z-[9400] bg-black/60 backdrop-blur-sm [animation:cmd-backdrop-in_0.12s_ease-out]"
       onClick={onClose}
     >
       <div
-        className="fixed left-1/2 top-[15%] flex max-h-[65vh] w-[440px] max-w-[calc(100vw-40px)] -translate-x-1/2 flex-col overflow-hidden rounded-[var(--radius-lg)] border border-[var(--border)] bg-[var(--bg-surface)] shadow-[0_24px_64px_rgba(0,0,0,0.6),0_0_0_1px_rgba(255,255,255,0.04)] [animation:cmd-palette-in_0.15s_ease-out] z-[9999]"
+        className="fixed left-1/2 top-[15%] flex max-h-[65vh] w-[440px] max-w-[calc(100vw-40px)] -translate-x-1/2 flex-col overflow-hidden rounded-[var(--radius-lg)] border border-[var(--border)] bg-[var(--bg-surface)] shadow-[0_24px_64px_rgba(0,0,0,0.6),0_0_0_1px_rgba(255,255,255,0.04)] [animation:cmd-palette-in_0.15s_ease-out] z-[9500]"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}

--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -509,15 +509,36 @@ function TerminalInstance({
         window.open(url, "_blank", "noopener");
       }),
     );
-    term.open(el);
 
-    // GPU-accelerated renderer; fall back silently if WebGL is unavailable.
-    try {
-      const webgl = new WebglAddon();
-      webgl.onContextLoss(() => webgl.dispose());
-      term.loadAddon(webgl);
-    } catch {
-      // WebGL not available — xterm falls back to its canvas renderer.
+    // xterm requires the container to have non-zero dimensions when open()
+    // is called.  Defer open() until layout is ready — handles the case
+    // where the parent transitions from display:none.
+    let opened = false;
+    const openWhenReady = () => {
+      if (cancelled || opened) return;
+      if (el.offsetWidth > 0 && el.offsetHeight > 0) {
+        term.open(el);
+        opened = true;
+
+        // GPU-accelerated renderer; fall back silently if WebGL is unavailable.
+        try {
+          const webgl = new WebglAddon();
+          webgl.onContextLoss(() => webgl.dispose());
+          term.loadAddon(webgl);
+        } catch {
+          // WebGL not available — xterm falls back to its canvas renderer.
+        }
+      }
+    };
+
+    // Try immediately, then poll briefly if container has zero size.
+    openWhenReady();
+    if (!opened) {
+      const openPoller = setInterval(() => {
+        openWhenReady();
+        if (opened || cancelled) clearInterval(openPoller);
+      }, 30);
+      setTimeout(() => clearInterval(openPoller), 3000);
     }
 
     termRef.current = term;
@@ -537,9 +558,29 @@ function TerminalInstance({
     };
     window.addEventListener("keydown", preventBrowserNav, true);
 
-    // Load settings, fit, spawn
+    // Wait for term.open() to complete before fitting and spawning.
+    const waitForOpen = (): Promise<void> => {
+      return new Promise((resolve) => {
+        const check = (attempts: number) => {
+          if (cancelled || opened) {
+            resolve();
+            return;
+          }
+          if (attempts > 100) {
+            resolve();
+            return;
+          }
+          setTimeout(() => check(attempts + 1), 30);
+        };
+        check(0);
+      });
+    };
+
     const initTimer = setTimeout(async () => {
       if (cancelled) return;
+
+      await waitForOpen();
+      if (cancelled || !opened) return;
 
       try {
         fitAddon.fit();

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -17,7 +17,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-[9998] bg-black/50 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-[9400] bg-black/50 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className,
     )}
     {...props}

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -346,11 +346,12 @@ export function MainLayout({
               className="resize-handle resize-handle--right"
               onMouseDown={handleRightMouseDown}
             />
-            <div style={{ width: rightSidebarWidth, flexShrink: 0 }}>
-              <ErrorBoundary name="GitHub Sidebar">
-                <GitHubSidebar projectId={selectedProjectId} />
-              </ErrorBoundary>
-            </div>
+            <ErrorBoundary name="GitHub Sidebar">
+              <GitHubSidebar
+                projectId={selectedProjectId}
+                width={rightSidebarWidth}
+              />
+            </ErrorBoundary>
           </>
         )}
       </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -478,7 +478,7 @@ button:disabled {
 .panel-overlay {
   position: fixed;
   inset: 0;
-  z-index: 9500;
+  z-index: 9000;
   background: rgba(6, 6, 8, 0.65);
   backdrop-filter: blur(12px) saturate(0.8);
   -webkit-backdrop-filter: blur(12px) saturate(0.8);

--- a/src/styles/command-palette.css
+++ b/src/styles/command-palette.css
@@ -25,7 +25,7 @@
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.04);
-  z-index: 9100;
+  z-index: 9500;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/src/styles/github-sidebar.css
+++ b/src/styles/github-sidebar.css
@@ -15,10 +15,13 @@
   flex-shrink: 0;
   overflow: hidden;
   animation: ghSidebarFadeIn 0.15s ease-out;
+  transition: width 0.15s ease-out;
 }
 
 .gh-sidebar--collapsed {
   width: 28px;
+  min-width: 28px;
+  max-width: 28px;
   display: flex;
   align-items: flex-start;
   justify-content: center;
@@ -26,6 +29,7 @@
   background-color: var(--bg-surface);
   border-left: 1px solid var(--border-subtle);
   flex-shrink: 0;
+  overflow: hidden;
 }
 
 @keyframes ghSidebarFadeIn {

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -843,12 +843,12 @@
 .context-menu-backdrop {
   position: fixed;
   inset: 0;
-  z-index: 999;
+  z-index: 9900;
 }
 
 .context-menu {
   position: fixed;
-  z-index: 1000;
+  z-index: 9901;
   background: linear-gradient(
     160deg,
     var(--bg-elevated) 0%,
@@ -916,7 +916,7 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  z-index: 9501;
+  z-index: 9902;
   background: var(--bg-primary);
   border: 1px solid var(--border);
   border-radius: 8px;


### PR DESCRIPTION
## Summary
- **Overlay z-index conflicts**: Reordered z-index hierarchy so context menus (9900+), command palette (9500), and delete confirmation dialogs render above panel overlays (9000) and dialog backdrops (9400). Fixes delete worktree button being hidden and Cmd+K being blocked by overlays.
- **Terminal not opening**: Deferred `xterm.open()` until the container has non-zero dimensions, handling the case where the parent transitions from `display:none` — xterm 6 requires visible dimensions at open time.
- **GitHub sidebar collapse**: Passed resize width directly to `GitHubSidebar` component and enforced collapsed width via `min-width`/`max-width` so the sidebar fully retracts instead of the parent wrapper still allocating full width.

Fixes #264, #265, #266

## Test plan
- [ ] Open a worktree, right-click → delete should show context menu above any overlays
- [ ] Press Cmd+K with a panel open — command palette should appear on top
- [ ] Select a worktree — terminal should load and display shell prompt
- [ ] Toggle GitHub sidebar collapse/expand — should fully retract and not block content

🤖 Generated with [Claude Code](https://claude.com/claude-code)