### PR TITLE
fix: scope panel-overlay to content area and fix terminal loading

### DIFF
--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -594,35 +594,15 @@ function TerminalInstance({
       }),
     );
 
-    // xterm requires the container to have non-zero dimensions when open()
-    // is called.  Defer open() until layout is ready — handles the case
-    // where the parent transitions from display:none.
-    let opened = false;
-    const openWhenReady = () => {
-      if (cancelled || opened) return;
-      if (el.offsetWidth > 0 && el.offsetHeight > 0) {
-        term.open(el);
-        opened = true;
+    term.open(el);
 
-        // GPU-accelerated renderer; fall back silently if WebGL is unavailable.
-        try {
-          const webgl = new WebglAddon();
-          webgl.onContextLoss(() => webgl.dispose());
-          term.loadAddon(webgl);
-        } catch {
-          // WebGL not available — xterm falls back to its canvas renderer.
-        }
-      }
-    };
-
-    // Try immediately, then poll briefly if container has zero size.
-    openWhenReady();
-    if (!opened) {
-      const openPoller = setInterval(() => {
-        openWhenReady();
-        if (opened || cancelled) clearInterval(openPoller);
-      }, 30);
-      setTimeout(() => clearInterval(openPoller), 3000);
+    // GPU-accelerated renderer; fall back silently if WebGL is unavailable.
+    try {
+      const webgl = new WebglAddon();
+      webgl.onContextLoss(() => webgl.dispose());
+      term.loadAddon(webgl);
+    } catch {
+      // WebGL not available — xterm falls back to its canvas renderer.
     }
 
     termRef.current = term;
@@ -642,29 +622,8 @@ function TerminalInstance({
     };
     window.addEventListener("keydown", preventBrowserNav, true);
 
-    // Wait for term.open() to complete before fitting and spawning.
-    const waitForOpen = (): Promise<void> => {
-      return new Promise((resolve) => {
-        const check = (attempts: number) => {
-          if (cancelled || opened) {
-            resolve();
-            return;
-          }
-          if (attempts > 100) {
-            resolve();
-            return;
-          }
-          setTimeout(() => check(attempts + 1), 30);
-        };
-        check(0);
-      });
-    };
-
     const initTimer = setTimeout(async () => {
       if (cancelled) return;
-
-      await waitForOpen();
-      if (cancelled || !opened) return;
 
       try {
         fitAddon.fit();

--- a/src/styles.css
+++ b/src/styles.css
@@ -476,7 +476,7 @@ button:disabled {
    ========================================================== */
 
 .panel-overlay {
-  position: fixed;
+  position: absolute;
   inset: 0;
   z-index: 9000;
   background: rgba(6, 6, 8, 0.65);

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -64,6 +64,7 @@
   flex-direction: column;
   overflow: hidden;
   background-color: var(--bg-base);
+  position: relative;
 }
 
 .content-scroll {


### PR DESCRIPTION
## Summary
- **Overlay blocking sidebar (root cause fix)**: Changed `panel-overlay` from `position: fixed` to `position: absolute` and added `position: relative` to `.content-area`. Panel overlays now only cover the content area, not the sidebar — so context menus, delete worktree, and other sidebar interactions work even when a panel is open.
- **Terminal not loading**: Reverted the `term.open()` deferral from #267 which could give up after 3s and leave the terminal blank. xterm handles zero-dimension containers gracefully — the original direct `open()` call is restored.

Fixes #264, #265, #266

## Test plan
- [ ] Open a panel (e.g. Changes tab) — sidebar should remain interactive
- [ ] Right-click worktree → Delete should show context menu above overlay
- [ ] Press Cmd+K — command palette should appear and be usable
- [ ] Select a worktree — terminal should load immediately
- [ ] Toggle GitHub sidebar collapse — should fully retract

🤖 Generated with [Claude Code](https://claude.com/claude-code)