### PR TITLE
fix: remove backdrop blur from dialog overlays and fix terminal init

### DIFF
--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -622,7 +622,10 @@ function TerminalInstance({
     };
     window.addEventListener("keydown", preventBrowserNav, true);
 
-    const initTimer = setTimeout(async () => {
+    // Use requestAnimationFrame to ensure the DOM is laid out before
+    // fitting and spawning the PTY — setTimeout(100) can fire before
+    // the browser has painted the terminal container.
+    const initTimer = requestAnimationFrame(async () => {
       if (cancelled) return;
 
       try {
@@ -732,7 +735,7 @@ function TerminalInstance({
           term.write(`\r\n\x1b[31mFailed to spawn shell: ${err}\x1b[0m\r\n`);
         }
       }
-    }, 100);
+    });
 
     // Tauri native drag-drop listener — writes dropped file paths to the PTY.
     let unlistenDrop: (() => void) | null = null;
@@ -758,7 +761,7 @@ function TerminalInstance({
 
     return () => {
       cancelled = true;
-      clearTimeout(initTimer);
+      cancelAnimationFrame(initTimer);
       unlistenDrop?.();
       if (idleTimerRef.current) {
         clearTimeout(idleTimerRef.current);

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -16,7 +16,7 @@ const AlertDialogOverlay = React.forwardRef<
   <AlertDialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-[9998] bg-black/50 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-[9998] bg-black/30 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className,
     )}
     {...props}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -17,7 +17,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-[9400] bg-black/50 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-[9400] bg-black/30 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className,
     )}
     {...props}


### PR DESCRIPTION
## Summary
- **Dialog overlays blurring entire screen**: Removed `backdrop-blur-sm` from both `AlertDialogOverlay` and `DialogOverlay`. The blur made the entire viewport look frozen when dialogs (like delete worktree confirmation) were open. Reduced bg opacity from 50% to 30% for a lighter dimming effect.
- **Terminal init timing**: Replaced `setTimeout(100)` with `requestAnimationFrame` for PTY init to ensure the browser has painted the container before fitting the terminal.

Fixes #264, #265

## Test plan
- [ ] Right-click worktree → Delete — dialog should show clearly without blurring the whole screen
- [ ] Cmd+K — command palette should appear without heavy blur
- [ ] Select a worktree — terminal should load and show shell prompt
- [ ] Close dialog — screen should return to normal without visual artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)