### PR TITLE
fix: stabilize terminal pane focus and modal overlay trapping

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import {
 } from "react";
 import { ErrorProvider } from "./contexts/ErrorContext";
 import { ErrorBoundary, PanelBoundary } from "./components/ErrorBoundary";
+import { FocusTrapOverlay } from "./components/FocusTrapOverlay";
 import { GlobalErrorToast } from "./components/GlobalErrorToast";
 import { invoke } from "@tauri-apps/api/core";
 import { MainLayout } from "./layouts/MainLayout";
@@ -1840,10 +1841,7 @@ function AppContent({
       )}
       {panels.morningBriefing && selectedProjectId && (
         <PanelBoundary name="MorningBriefing">
-          <div
-            className="panel-overlay"
-            onClick={() => closePanel("morningBriefing")}
-          >
+          <FocusTrapOverlay onClick={() => closePanel("morningBriefing")}>
             <div className="panel-dialog" onClick={(e) => e.stopPropagation()}>
               <div className="panel-dialog-header">
                 <span>Morning Briefing</span>
@@ -1856,15 +1854,12 @@ function AppContent({
               </div>
               <MorningBriefing projectId={selectedProjectId} />
             </div>
-          </div>
+          </FocusTrapOverlay>
         </PanelBoundary>
       )}
       {panels.onboarding && (
         <PanelBoundary name="Onboarding">
-          <div
-            className="panel-overlay"
-            onClick={() => closePanel("onboarding")}
-          >
+          <FocusTrapOverlay onClick={() => closePanel("onboarding")}>
             <div
               className="panel-dialog panel-dialog--wide"
               onClick={(e) => e.stopPropagation()}
@@ -1874,15 +1869,12 @@ function AppContent({
                 onClose={() => closePanel("onboarding")}
               />
             </div>
-          </div>
+          </FocusTrapOverlay>
         </PanelBoundary>
       )}
       {panels.networkTab && (
         <PanelBoundary name="NetworkTab">
-          <div
-            className="panel-overlay"
-            onClick={() => closePanel("networkTab")}
-          >
+          <FocusTrapOverlay onClick={() => closePanel("networkTab")}>
             <div
               className="panel-dialog panel-dialog--wide"
               onClick={(e) => e.stopPropagation()}
@@ -1898,12 +1890,12 @@ function AppContent({
               </div>
               <NetworkTab />
             </div>
-          </div>
+          </FocusTrapOverlay>
         </PanelBoundary>
       )}
       {panels.prStatus && selectedWorktreeId && (
         <PanelBoundary name="PRStatus">
-          <div className="panel-overlay" onClick={() => closePanel("prStatus")}>
+          <FocusTrapOverlay onClick={() => closePanel("prStatus")}>
             <div
               className="panel-dialog panel-dialog--wide"
               onClick={(e) => e.stopPropagation()}
@@ -1919,13 +1911,12 @@ function AppContent({
               </div>
               <PRStatusPanel worktreeId={selectedWorktreeId} />
             </div>
-          </div>
+          </FocusTrapOverlay>
         </PanelBoundary>
       )}
       {panels.gitDiff && selectedWorktreeId && (
         <PanelBoundary name="GitDiff">
-          <div
-            className="panel-overlay"
+          <FocusTrapOverlay
             onClick={() => {
               closePanel("gitDiff");
               setContentTab("terminal");
@@ -1956,13 +1947,12 @@ function AppContent({
                 }}
               />
             </div>
-          </div>
+          </FocusTrapOverlay>
         </PanelBoundary>
       )}
       {panels.createPr && selectedWorktreeId && selectedWorktreeName && (
         <PanelBoundary name="CreatePR">
-          <div
-            className="panel-overlay"
+          <FocusTrapOverlay
             onClick={() => {
               closePanel("createPr");
               setContentTab("terminal");
@@ -1978,15 +1968,12 @@ function AppContent({
                 }}
               />
             </div>
-          </div>
+          </FocusTrapOverlay>
         </PanelBoundary>
       )}
       {panels.memoryTab && selectedWorktreeId && (
         <PanelBoundary name="MemoryTab">
-          <div
-            className="panel-overlay"
-            onClick={() => closePanel("memoryTab")}
-          >
+          <FocusTrapOverlay onClick={() => closePanel("memoryTab")}>
             <div
               className="panel-dialog panel-dialog--wide"
               onClick={(e) => e.stopPropagation()}
@@ -2002,15 +1989,12 @@ function AppContent({
               </div>
               <MemoryTab worktreeId={selectedWorktreeId} />
             </div>
-          </div>
+          </FocusTrapOverlay>
         </PanelBoundary>
       )}
       {panels.shellHistory && selectedProjectId && (
         <PanelBoundary name="ShellHistory">
-          <div
-            className="panel-overlay"
-            onClick={() => closePanel("shellHistory")}
-          >
+          <FocusTrapOverlay onClick={() => closePanel("shellHistory")}>
             <div
               className="panel-dialog panel-dialog--wide"
               onClick={(e) => e.stopPropagation()}
@@ -2029,12 +2013,12 @@ function AppContent({
                 branch={selectedWorktreeName ?? ""}
               />
             </div>
-          </div>
+          </FocusTrapOverlay>
         </PanelBoundary>
       )}
       {panels.deadEnds && selectedWorktreeId && (
         <PanelBoundary name="DeadEnds">
-          <div className="panel-overlay" onClick={() => closePanel("deadEnds")}>
+          <FocusTrapOverlay onClick={() => closePanel("deadEnds")}>
             <div className="panel-dialog" onClick={(e) => e.stopPropagation()}>
               <div className="panel-dialog-header">
                 <span>Dead Ends Log</span>
@@ -2047,12 +2031,12 @@ function AppContent({
               </div>
               <DeadEndsLog worktreeId={selectedWorktreeId} />
             </div>
-          </div>
+          </FocusTrapOverlay>
         </PanelBoundary>
       )}
       {panels.dbSchema && selectedWorktreeId && (
         <PanelBoundary name="DbSchema">
-          <div className="panel-overlay" onClick={() => closePanel("dbSchema")}>
+          <FocusTrapOverlay onClick={() => closePanel("dbSchema")}>
             <div
               className="panel-dialog panel-dialog--wide"
               onClick={(e) => e.stopPropagation()}
@@ -2068,15 +2052,12 @@ function AppContent({
               </div>
               <DbSchemaTab worktreeId={selectedWorktreeId} />
             </div>
-          </div>
+          </FocusTrapOverlay>
         </PanelBoundary>
       )}
       {panels.browserEvents && selectedWorktreeId && (
         <PanelBoundary name="BrowserEvents">
-          <div
-            className="panel-overlay"
-            onClick={() => closePanel("browserEvents")}
-          >
+          <FocusTrapOverlay onClick={() => closePanel("browserEvents")}>
             <div
               className="panel-dialog panel-dialog--wide"
               onClick={(e) => e.stopPropagation()}
@@ -2086,15 +2067,12 @@ function AppContent({
                 onClose={() => closePanel("browserEvents")}
               />
             </div>
-          </div>
+          </FocusTrapOverlay>
         </PanelBoundary>
       )}
       {panels.dbExplorer && selectedWorktreeId && (
         <PanelBoundary name="DatabaseExplorer">
-          <div
-            className="panel-overlay"
-            onClick={() => closePanel("dbExplorer")}
-          >
+          <FocusTrapOverlay onClick={() => closePanel("dbExplorer")}>
             <div
               className="panel-dialog panel-dialog--wide"
               onClick={(e) => e.stopPropagation()}
@@ -2104,7 +2082,7 @@ function AppContent({
                 onClose={() => closePanel("dbExplorer")}
               />
             </div>
-          </div>
+          </FocusTrapOverlay>
         </PanelBoundary>
       )}
       <PanelBoundary name="QuickSwitcher">

--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -143,13 +143,37 @@ export function TerminalPanel({
           const idx = s.tabs.findIndex((t) => t.id === id);
           newActiveTabId = next[Math.min(idx, next.length - 1)].id;
         }
-        return { ...s, tabs: next, activeTabId: newActiveTabId };
+        const nextActiveTab = next.find((t) => t.id === newActiveTabId);
+        const nextLeafIds = nextActiveTab
+          ? collectLeafIds(nextActiveTab.paneTree)
+          : [];
+        const nextFocusedPaneId = nextLeafIds.includes(s.focusedPaneId ?? "")
+          ? s.focusedPaneId
+          : (nextLeafIds[0] ?? null);
+        return {
+          ...s,
+          tabs: next,
+          activeTabId: newActiveTabId,
+          focusedPaneId: nextFocusedPaneId,
+        };
       });
     },
     [updateCurrentPath],
   );
 
   const activeTab = tabs.find((t) => t.id === activeTabId);
+
+  useEffect(() => {
+    if (!activeTab) return;
+    const leafIds = collectLeafIds(activeTab.paneTree);
+    const nextFocusedPaneId =
+      focusedPaneId && leafIds.includes(focusedPaneId)
+        ? focusedPaneId
+        : (leafIds[0] ?? null);
+    if (nextFocusedPaneId !== focusedPaneId) {
+      updateCurrentPath((s) => ({ ...s, focusedPaneId: nextFocusedPaneId }));
+    }
+  }, [activeTab, focusedPaneId, updateCurrentPath]);
 
   const updatePaneTree = useCallback(
     (newTree: PaneNode) => {
@@ -164,7 +188,17 @@ export function TerminalPanel({
   );
 
   const setActiveTabId = useCallback(
-    (id: string) => updateCurrentPath((s) => ({ ...s, activeTabId: id })),
+    (id: string) =>
+      updateCurrentPath((s) => {
+        const nextActiveTab = s.tabs.find((t) => t.id === id);
+        return {
+          ...s,
+          activeTabId: id,
+          focusedPaneId: nextActiveTab
+            ? (collectLeafIds(nextActiveTab.paneTree)[0] ?? null)
+            : s.focusedPaneId,
+        };
+      }),
     [updateCurrentPath],
   );
 
@@ -501,6 +535,8 @@ function TerminalInstance({
   onAgentCompleteRef.current = onAgentComplete;
   const onAgentNeedsAttentionRef = useRef(onAgentNeedsAttention);
   onAgentNeedsAttentionRef.current = onAgentNeedsAttention;
+  const activeRef = useRef(active);
+  activeRef.current = active;
   const lastAttentionTimeRef = useRef(0);
   const [dragOver, setDragOver] = useState(false);
 
@@ -754,7 +790,7 @@ function TerminalInstance({
         } else if (event.payload.type === "drop") {
           setDragOver(false);
           const paths = event.payload.paths;
-          if (paths.length > 0 && ptyRef.current && active) {
+          if (paths.length > 0 && ptyRef.current && activeRef.current) {
             const pathStr = paths.map((p: string) => `"${p}"`).join(" ");
             ptyRef.current.write(pathStr);
           }

--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -21,18 +21,26 @@ export function useFocusTrap<
   const containerRef = useRef<T | null>(null);
 
   useEffect(() => {
-    const container = containerRef.current;
-    if (!container) return;
+    if (!containerRef.current) return;
+    const containerEl = containerRef.current as T;
+    const previousActiveElement =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+
+    const getFocusableElements = () =>
+      Array.from(
+        containerEl.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+      ).filter((el) => el.getClientRects().length > 0);
 
     function handleKeyDown(e: KeyboardEvent) {
       if (e.key !== "Tab") return;
 
-      const focusable = Array.from(
-        container!.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
-      ).filter((el) => el.offsetParent !== null);
+      const focusable = getFocusableElements();
 
       if (focusable.length === 0) {
         e.preventDefault();
+        containerEl.focus();
         return;
       }
 
@@ -42,7 +50,7 @@ export function useFocusTrap<
       if (e.shiftKey) {
         if (
           document.activeElement === first ||
-          !container!.contains(document.activeElement)
+          !containerEl.contains(document.activeElement)
         ) {
           e.preventDefault();
           last.focus();
@@ -50,7 +58,7 @@ export function useFocusTrap<
       } else {
         if (
           document.activeElement === last ||
-          !container!.contains(document.activeElement)
+          !containerEl.contains(document.activeElement)
         ) {
           e.preventDefault();
           first.focus();
@@ -59,14 +67,27 @@ export function useFocusTrap<
     }
 
     // Focus the first focusable element on mount
-    const focusable =
-      container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+    if (!containerEl.hasAttribute("tabindex")) {
+      containerEl.tabIndex = -1;
+    }
+    const focusable = getFocusableElements();
     if (focusable.length > 0) {
       focusable[0].focus();
+    } else {
+      containerEl.focus();
     }
 
-    container.addEventListener("keydown", handleKeyDown);
-    return () => container.removeEventListener("keydown", handleKeyDown);
+    containerEl.addEventListener("keydown", handleKeyDown);
+    return () => {
+      containerEl.removeEventListener("keydown", handleKeyDown);
+      if (
+        previousActiveElement &&
+        previousActiveElement.isConnected &&
+        !containerEl.contains(previousActiveElement)
+      ) {
+        previousActiveElement.focus();
+      }
+    };
   }, []);
 
   return containerRef;


### PR DESCRIPTION
## Summary
- keep terminal pane focus valid when switching or closing tabs so the active pane stays interactive
- route modal overlays through the shared focus-trap wrapper and restore focus on close
- guard native terminal drag-and-drop with live active-pane state so inactive terminals do not consume drops

## Test plan
- [x] pnpm build
- [ ] Open modal panels and verify Tab stays inside the dialog
- [ ] Switch terminal tabs and split panes, then close tabs/panes and confirm focus stays on the visible terminal
- [ ] Drop files into an inactive terminal tab and confirm they are ignored