### PR TITLE
fix: make the conflict panel read-only

### DIFF
--- a/src/components/ConflictResolver.tsx
+++ b/src/components/ConflictResolver.tsx
@@ -5,9 +5,9 @@ import { useFocusTrap } from "../hooks/useFocusTrap";
 
 interface ConflictedFile {
   path: string;
-  ours: string;
-  theirs: string;
-  base: string;
+  ancestor_exists: boolean;
+  ours_exists: boolean;
+  theirs_exists: boolean;
 }
 
 interface ConflictResolverProps {
@@ -23,7 +23,6 @@ export function ConflictResolver({
   const [files, setFiles] = useState<ConflictedFile[]>([]);
   const [loading, setLoading] = useState(true);
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
-  const [resolving, setResolving] = useState(false);
 
   const loadConflicts = useCallback(async () => {
     setLoading(true);
@@ -45,31 +44,29 @@ export function ConflictResolver({
     loadConflicts();
   }, [loadConflicts]);
 
-  const handleResolve = useCallback(
-    async (filePath: string, resolution: "ours" | "theirs" | "both") => {
-      setResolving(true);
-      try {
-        await invoke("resolve_conflict", {
-          worktreeId,
-          filePath,
-          resolution,
-        });
-        await loadConflicts();
-      } catch {
-        // resolve failed
-      }
-      setResolving(false);
-    },
-    [worktreeId, loadConflicts],
-  );
-
   const selected = files.find((f) => f.path === selectedFile);
+  const stageSummary = selected
+    ? [
+        {
+          label: "Base",
+          present: selected.ancestor_exists,
+        },
+        {
+          label: "Ours",
+          present: selected.ours_exists,
+        },
+        {
+          label: "Theirs",
+          present: selected.theirs_exists,
+        },
+      ]
+    : [];
 
   return (
     <div className="conflict-backdrop" ref={focusTrapRef} onClick={onClose}>
       <div className="conflict-panel" onClick={(e) => e.stopPropagation()}>
         <div className="conflict-header">
-          <h3 className="conflict-title">Conflict Resolver</h3>
+          <h3 className="conflict-title">Conflict Inspector</h3>
           <button className="conflict-close" onClick={onClose}>
             &times;
           </button>
@@ -98,46 +95,40 @@ export function ConflictResolver({
               {selected && (
                 <div className="conflict-detail">
                   <div className="conflict-actions">
-                    <span className="conflict-detail-path">
-                      {selected.path}
-                    </span>
-                    <div className="conflict-action-btns">
-                      <button
-                        className="conflict-resolve-btn conflict-btn-ours"
-                        onClick={() => handleResolve(selected.path, "ours")}
-                        disabled={resolving}
-                      >
-                        Accept Ours
-                      </button>
-                      <button
-                        className="conflict-resolve-btn conflict-btn-theirs"
-                        onClick={() => handleResolve(selected.path, "theirs")}
-                        disabled={resolving}
-                      >
-                        Accept Theirs
-                      </button>
-                      <button
-                        className="conflict-resolve-btn conflict-btn-both"
-                        onClick={() => handleResolve(selected.path, "both")}
-                        disabled={resolving}
-                      >
-                        Accept Both
-                      </button>
+                    <div className="conflict-detail-meta">
+                      <span className="conflict-detail-path">
+                        {selected.path}
+                      </span>
+                      <span className="conflict-detail-note">
+                        Resolution is not available in Workroot yet. Use Git or
+                        your editor to resolve this file.
+                      </span>
                     </div>
                   </div>
 
                   <div className="conflict-diff">
                     <div className="conflict-side">
-                      <div className="conflict-side-label conflict-label-ours">
-                        Ours
+                      <div className="conflict-side-label">
+                        Available Conflict Stages
                       </div>
-                      <pre className="conflict-code">{selected.ours}</pre>
-                    </div>
-                    <div className="conflict-side">
-                      <div className="conflict-side-label conflict-label-theirs">
-                        Theirs
+                      <div className="conflict-stage-list">
+                        {stageSummary.map((stage) => (
+                          <div key={stage.label} className="conflict-stage-row">
+                            <span className="conflict-stage-name">
+                              {stage.label}
+                            </span>
+                            <span
+                              className={`conflict-stage-pill ${
+                                stage.present
+                                  ? "conflict-stage-pill-present"
+                                  : "conflict-stage-pill-missing"
+                              }`}
+                            >
+                              {stage.present ? "Present" : "Missing"}
+                            </span>
+                          </div>
+                        ))}
                       </div>
-                      <pre className="conflict-code">{selected.theirs}</pre>
                     </div>
                   </div>
                 </div>

--- a/src/styles/conflict-resolver.css
+++ b/src/styles/conflict-resolver.css
@@ -145,10 +145,15 @@
 
 .conflict-actions {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
   padding: 8px 12px;
   border-bottom: 1px solid var(--border-subtle);
+}
+
+.conflict-detail-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
 }
 
 .conflict-detail-path {
@@ -157,53 +162,9 @@
   color: var(--accent);
 }
 
-.conflict-action-btns {
-  display: flex;
-  gap: 6px;
-}
-
-.conflict-resolve-btn {
-  font-family: var(--font-sans);
-  font-size: 0.68em;
-  font-weight: 500;
-  padding: 4px 10px;
-  border-radius: var(--radius-sm);
-  border: none;
-  cursor: pointer;
-}
-
-.conflict-resolve-btn:disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
-}
-
-.conflict-btn-ours {
-  color: #fff;
-  background: var(--accent);
-}
-
-.conflict-btn-ours:hover {
-  background: var(--accent-hover);
-}
-
-.conflict-btn-theirs {
-  color: #fff;
-  background: #6366f1;
-}
-
-.conflict-btn-theirs:hover {
-  background: #818cf8;
-}
-
-.conflict-btn-both {
-  color: var(--text-secondary);
-  background: var(--bg-elevated);
-  border: 1px solid var(--border);
-}
-
-.conflict-btn-both:hover {
-  background: var(--bg-hover);
-  color: var(--text-primary);
+.conflict-detail-note {
+  font-size: 0.74em;
+  color: var(--text-muted);
 }
 
 /* -- Diff -- */
@@ -223,10 +184,6 @@
   min-width: 0;
 }
 
-.conflict-side:first-child {
-  border-right: 1px solid var(--border-subtle);
-}
-
 .conflict-side-label {
   font-size: 0.68em;
   font-weight: 600;
@@ -237,25 +194,46 @@
   flex-shrink: 0;
 }
 
-.conflict-label-ours {
-  color: var(--accent);
-  background: var(--accent-muted);
+.conflict-stage-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 14px 12px;
 }
 
-.conflict-label-theirs {
-  color: #6366f1;
-  background: rgba(99, 102, 241, 0.1);
+.conflict-stage-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-elevated);
 }
 
-.conflict-code {
-  margin: 0;
-  padding: 8px 12px;
+.conflict-stage-name {
   font-family: var(--font-mono);
   font-size: 0.78em;
-  line-height: 1.6;
   color: var(--text-primary);
-  white-space: pre;
-  overflow: auto;
+}
+
+.conflict-stage-pill {
+  padding: 4px 8px;
+  border-radius: 999px;
+  font-size: 0.68em;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.conflict-stage-pill-present {
+  background: rgba(16, 185, 129, 0.12);
+  color: #34d399;
+}
+
+.conflict-stage-pill-missing {
+  background: rgba(245, 158, 11, 0.12);
+  color: #fbbf24;
 }
 
 .conflict-code::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- remove the fake conflict resolution actions that were not supported by the backend
- align the conflict panel with the actual `get_conflicted_files` payload
- present a read-only conflict inspector with stage availability and clear guidance

Closes #274

## Testing
- pnpm format:check
- pnpm lint
- pnpm typecheck
- pnpm build
