### PR TITLE
fix: route Docker UI actions through container_action

### DIFF
--- a/src/components/ContainerMonitor.tsx
+++ b/src/components/ContainerMonitor.tsx
@@ -52,7 +52,7 @@ export function ContainerMonitor({ onClose }: ContainerMonitorProps) {
     async (containerId: string, action: "start" | "stop" | "restart") => {
       setActionLoading(containerId);
       try {
-        await invoke(`${action}_container`, { containerId });
+        await invoke("container_action", { containerId, action });
         await loadStats();
       } catch (e) {
         setError(String(e));

--- a/src/components/DockerPanel.tsx
+++ b/src/components/DockerPanel.tsx
@@ -63,7 +63,7 @@ export function DockerPanel({ cwd, onClose }: DockerPanelProps) {
     async (containerId: string, action: "start" | "stop") => {
       setActionLoading(containerId);
       try {
-        await invoke(`${action}_container`, { containerId });
+        await invoke("container_action", { containerId, action });
         await loadData();
       } catch (err) {
         setDockerError(


### PR DESCRIPTION
## Summary
- route Docker panel actions through the existing `container_action` Tauri command
- send the requested action as an argument instead of synthesizing missing command names

Closes #275