### PR TITLE
fix: handle PTY data type mismatch crashing terminal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.1.18",
+  "version": "0.1.19",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.1.18"
+version = "0.1.19"
 edition = "2021"
 authors = ["Saurav Panda <saurav@workroot.dev>"]
 description = "A local-first developer workspace for managing projects, terminals, and Git workflows."

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -691,25 +691,36 @@ function TerminalInstance({
 
         ptyRef.current = pty;
 
-        pty.onData((data: Uint8Array) => {
+        pty.onData((data: string | Uint8Array) => {
           if (!termRef.current) return;
           term.write(data);
 
+          // Activity tracking for agent-complete detection.
+          const byteLen =
+            typeof data === "string" ? data.length : (data?.length ?? 0);
+          activityBytesRef.current += byteLen;
+
           // Check for patterns that suggest the agent needs user input.
-          const text = new TextDecoder().decode(data);
-          const now = Date.now();
-          if (now - lastAttentionTimeRef.current >= ATTENTION_COOLDOWN_MS) {
-            for (const pattern of ATTENTION_PATTERNS) {
-              if (pattern.test(text)) {
-                lastAttentionTimeRef.current = now;
-                onAgentNeedsAttentionRef.current?.();
-                break;
+          try {
+            const text =
+              typeof data === "string"
+                ? data
+                : data instanceof Uint8Array
+                  ? new TextDecoder().decode(data)
+                  : String(data);
+            const now = Date.now();
+            if (now - lastAttentionTimeRef.current >= ATTENTION_COOLDOWN_MS) {
+              for (const pattern of ATTENTION_PATTERNS) {
+                if (pattern.test(text)) {
+                  lastAttentionTimeRef.current = now;
+                  onAgentNeedsAttentionRef.current?.();
+                  break;
+                }
               }
             }
+          } catch {
+            // Ignore decode errors — terminal still works via term.write()
           }
-
-          // Activity tracking for agent-complete detection.
-          activityBytesRef.current += data.length;
           if (idleTimerRef.current) clearTimeout(idleTimerRef.current);
           if (activityBytesRef.current >= ACTIVITY_THRESHOLD_BYTES) {
             idleTimerRef.current = setTimeout(() => {


### PR DESCRIPTION
## Summary
- `tauri-pty`'s `onData` callback emits data that is not a `Uint8Array`, causing `TextDecoder.decode()` to throw `TypeError` and crash the terminal
- This was the actual root cause of the "terminal not working" bug — the attention pattern check (added in v0.1.11) crashed on every PTY output
- Fix: guard the decode with `instanceof` check + try-catch fallback
- Bump version to 0.1.19

## Test plan
- [x] Tested locally with `pnpm tauri dev` — terminal opens and works

🤖 Generated with [Claude Code](https://claude.com/claude-code)