### PR TITLE
perf: remove backdrop-filter animation to reduce modal jank (#312)

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -480,12 +480,11 @@ button:disabled {
   inset: 0;
   z-index: 9000;
   background: rgba(6, 6, 8, 0.65);
-  backdrop-filter: blur(12px) saturate(0.8);
-  -webkit-backdrop-filter: blur(12px) saturate(0.8);
   display: flex;
   align-items: center;
   justify-content: center;
   animation: panel-overlay-in 0.18s var(--ease-out, ease-out);
+  will-change: opacity;
 }
 
 @keyframes panel-overlay-in {
@@ -515,6 +514,7 @@ button:disabled {
     0 0 0 1px rgba(255, 255, 255, 0.05) inset;
   animation: panel-dialog-in 0.22s
     var(--ease-spring, cubic-bezier(0.16, 1, 0.3, 1));
+  will-change: opacity, transform;
 }
 
 @keyframes panel-dialog-in {


### PR DESCRIPTION
## Summary
- Removed `backdrop-filter: blur(12px) saturate(0.8)` from `.panel-overlay` — GPU-intensive and causes jank on modal open
- Added `will-change: opacity` to `.panel-overlay` and `will-change: opacity, transform` to `.panel-dialog`

Closes #312

## Test plan
- [ ] Open any modal/dialog — should animate smoothly without jank

🤖 Generated with [Claude Code](https://claude.com/claude-code)