### PR TITLE
fix: resolve stale closure warnings in App.tsx keyboard shortcuts (#306)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1228,6 +1228,8 @@ function AppContent({
     setSelectedWorktreePath,
     setSelectedWorktreeName,
     setShowRightSidebar,
+    openPanel,
+    togglePanel,
   ]);
 
   // Register commands whenever they change
@@ -1302,7 +1304,6 @@ function AppContent({
         action: () => togglePanel("errorDiagnosis"),
       },
     ],
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       showRightSidebar,
       setShowSettings,
@@ -1310,12 +1311,13 @@ function AppContent({
       setSelectedWorktreePath,
       setSelectedWorktreeName,
       setShowRightSidebar,
+      togglePanel,
     ],
   );
   useGlobalShortcuts(shortcuts);
 
-  const handleClosePalette = useCallback(() => closePanel("palette"), []);
-  const handleCloseBookmarks = useCallback(() => closePanel("bookmarks"), []);
+  const handleClosePalette = useCallback(() => closePanel("palette"), [closePanel]);
+  const handleCloseBookmarks = useCallback(() => closePanel("bookmarks"), [closePanel]);
 
   /* Expose sidebar-toolbar actions to parent via ref */
   sidebarActionsRef.current = {
@@ -1347,7 +1349,7 @@ function AppContent({
         openPanel("docker");
         break;
     }
-  }, []);
+  }, [openPanel]);
 
   const handleContentTabChange = useCallback((tab: string) => {
     setContentTab(tab);
@@ -1368,7 +1370,7 @@ function AppContent({
         openPanel("docker");
         break;
     }
-  }, []);
+  }, [openPanel]);
 
   return (
     <Suspense fallback={null}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1316,8 +1316,14 @@ function AppContent({
   );
   useGlobalShortcuts(shortcuts);
 
-  const handleClosePalette = useCallback(() => closePanel("palette"), [closePanel]);
-  const handleCloseBookmarks = useCallback(() => closePanel("bookmarks"), [closePanel]);
+  const handleClosePalette = useCallback(
+    () => closePanel("palette"),
+    [closePanel],
+  );
+  const handleCloseBookmarks = useCallback(
+    () => closePanel("bookmarks"),
+    [closePanel],
+  );
 
   /* Expose sidebar-toolbar actions to parent via ref */
   sidebarActionsRef.current = {
@@ -1329,48 +1335,54 @@ function AppContent({
     },
   };
 
-  const handleDashboardAction = useCallback((action: string) => {
-    switch (action) {
-      case "terminal":
-        break;
-      case "git":
-        openPanel("gitDiff");
-        break;
-      case "ai":
-        openPanel("aiChat");
-        break;
-      case "search":
-        openPanel("unifiedSearch");
-        break;
-      case "security":
-        openPanel("securityAudit");
-        break;
-      case "docker":
-        openPanel("docker");
-        break;
-    }
-  }, [openPanel]);
+  const handleDashboardAction = useCallback(
+    (action: string) => {
+      switch (action) {
+        case "terminal":
+          break;
+        case "git":
+          openPanel("gitDiff");
+          break;
+        case "ai":
+          openPanel("aiChat");
+          break;
+        case "search":
+          openPanel("unifiedSearch");
+          break;
+        case "security":
+          openPanel("securityAudit");
+          break;
+        case "docker":
+          openPanel("docker");
+          break;
+      }
+    },
+    [openPanel],
+  );
 
-  const handleContentTabChange = useCallback((tab: string) => {
-    setContentTab(tab);
-    switch (tab) {
-      case "changes":
-        openPanel("gitDiff");
-        break;
-      case "pr":
-        openPanel("createPr");
-        break;
-      case "tests":
-        openPanel("testRunnerPanel");
-        break;
-      case "security":
-        openPanel("securityAudit");
-        break;
-      case "docker":
-        openPanel("docker");
-        break;
-    }
-  }, [openPanel]);
+  const handleContentTabChange = useCallback(
+    (tab: string) => {
+      setContentTab(tab);
+      switch (tab) {
+        case "changes":
+          openPanel("gitDiff");
+          break;
+        case "pr":
+          openPanel("createPr");
+          break;
+        case "tests":
+          openPanel("testRunnerPanel");
+          break;
+        case "security":
+          openPanel("securityAudit");
+          break;
+        case "docker":
+          openPanel("docker");
+          break;
+      }
+    },
+    [openPanel],
+  );
 
   return (
     <Suspense fallback={null}>


### PR DESCRIPTION
## Summary
- Added missing dependencies (`openPanel`, `togglePanel`, `closePanel`) to 5 hook dependency arrays in App.tsx
- All functions come from `usePanels` where they're defined with empty deps, so they're referentially stable — no infinite loop risk
- `pnpm lint` now reports zero warnings for App.tsx

Closes #306

## Test plan
- [ ] Keyboard shortcuts work correctly (Cmd+K, Cmd+comma, etc.)
- [ ] No lint warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)