### PR TITLE
chore: release v0.1.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.1.19",
+  "version": "0.1.20",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.1.19"
+version = "0.1.20"
 edition = "2021"
 authors = ["Saurav Panda <saurav@workroot.dev>"]
 description = "A local-first developer workspace for managing projects, terminals, and Git workflows."

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Changes since v0.1.19

### Performance
- **split xterm vendor bundle** (#310) — TerminalPanel 483KB → 33KB, xterm cached independently
- **lazy-load 62 CSS files** (#305) — moved panel CSS into component files for code-splitting
- **Set-based panel state** (#311) — replaced 75 booleans with Set for fewer re-renders
- **remove backdrop-filter animation** (#312) — smoother modal open/close

### Bug Fixes
- **resolve stale closures** (#306) — keyboard shortcuts now use correct panel state

🤖 Generated with [Claude Code](https://claude.com/claude-code)