### PR TITLE
perf: make DORA metric commands async (#309)

### DIFF
--- a/src-tauri/src/metrics/dora.rs
+++ b/src-tauri/src/metrics/dora.rs
@@ -26,7 +26,7 @@ pub struct DoraMetrics {
 
 /// Records a deployment event. Returns the deployment ID.
 #[tauri::command]
-pub fn record_deployment(
+pub async fn record_deployment(
     db: State<'_, AppDb>,
     project_id: i64,
     version: String,
@@ -45,7 +45,7 @@ pub fn record_deployment(
 
 /// Calculates DORA metrics for a project over a given period.
 #[tauri::command]
-pub fn get_dora_metrics(
+pub async fn get_dora_metrics(
     db: State<'_, AppDb>,
     project_id: i64,
     period_days: i64,
@@ -186,7 +186,7 @@ fn classify_rating(freq: f64, lead_time: f64, cfr: f64, mttr: f64, period_days: 
 
 /// Lists recent deployments for a project with an optional limit.
 #[tauri::command]
-pub fn list_deployments(
+pub async fn list_deployments(
     db: State<'_, AppDb>,
     project_id: i64,
     limit: Option<i64>,


### PR DESCRIPTION
## Summary
- Made `record_deployment`, `get_dora_metrics`, and `list_deployments` Tauri commands `async` to avoid blocking the main IPC thread with synchronous SQLite queries
- Follows the existing pattern used by other async commands in the codebase (e.g., `export_backup`, `stop_process`)

Closes #309

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] All 168 unit tests pass (`cargo test`)