### PR TITLE
ux: remove GitHub sidebar and unused toolbar tabs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -392,8 +392,6 @@ function AppContent({
     setSelectedWorktreeId,
     setSelectedWorktreePath,
     setSelectedWorktreeName,
-    showRightSidebar,
-    setShowRightSidebar,
     markAgentDone,
     markAgentNeedsAttention,
   } = useUiStore();
@@ -708,14 +706,6 @@ function AppContent({
         icon: "\u25B6",
         enabled: () => selectedWorktreePath !== null,
         action: () => openPanel("taskRunner"),
-      },
-      {
-        id: "github:toggle",
-        label: showRightSidebar ? "Hide GitHub Sidebar" : "Show GitHub Sidebar",
-        category: "Panels",
-        shortcut: "\u2318G",
-        icon: "\uD83D\uDC19",
-        action: () => setShowRightSidebar(!showRightSidebar),
       },
       // Git tools
       {
@@ -1218,7 +1208,6 @@ function AppContent({
     selectedProjectId,
     selectedWorktreePath,
     selectedWorktreeId,
-    showRightSidebar,
     allProjects,
     allWorktrees,
     selectWorktree,
@@ -1227,7 +1216,6 @@ function AppContent({
     setSelectedWorktreeId,
     setSelectedWorktreePath,
     setSelectedWorktreeName,
-    setShowRightSidebar,
     openPanel,
     togglePanel,
   ]);
@@ -1260,11 +1248,6 @@ function AppContent({
           setSelectedWorktreePath(null);
           setSelectedWorktreeName(null);
         },
-      },
-      {
-        key: "g",
-        meta: true,
-        action: () => setShowRightSidebar(!showRightSidebar),
       },
       {
         key: "n",
@@ -1305,12 +1288,10 @@ function AppContent({
       },
     ],
     [
-      showRightSidebar,
       setShowSettings,
       setSelectedWorktreeId,
       setSelectedWorktreePath,
       setSelectedWorktreeName,
-      setShowRightSidebar,
       togglePanel,
     ],
   );
@@ -1349,12 +1330,6 @@ function AppContent({
         case "search":
           openPanel("unifiedSearch");
           break;
-        case "security":
-          openPanel("securityAudit");
-          break;
-        case "docker":
-          openPanel("docker");
-          break;
       }
     },
     [openPanel],
@@ -1369,15 +1344,6 @@ function AppContent({
           break;
         case "pr":
           openPanel("createPr");
-          break;
-        case "tests":
-          openPanel("testRunnerPanel");
-          break;
-        case "security":
-          openPanel("securityAudit");
-          break;
-        case "docker":
-          openPanel("docker");
           break;
       }
     },

--- a/src/components/ContentToolbar.tsx
+++ b/src/components/ContentToolbar.tsx
@@ -50,61 +50,6 @@ const TABS = [
       </svg>
     ),
   },
-  {
-    id: "tests",
-    label: "Tests",
-    icon: (
-      <svg
-        viewBox="0 0 16 16"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        className="size-3.5 shrink-0"
-      >
-        <path d="M3.5 8.5l3 3 6-7" />
-      </svg>
-    ),
-  },
-  {
-    id: "security",
-    label: "Security",
-    icon: (
-      <svg
-        viewBox="0 0 16 16"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        className="size-3.5 shrink-0"
-      >
-        <path d="M8 1.5L2.5 4v4c0 3.5 2.5 5.5 5.5 6.5 3-1 5.5-3 5.5-6.5V4L8 1.5z" />
-      </svg>
-    ),
-  },
-  {
-    id: "docker",
-    label: "Docker",
-    icon: (
-      <svg
-        viewBox="0 0 16 16"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        className="size-3.5 shrink-0"
-      >
-        <rect x="1.5" y="6" width="13" height="7" rx="1" />
-        <path d="M4 6V4.5a1 1 0 011-1h6a1 1 0 011 1V6" />
-        <path d="M5.5 9h0" />
-        <path d="M8 9h0" />
-        <path d="M10.5 9h0" />
-      </svg>
-    ),
-  },
 ] as const;
 
 export function ContentToolbar({

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useRef, useEffect, useMemo } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { Sidebar } from "../components/Sidebar";
-import { GitHubSidebar } from "../components/GitHubSidebar";
+
 import { UiContext } from "../stores/uiStore";
 import { ErrorBoundary } from "../components/ErrorBoundary";
 import { ProjectTabBar, type ProjectTab } from "../components/ProjectTabBar";
@@ -11,10 +11,7 @@ const SIDEBAR_MAX = 480;
 const SIDEBAR_DEFAULT = 260;
 const STORAGE_KEY = "workroot:sidebar-width";
 
-const RIGHT_SIDEBAR_MIN = 200;
-const RIGHT_SIDEBAR_MAX = 500;
-const RIGHT_SIDEBAR_DEFAULT = 280;
-const RIGHT_STORAGE_KEY = "workroot:right-sidebar-width";
+
 
 const OPEN_TABS_KEY = "workroot:open-project-tabs";
 const TAB_BAR_HEIGHT = 32;
@@ -30,19 +27,6 @@ function getSavedWidth(): number {
     // ignore
   }
   return SIDEBAR_DEFAULT;
-}
-
-function getSavedRightWidth(): number {
-  try {
-    const saved = localStorage.getItem(RIGHT_STORAGE_KEY);
-    if (saved) {
-      const n = parseInt(saved, 10);
-      if (n >= RIGHT_SIDEBAR_MIN && n <= RIGHT_SIDEBAR_MAX) return n;
-    }
-  } catch {
-    // ignore
-  }
-  return RIGHT_SIDEBAR_DEFAULT;
 }
 
 function getSavedOpenTabIds(): number[] {
@@ -71,8 +55,6 @@ export function MainLayout({
   onOpenSettings,
 }: MainLayoutProps) {
   const [sidebarWidth, setSidebarWidth] = useState(getSavedWidth);
-  const [rightSidebarWidth, setRightSidebarWidth] =
-    useState(getSavedRightWidth);
   const [selectedProjectId, setSelectedProjectIdRaw] = useState<number | null>(
     null,
   );
@@ -86,7 +68,6 @@ export function MainLayout({
     string | null
   >(null);
   const [showSettings, setShowSettings] = useState(false);
-  const [showRightSidebar, setShowRightSidebar] = useState(true);
   const [agentDoneWorktreeIds, setAgentDoneWorktreeIds] = useState<Set<number>>(
     () => new Set(),
   );
@@ -199,18 +180,9 @@ export function MainLayout({
   }, []);
 
   const dragging = useRef(false);
-  const draggingRight = useRef(false);
-
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
     dragging.current = true;
-    document.body.style.cursor = "col-resize";
-    document.body.style.userSelect = "none";
-  }, []);
-
-  const handleRightMouseDown = useCallback((e: React.MouseEvent) => {
-    e.preventDefault();
-    draggingRight.current = true;
     document.body.style.cursor = "col-resize";
     document.body.style.userSelect = "none";
   }, []);
@@ -221,23 +193,11 @@ export function MainLayout({
         const width = Math.min(SIDEBAR_MAX, Math.max(SIDEBAR_MIN, e.clientX));
         setSidebarWidth(width);
       }
-      if (draggingRight.current) {
-        const width = Math.min(
-          RIGHT_SIDEBAR_MAX,
-          Math.max(RIGHT_SIDEBAR_MIN, window.innerWidth - e.clientX),
-        );
-        setRightSidebarWidth(width);
-      }
     };
 
     const handleMouseUp = () => {
       if (dragging.current) {
         dragging.current = false;
-        document.body.style.cursor = "";
-        document.body.style.userSelect = "";
-      }
-      if (draggingRight.current) {
-        draggingRight.current = false;
         document.body.style.cursor = "";
         document.body.style.userSelect = "";
       }
@@ -259,14 +219,6 @@ export function MainLayout({
     }
   }, [sidebarWidth]);
 
-  useEffect(() => {
-    try {
-      localStorage.setItem(RIGHT_STORAGE_KEY, String(rightSidebarWidth));
-    } catch {
-      // ignore
-    }
-  }, [rightSidebarWidth]);
-
   const showTabBar = visibleTabs.length > 0;
 
   return (
@@ -283,8 +235,6 @@ export function MainLayout({
           setSelectedWorktreeName,
           showSettings,
           setShowSettings,
-          showRightSidebar,
-          setShowRightSidebar,
           agentDoneWorktreeIds,
           markAgentDone,
           clearAgentDone,
@@ -299,7 +249,6 @@ export function MainLayout({
           selectedWorktreePath,
           selectedWorktreeName,
           showSettings,
-          showRightSidebar,
           agentDoneWorktreeIds,
           markAgentDone,
           clearAgentDone,
@@ -340,20 +289,6 @@ export function MainLayout({
         </div>
         <div className="resize-handle" onMouseDown={handleMouseDown} />
         <div className="content-area">{children}</div>
-        {showRightSidebar && (
-          <>
-            <div
-              className="resize-handle resize-handle--right"
-              onMouseDown={handleRightMouseDown}
-            />
-            <ErrorBoundary name="GitHub Sidebar">
-              <GitHubSidebar
-                projectId={selectedProjectId}
-                width={rightSidebarWidth}
-              />
-            </ErrorBoundary>
-          </>
-        )}
       </div>
     </UiContext.Provider>
   );

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -11,8 +11,6 @@ const SIDEBAR_MAX = 480;
 const SIDEBAR_DEFAULT = 260;
 const STORAGE_KEY = "workroot:sidebar-width";
 
-
-
 const OPEN_TABS_KEY = "workroot:open-project-tabs";
 const TAB_BAR_HEIGHT = 32;
 

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -11,8 +11,6 @@ interface UiContextValue {
   setSelectedWorktreeName: (name: string | null) => void;
   showSettings: boolean;
   setShowSettings: (show: boolean) => void;
-  showRightSidebar: boolean;
-  setShowRightSidebar: (show: boolean) => void;
   agentDoneWorktreeIds: Set<number>;
   markAgentDone: (id: number) => void;
   clearAgentDone: (id: number) => void;
@@ -32,8 +30,6 @@ export const UiContext = createContext<UiContextValue>({
   setSelectedWorktreeName: () => {},
   showSettings: false,
   setShowSettings: () => {},
-  showRightSidebar: true,
-  setShowRightSidebar: () => {},
   agentDoneWorktreeIds: new Set(),
   markAgentDone: () => {},
   clearAgentDone: () => {},


### PR DESCRIPTION
## Summary
- Removed the GitHub sidebar (right panel with PRs/Issues/Activity tabs) from the main layout
- Removed the Tests, Security, and Docker tabs from the content toolbar
- Cleaned up related state, constants, keyboard shortcuts, and command palette entries
- Component files are preserved for potential future use

Closes #318

## Test plan
- [ ] Verify the right sidebar no longer renders
- [ ] Verify only Changes and PR tabs appear in the content toolbar
- [ ] Verify Cmd+G no longer toggles a sidebar
- [ ] Verify the app builds and lints cleanly