### PR TITLE
fix: make delete dialog overlay block clicks to content behind (#303)

### DIFF
--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -917,13 +917,14 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  z-index: 9902;
+  z-index: 9999;
   background: var(--bg-primary);
   border: 1px solid var(--border);
   border-radius: 8px;
   padding: 1em 1.2em;
   min-width: 260px;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  pointer-events: auto;
 }
 
 .delete-confirm-title {


### PR DESCRIPTION
## Summary
- `.delete-confirm-dialog` had `z-index: 9902` which was below its own Radix overlay at `z-index: 9998`, making buttons unclickable
- Fixed z-index to 9999 and added `pointer-events: auto` as safeguard

Closes #303

## Test plan
- [ ] Delete worktree → dialog buttons are clickable with mouse

🤖 Generated with [Claude Code](https://claude.com/claude-code)