### PR TITLE
feat: workspace grid view (Cockpit Phase 1) (#327)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,15 +27,6 @@ const namedLazy = <K extends string>(
   lazy(() => factory().then((m) => ({ default: m[name] })));
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
-const AuthButton = namedLazy(
-  () => import("./components/AuthButton"),
-  "AuthButton",
-);
-const RepoList = namedLazy(() => import("./components/RepoList"), "RepoList");
-const ActiveProjectBadge = namedLazy(
-  () => import("./components/ActiveProjectBadge"),
-  "ActiveProjectBadge",
-);
 const loadTerminalPanel = () => import("./components/TerminalPanel");
 const TerminalPanel = namedLazy(loadTerminalPanel, "TerminalPanel");
 const CommandPalette = namedLazy(
@@ -46,14 +37,13 @@ const ContentToolbar = namedLazy(
   () => import("./components/ContentToolbar"),
   "ContentToolbar",
 );
-const EnvPanel = namedLazy(() => import("./components/EnvPanel"), "EnvPanel");
 const SettingsTab = namedLazy(
   () => import("./components/SettingsTab"),
   "SettingsTab",
 );
-const Dashboard = namedLazy(
-  () => import("./components/Dashboard"),
-  "Dashboard",
+const WorkspaceGrid = namedLazy(
+  () => import("./components/WorkspaceGrid"),
+  "WorkspaceGrid",
 );
 const CommandBookmarks = namedLazy(
   () => import("./components/CommandBookmarks"),
@@ -1316,24 +1306,37 @@ function AppContent({
     },
   };
 
-  const handleDashboardAction = useCallback(
-    (action: string) => {
-      switch (action) {
-        case "terminal":
-          break;
-        case "git":
-          openPanel("gitDiff");
-          break;
-        case "ai":
-          openPanel("aiChat");
-          break;
-        case "search":
-          openPanel("unifiedSearch");
-          break;
-      }
-    },
-    [openPanel],
-  );
+  // Escape returns to the workspace grid when viewing a terminal.
+  // Only triggers when no modals/panels are open, settings is closed, and
+  // the focused element is within the terminal surface.
+  useEffect(() => {
+    if (!selectedWorktreePath) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      if (e.defaultPrevented) return;
+      if (e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return;
+      if (showSettings) return;
+      if (panels.size > 0) return;
+      const active = document.activeElement as HTMLElement | null;
+      if (!active) return;
+      // Require the focus to be inside the terminal surface.
+      if (!active.closest(".terminal-fullscreen")) return;
+      e.preventDefault();
+      e.stopPropagation();
+      setSelectedWorktreeId(null);
+      setSelectedWorktreePath(null);
+      setSelectedWorktreeName(null);
+    };
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [
+    selectedWorktreePath,
+    showSettings,
+    panels,
+    setSelectedWorktreeId,
+    setSelectedWorktreePath,
+    setSelectedWorktreeName,
+  ]);
 
   const handleContentTabChange = useCallback(
     (tab: string) => {
@@ -1357,26 +1360,22 @@ function AppContent({
           <SettingsTab />
         </PanelBoundary>
       ) : !selectedWorktreePath ? (
-        <div className="content-scroll">
-          <div className="content-inner">
-            <PanelBoundary name="Dashboard">
-              <Dashboard
-                projectId={selectedProjectId}
-                onAction={handleDashboardAction}
-              />
-            </PanelBoundary>
-            <ActiveProjectBadge />
-            <AuthButton />
-            <PanelBoundary name="RepoList">
-              <RepoList />
-            </PanelBoundary>
-            {selectedProjectId !== null && (
-              <PanelBoundary name="EnvPanel">
-                <EnvPanel projectId={selectedProjectId} />
-              </PanelBoundary>
-            )}
-          </div>
-        </div>
+        <PanelBoundary name="WorkspaceGrid">
+          <WorkspaceGrid
+            projects={allProjects}
+            worktrees={allWorktrees}
+            onSelectWorktree={(wt: WorktreeInfo) => {
+              setSelectedProjectId(wt.project_id);
+              setSelectedWorktreeId(wt.id);
+              setSelectedWorktreePath(wt.path);
+              setSelectedWorktreeName(wt.branch_name);
+              setShowSettings(false);
+            }}
+            onNewWorktree={(projectId: number) => {
+              setSelectedProjectId(projectId);
+            }}
+          />
+        </PanelBoundary>
       ) : null}
       {/* TerminalPanel is rendered outside the ternary so it stays mounted
           (and PTY sessions stay alive) when the user navigates to Home or

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1306,21 +1306,17 @@ function AppContent({
     },
   };
 
-  // Escape returns to the workspace grid when viewing a terminal.
-  // Only triggers when no modals/panels are open, settings is closed, and
-  // the focused element is within the terminal surface.
+  // Cmd+Escape returns to the workspace grid when viewing a terminal.
+  // We use Cmd+Escape (not plain Escape) so terminal apps like vim/less can
+  // still receive the Escape key normally.
   useEffect(() => {
     if (!selectedWorktreePath) return;
     const handleKey = (e: KeyboardEvent) => {
       if (e.key !== "Escape") return;
+      if (!e.metaKey) return;
       if (e.defaultPrevented) return;
-      if (e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return;
       if (showSettings) return;
       if (panels.size > 0) return;
-      const active = document.activeElement as HTMLElement | null;
-      if (!active) return;
-      // Require the focus to be inside the terminal surface.
-      if (!active.closest(".terminal-fullscreen")) return;
       e.preventDefault();
       e.stopPropagation();
       setSelectedWorktreeId(null);

--- a/src/components/WorkspaceGrid.tsx
+++ b/src/components/WorkspaceGrid.tsx
@@ -1,0 +1,211 @@
+import { useEffect, useMemo, useState, useCallback } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { useUiStore } from "../stores/uiStore";
+import "../styles/workspace-grid.css";
+
+interface ProjectInfo {
+  id: number;
+  name: string;
+  local_path: string;
+  framework: string | null;
+}
+
+interface WorktreeInfo {
+  id: number;
+  project_id: number;
+  branch_name: string;
+  path: string;
+  status: string;
+}
+
+interface WorkspaceGridProps {
+  projects: ProjectInfo[];
+  worktrees: Array<WorktreeInfo & { projectName: string }>;
+  onSelectWorktree: (wt: WorktreeInfo) => void;
+  onNewWorktree?: (projectId: number) => void;
+}
+
+type CardStatus = "active" | "attention" | "idle";
+
+function formatPath(path: string): string {
+  return path.replace(/^\/Users\/[^/]+/, "~");
+}
+
+export function WorkspaceGrid({
+  projects,
+  worktrees,
+  onSelectWorktree,
+  onNewWorktree,
+}: WorkspaceGridProps) {
+  const { selectedWorktreeId, agentNeedsAttentionIds, agentDoneWorktreeIds } =
+    useUiStore();
+
+  // Fallback in case props are empty — load projects + worktrees ourselves.
+  const [fallbackProjects, setFallbackProjects] = useState<ProjectInfo[]>([]);
+  const [fallbackWorktrees, setFallbackWorktrees] = useState<
+    Array<WorktreeInfo & { projectName: string }>
+  >([]);
+
+  useEffect(() => {
+    if (projects.length > 0) return;
+    let cancelled = false;
+    async function load() {
+      try {
+        const ps = await invoke<ProjectInfo[]>("list_projects");
+        if (cancelled) return;
+        setFallbackProjects(ps);
+        const results = await Promise.all(
+          ps.map(async (p) => {
+            try {
+              const wts = await invoke<WorktreeInfo[]>(
+                "list_project_worktrees",
+                { projectId: p.id },
+              );
+              return wts.map((wt) => ({ ...wt, projectName: p.name }));
+            } catch {
+              return [];
+            }
+          }),
+        );
+        if (cancelled) return;
+        setFallbackWorktrees(results.flat());
+      } catch {
+        // ignore
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [projects.length]);
+
+  const activeProjects = projects.length > 0 ? projects : fallbackProjects;
+  const activeWorktrees =
+    worktrees.length > 0 || projects.length > 0 ? worktrees : fallbackWorktrees;
+
+  const grouped = useMemo(() => {
+    const byProject = new Map<
+      number,
+      {
+        project: ProjectInfo;
+        worktrees: Array<WorktreeInfo & { projectName: string }>;
+      }
+    >();
+    for (const p of activeProjects) {
+      byProject.set(p.id, { project: p, worktrees: [] });
+    }
+    for (const wt of activeWorktrees) {
+      const entry = byProject.get(wt.project_id);
+      if (entry) entry.worktrees.push(wt);
+    }
+    return Array.from(byProject.values());
+  }, [activeProjects, activeWorktrees]);
+
+  const statusFor = useCallback(
+    (wt: WorktreeInfo): CardStatus => {
+      if (agentNeedsAttentionIds.has(wt.id)) return "attention";
+      if (selectedWorktreeId === wt.id || agentDoneWorktreeIds.has(wt.id)) {
+        return "active";
+      }
+      return "idle";
+    },
+    [selectedWorktreeId, agentNeedsAttentionIds, agentDoneWorktreeIds],
+  );
+
+  const totalWorktrees = activeWorktrees.length;
+
+  return (
+    <div className="workspace-grid-root">
+      <div className="workspace-grid-inner">
+        <div className="workspace-grid-header">
+          <div>
+            <h1 className="workspace-grid-title">Workspaces</h1>
+            <div className="workspace-grid-subtitle">
+              {totalWorktrees === 0
+                ? "No worktrees yet. Create one to get started."
+                : `${totalWorktrees} worktree${totalWorktrees === 1 ? "" : "s"} across ${activeProjects.length} project${activeProjects.length === 1 ? "" : "s"}`}
+            </div>
+          </div>
+        </div>
+
+        {grouped.length === 0 && (
+          <div className="workspace-grid-empty">
+            No projects registered. Add a project to begin.
+          </div>
+        )}
+
+        {grouped.map(({ project, worktrees: wts }) => (
+          <div key={project.id} className="workspace-project-group">
+            <div className="workspace-project-header">
+              <span className="workspace-project-name">{project.name}</span>
+              <span className="workspace-project-path">
+                {formatPath(project.local_path)}
+              </span>
+              <span className="workspace-project-count">{wts.length}</span>
+            </div>
+            <div className="workspace-grid">
+              {wts.map((wt) => {
+                const status = statusFor(wt);
+                return (
+                  <button
+                    key={wt.id}
+                    type="button"
+                    className="workspace-card"
+                    onClick={() => onSelectWorktree(wt)}
+                  >
+                    <div className="workspace-card-top">
+                      <span
+                        className={
+                          "workspace-card-dot" +
+                          (status === "active"
+                            ? " workspace-card-dot--active"
+                            : status === "attention"
+                              ? " workspace-card-dot--attention"
+                              : "")
+                        }
+                        aria-hidden
+                      />
+                      <span className="workspace-card-branch">
+                        {wt.branch_name}
+                      </span>
+                    </div>
+                    <div className="workspace-card-meta">
+                      <span className="workspace-card-project">
+                        {project.name}
+                      </span>
+                      <span
+                        className={
+                          "workspace-card-status" +
+                          (status === "active"
+                            ? " workspace-card-status--active"
+                            : status === "attention"
+                              ? " workspace-card-status--attention"
+                              : "")
+                        }
+                      >
+                        {status === "active"
+                          ? "Active"
+                          : status === "attention"
+                            ? "Attention"
+                            : "Idle"}
+                      </span>
+                    </div>
+                  </button>
+                );
+              })}
+              <button
+                type="button"
+                className="workspace-card workspace-card--new"
+                onClick={() => onNewWorktree?.(project.id)}
+                aria-label={`New worktree in ${project.name}`}
+              >
+                <span className="workspace-card-plus">+</span>
+                <span className="workspace-card-new-label">New worktree</span>
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -275,17 +275,21 @@ export function MainLayout({
             : undefined
         }
       >
-        <div className="sidebar-panel" style={{ width: sidebarWidth }}>
-          <ErrorBoundary name="Sidebar">
-            <Sidebar
-              onOpenSearch={onOpenSearch}
-              onOpenAiChat={onOpenAiChat}
-              onOpenNotifications={onOpenNotifications}
-              onOpenSettings={onOpenSettings}
-            />
-          </ErrorBoundary>
-        </div>
-        <div className="resize-handle" onMouseDown={handleMouseDown} />
+        {selectedWorktreePath && (
+          <>
+            <div className="sidebar-panel" style={{ width: sidebarWidth }}>
+              <ErrorBoundary name="Sidebar">
+                <Sidebar
+                  onOpenSearch={onOpenSearch}
+                  onOpenAiChat={onOpenAiChat}
+                  onOpenNotifications={onOpenNotifications}
+                  onOpenSettings={onOpenSettings}
+                />
+              </ErrorBoundary>
+            </div>
+            <div className="resize-handle" onMouseDown={handleMouseDown} />
+          </>
+        )}
         <div className="content-area">{children}</div>
       </div>
     </UiContext.Provider>

--- a/src/styles/workspace-grid.css
+++ b/src/styles/workspace-grid.css
@@ -1,0 +1,242 @@
+/* ==========================================================
+   Workspace Grid — Cockpit view
+   ========================================================== */
+
+.workspace-grid-root {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  background:
+    radial-gradient(
+      ellipse 60% 40% at 50% 20%,
+      rgba(16, 185, 129, 0.05) 0%,
+      transparent 70%
+    ),
+    var(--bg-base);
+  padding: 2.5em 2em 4em;
+}
+
+.workspace-grid-inner {
+  max-width: 1400px;
+  margin: 0 auto;
+}
+
+.workspace-grid-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 2em;
+  gap: 1em;
+}
+
+.workspace-grid-title {
+  font-size: 1.5em;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.workspace-grid-subtitle {
+  font-size: 0.85em;
+  color: var(--text-muted);
+  margin-top: 0.25em;
+}
+
+.workspace-grid-empty {
+  text-align: center;
+  padding: 4em 2em;
+  color: var(--text-muted);
+  font-size: 0.9em;
+}
+
+.workspace-project-group {
+  margin-bottom: 2.5em;
+}
+
+.workspace-project-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+  margin-bottom: 0.75em;
+  padding: 0 0.25em 0.5em;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.workspace-project-name {
+  font-size: 0.7em;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-secondary);
+}
+
+.workspace-project-path {
+  font-family: var(--font-mono);
+  font-size: 0.7em;
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}
+
+.workspace-project-count {
+  font-size: 0.7em;
+  color: var(--text-muted);
+  background: var(--bg-elevated);
+  padding: 1px 7px;
+  border-radius: 10px;
+  border: 1px solid var(--border-subtle);
+}
+
+.workspace-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 0.85em;
+}
+
+.workspace-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5em;
+  padding: 0.9em 1em;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+  color: var(--text-primary);
+  transition:
+    border-color var(--transition-fast) var(--ease-out),
+    background-color var(--transition-fast) var(--ease-out),
+    transform var(--transition-fast) var(--ease-out),
+    box-shadow var(--transition-fast) var(--ease-out);
+  position: relative;
+  min-height: 86px;
+}
+
+.workspace-card:hover {
+  border-color: var(--accent);
+  background: var(--bg-elevated);
+  transform: translateY(-1px);
+  box-shadow: var(--shadow);
+}
+
+.workspace-card:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-muted);
+}
+
+.workspace-card:active {
+  transform: translateY(0);
+}
+
+.workspace-card-top {
+  display: flex;
+  align-items: center;
+  gap: 0.55em;
+  min-width: 0;
+}
+
+.workspace-card-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: var(--text-muted);
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.02);
+}
+
+.workspace-card-dot--active {
+  background: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-muted);
+}
+
+.workspace-card-dot--attention {
+  background: var(--warning);
+  box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.2);
+  animation: workspace-pulse 1.8s ease-in-out infinite;
+}
+
+@keyframes workspace-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.2);
+  }
+  50% {
+    box-shadow: 0 0 0 5px rgba(245, 158, 11, 0.35);
+  }
+}
+
+.workspace-card-branch {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  font-weight: 500;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+  flex: 1;
+}
+
+.workspace-card-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5em;
+  font-size: 0.72em;
+  color: var(--text-muted);
+}
+
+.workspace-card-status {
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.workspace-card-status--active {
+  color: var(--accent);
+}
+
+.workspace-card-status--attention {
+  color: var(--warning);
+}
+
+.workspace-card-project {
+  font-size: 0.72em;
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workspace-card--new {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-style: dashed;
+  border-color: var(--border);
+  background: transparent;
+  color: var(--text-muted);
+  gap: 0.5em;
+  min-height: 86px;
+}
+
+.workspace-card--new:hover {
+  border-style: dashed;
+  color: var(--accent);
+  background: var(--accent-muted);
+}
+
+.workspace-card-plus {
+  font-size: 1.2em;
+  line-height: 1;
+}
+
+.workspace-card-new-label {
+  font-size: 0.85em;
+  font-weight: 500;
+}


### PR DESCRIPTION
## Summary
Phase 1 of the Cockpit UX redesign (#327). Replaces the dashboard/home view with a grid of worktree cards.

### What's new
- **WorkspaceGrid component** — responsive card grid showing all worktrees across all projects, grouped by project
- **Status indicators** — green dot (active), amber pulse (needs attention), gray (idle)
- **Sidebar auto-hides** — when no worktree selected, sidebar is hidden so the grid is the main view
- **Cmd+Escape to return** — from a terminal, press Cmd+Escape to go back to the grid (uses Cmd modifier so vim/less still work)

### What's not in this phase
- Live terminal previews on cards (Phase 2)
- Status grouping by state (Phase 2)
- Supervisor agent integration (Phase 3)
- Natural language command bar (Phase 4)

Part of #327

## Test plan
- [ ] Open app → see grid of all worktrees grouped by project
- [ ] Click a worktree card → opens terminal view
- [ ] Press Cmd+Escape from terminal → returns to grid
- [ ] vim/less inside terminal still receives plain Escape
- [ ] Sidebar appears only when a worktree is selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)