### PR TITLE
fix: add updater plugin permissions to ACL capability (#263)

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,6 +7,9 @@
     "core:default",
     "shell:allow-open",
     "dialog:default",
-    "pty:default"
+    "pty:default",
+    "updater:default",
+    "updater:allow-check",
+    "updater:allow-download-and-install"
   ]
 }


### PR DESCRIPTION
## Summary
- Adds `updater:default`, `updater:allow-check`, and `updater:allow-download-and-install` to `src-tauri/capabilities/default.json`
- The Tauri ACL was blocking the updater plugin at runtime with `Command plugin:updater|check not allowed by ACL`

## Test plan
- [ ] Build the app and verify update check no longer throws ACL error
- [ ] Settings → Check for Updates button should work without console errors

Fixes #263