### PR TITLE
fix: compare github_url for registered repo state (#279)

### DIFF
--- a/src/components/RepoList.tsx
+++ b/src/components/RepoList.tsx
@@ -19,8 +19,13 @@ export function RepoList() {
   const [cloningRepo, setCloningRepo] = useState<string | null>(null);
   const [view, setView] = useState<"projects" | "github">("projects");
 
-  const registeredPaths = useMemo(
-    () => new Set(projects.map((p) => p.local_path)),
+  const registeredUrls = useMemo(
+    () =>
+      new Set(
+        projects
+          .map((p) => p.github_url)
+          .filter((u): u is string => u !== null),
+      ),
     [projects],
   );
 
@@ -152,7 +157,7 @@ export function RepoList() {
                     )}
                   </span>
                 </div>
-                {registeredPaths.has(repo.name) ? (
+                {registeredUrls.has(repo.html_url) ? (
                   <span className="repo-registered">Registered</span>
                 ) : (
                   <button


### PR DESCRIPTION
## Summary
- RepoList was building registeredPaths from projects local_path (absolute paths) and checking against repo.name (short name) — never matched
- Fix: build registeredUrls from projects.github_url filtered for non-null, check against repo.html_url
- Both fields are GitHub HTML URLs so they match reliably

## Test plan
- Clone a GitHub repo via RepoList, reopen GitHub tab — should show Registered not Clone
- Repos not yet cloned still show Clone

Fixes #279