### PR TITLE
fix: propagate sidebar collapsed state to parent container (#266)

### DIFF
--- a/src/components/GitHubSidebar.tsx
+++ b/src/components/GitHubSidebar.tsx
@@ -41,6 +41,7 @@ type Tab = "prs" | "issues" | "activity";
 
 interface GitHubSidebarProps {
   projectId: number | null;
+  onCollapsedChange?: (collapsed: boolean) => void;
 }
 
 /* ------------------------------------------------------------------ */
@@ -163,9 +164,20 @@ interface DeviceCodeInfo {
   interval: number;
 }
 
-export function GitHubSidebar({ projectId }: GitHubSidebarProps) {
+export function GitHubSidebar({
+  projectId,
+  onCollapsedChange,
+}: GitHubSidebarProps) {
   const [activeTab, setActiveTab] = useState<Tab>("prs");
   const [collapsed, setCollapsed] = useState(false);
+
+  const handleSetCollapsed = useCallback(
+    (value: boolean) => {
+      setCollapsed(value);
+      onCollapsedChange?.(value);
+    },
+    [onCollapsedChange],
+  );
 
   // Local sign-in state — managed here so we can call fetchData directly on success
   const [patInput, setPatInput] = useState("");
@@ -308,7 +320,7 @@ export function GitHubSidebar({ projectId }: GitHubSidebarProps) {
       <div className="gh-sidebar gh-sidebar--collapsed">
         <button
           className="gh-sidebar__expand-btn"
-          onClick={() => setCollapsed(false)}
+          onClick={() => handleSetCollapsed(false)}
           title="Expand GitHub sidebar"
         >
           {"\u276E"}
@@ -326,7 +338,7 @@ export function GitHubSidebar({ projectId }: GitHubSidebarProps) {
           <div className="gh-sidebar__header-actions">
             <button
               className="gh-sidebar__icon-btn"
-              onClick={() => setCollapsed(true)}
+              onClick={() => handleSetCollapsed(true)}
               title="Collapse"
             >
               {"\u276F"}

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -72,6 +72,7 @@ export function MainLayout({
   >(null);
   const [showSettings, setShowSettings] = useState(false);
   const [showRightSidebar, setShowRightSidebar] = useState(true);
+  const [rightSidebarCollapsed, setRightSidebarCollapsed] = useState(false);
   const dragging = useRef(false);
   const draggingRight = useRef(false);
 
@@ -173,13 +174,23 @@ export function MainLayout({
         <div className="content-area">{children}</div>
         {showRightSidebar && (
           <>
+            {!rightSidebarCollapsed && (
+              <div
+                className="resize-handle resize-handle--right"
+                onMouseDown={handleRightMouseDown}
+              />
+            )}
             <div
-              className="resize-handle resize-handle--right"
-              onMouseDown={handleRightMouseDown}
-            />
-            <div style={{ width: rightSidebarWidth, flexShrink: 0 }}>
+              style={{
+                width: rightSidebarCollapsed ? 28 : rightSidebarWidth,
+                flexShrink: 0,
+              }}
+            >
               <ErrorBoundary name="GitHub Sidebar">
-                <GitHubSidebar projectId={selectedProjectId} />
+                <GitHubSidebar
+                  projectId={selectedProjectId}
+                  onCollapsedChange={setRightSidebarCollapsed}
+                />
               </ErrorBoundary>
             </div>
           </>


### PR DESCRIPTION
## Summary
- When the collapse button inside GitHubSidebar fires, the component renders as 28px wide (gh-sidebar--collapsed) but the parent div in MainLayout kept its full rightSidebarWidth — wasting space and blocking content
- Add onCollapsedChange callback prop to GitHubSidebar
- Track rightSidebarCollapsed in MainLayout; set parent div width to 28px when collapsed, rightSidebarWidth when expanded
- Hide the resize-handle when collapsed (dragging a 28px strip is meaningless)

## Test plan
- [ ] Click the collapse arrow in the GitHub sidebar — content area should expand to fill the freed space
- [ ] Click the expand arrow — sidebar reopens at its previous width
- [ ] Drag resize handle works when expanded, is absent when collapsed

Fixes #266