### PR TITLE
fix: onboarding invoke payload and missing extension icons (#278, #280)

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -9,30 +9,15 @@ async function checkConnection() {
     connected = resp.ok;
     if (connected && !wasConnected) {
       console.log("[Workroot] Connected to daemon");
-      updateIcon(true);
     } else if (!connected && wasConnected) {
       console.log("[Workroot] Disconnected from daemon");
-      updateIcon(false);
     }
   } catch {
     if (connected) {
       console.log("[Workroot] Disconnected from daemon");
     }
     connected = false;
-    updateIcon(false);
   }
-}
-
-function updateIcon(isConnected) {
-  const path = isConnected ? "icons/icon-connected" : "icons/icon-disconnected";
-  chrome.action.setIcon({
-    path: {
-      16: `${path}16.png`,
-      48: `${path}48.png`,
-    },
-  }).catch(() => {
-    // Icons may not exist yet
-  });
 }
 
 // Send data to daemon

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -22,10 +22,5 @@
       "run_at": "document_start"
     }
   ],
-  "devtools_page": "devtools.html",
-  "icons": {
-    "16": "icons/icon16.png",
-    "48": "icons/icon48.png",
-    "128": "icons/icon128.png"
-  }
+  "devtools_page": "devtools.html"
 }

--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -46,7 +46,7 @@ export function OnboardingWizard({ onComplete }: OnboardingWizardProps) {
     setProjectError("");
     try {
       await invoke("register_local_project", {
-        path: projectPath.trim(),
+        localPath: projectPath.trim(),
       });
       setStep("done");
     } catch (err) {


### PR DESCRIPTION
## Summary
Two unrelated bugs bundled together since both are small:

**#280 — onboarding wrong invoke payload**
- OnboardingWizard called `register_local_project` with `{ path }` but the Tauri command and `useProjects` hook both expect `{ localPath }`
- Fix: rename the key in the invoke call

**#278 — browser extension missing icon assets**
- `extension/manifest.json` referenced `icons/icon16/48/128.png` and `background.js` attempted to swap connected/disconnected icons — none of those files exist in the repo
- Fix: remove the `icons` block from manifest.json and remove the `updateIcon` function/calls from background.js so the extension installs without missing-asset errors

## Test plan
- [ ] Onboarding add-project step: entering a valid path and clicking Add Project no longer throws a command error
- [ ] Extension installs in Chrome without console errors about missing icons

Fixes #280
Fixes #278