### PR TITLE
fix: unsupported DB schema error + QuickSwitcher file open (#281, #284)

### DIFF
--- a/src-tauri/src/dbconnect/schema.rs
+++ b/src-tauri/src/dbconnect/schema.rs
@@ -89,18 +89,21 @@ pub struct ForeignKeyInfo {
 }
 
 /// Introspect schema from a database config.
-/// Currently supports SQLite. Postgres and MySQL return stub schemas.
+/// Currently only SQLite is implemented; Postgres and MySQL return an error
+/// so callers can surface a clear "unsupported" message instead of an empty schema.
 pub fn introspect_schema(config: &DbConfig) -> Result<SchemaInfo, String> {
     match config.db_type {
         DbType::Sqlite => introspect_sqlite(config),
-        DbType::Postgres => Ok(SchemaInfo {
-            db_type: "postgres".into(),
-            tables: vec![],
-        }),
-        DbType::Mysql => Ok(SchemaInfo {
-            db_type: "mysql".into(),
-            tables: vec![],
-        }),
+        DbType::Postgres => Err(
+            "PostgreSQL schema introspection is not yet implemented. \
+             Please use a PostgreSQL client to inspect your database schema."
+                .into(),
+        ),
+        DbType::Mysql => Err(
+            "MySQL schema introspection is not yet implemented. \
+             Please use a MySQL client to inspect your database schema."
+                .into(),
+        ),
     }
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1573,6 +1573,11 @@ function AppContent({
         onSwitchBranch={() => {
           closePanel("quickSwitcher");
         }}
+        onOpenFile={(path) => {
+          closePanel("quickSwitcher");
+          setBlameFilePath(path);
+          openPanel("blameView");
+        }}
       />
       <ErrorDiagnosis
         open={panels.errorDiagnosis}

--- a/src/components/QuickSwitcher.tsx
+++ b/src/components/QuickSwitcher.tsx
@@ -11,6 +11,7 @@ interface QuickSwitcherProps {
   selectedProjectId: number | null;
   onSwitchProject: (id: number) => void;
   onSwitchBranch: (name: string) => void;
+  onOpenFile?: (path: string) => void;
 }
 
 interface ProjectItem {
@@ -79,6 +80,7 @@ export function QuickSwitcher({
   selectedProjectId,
   onSwitchProject,
   onSwitchBranch,
+  onOpenFile,
 }: QuickSwitcherProps) {
   const [query, setQuery] = useState("");
   const [projects, setProjects] = useState<ProjectItem[]>([]);
@@ -215,12 +217,12 @@ export function QuickSwitcher({
           onSwitchBranch((item.data as BranchItem).name);
           break;
         case "files":
-          // placeholder — no action for recent files yet
+          onOpenFile?.((item.data as RecentFileItem).path);
           break;
       }
       onClose();
     },
-    [onSwitchProject, onSwitchBranch, onClose],
+    [onSwitchProject, onSwitchBranch, onOpenFile, onClose],
   );
 
   const handleKeyDown = useCallback(


### PR DESCRIPTION
## Summary

**#281 — Postgres/MySQL schema returns empty stub**
- `introspect_schema` was returning `Ok(SchemaInfo { tables: vec![] })` for non-SQLite databases — indistinguishable from a real empty database
- Now returns `Err("... not yet implemented ...")` so the frontend can display a clear unsupported-state message

**#284 — QuickSwitcher file items are inert**
- The `files` case in `handleSelect` was a no-op placeholder; selecting a recent file just closed the modal
- Added `onOpenFile?: (path: string) => void` prop to `QuickSwitcher`
- In App.tsx, wired the handler to open the blame view for the selected file path

## Test plan
- [ ] Connecting a Postgres/MySQL database in DbSchemaTab shows an error message instead of empty tables
- [ ] Selecting a recent file in Quick Switcher opens the blame view for that file

Fixes #281
Fixes #284