### PR TITLE
fix: align plugin runtime UI with backend contract (#277)

### DIFF
--- a/src/components/PluginRuntime.tsx
+++ b/src/components/PluginRuntime.tsx
@@ -71,7 +71,7 @@ export function PluginRuntime({ cwd, onClose }: PluginRuntimeProps) {
         const result = await invoke<ExecutionResult>("execute_plugin", {
           cwd,
           pluginName,
-          args: args.trim() || null,
+          args: args.trim() ? args.trim().split(/\s+/) : [],
         });
         setExecResult(result);
       } catch (e) {
@@ -145,10 +145,10 @@ export function PluginRuntime({ cwd, onClose }: PluginRuntimeProps) {
                 <p>Create a plugin directory with a manifest:</p>
                 <pre className="plrt-code-block">
                   {`.workroot/plugins/my-plugin/
-  manifest.json
+  plugin.json
   index.js (or main.py, run.sh)`}
                 </pre>
-                <p>manifest.json format:</p>
+                <p>plugin.json format:</p>
                 <pre className="plrt-code-block">
                   {`{
   "name": "my-plugin",
@@ -238,7 +238,7 @@ export function PluginRuntime({ cwd, onClose }: PluginRuntimeProps) {
               <input
                 className="plrt-install-input"
                 type="text"
-                placeholder="https://github.com/user/plugin.git"
+                placeholder="https://example.com/my-plugin/plugin.json"
                 value={installUrl}
                 onChange={(e) => setInstallUrl(e.target.value)}
               />


### PR DESCRIPTION
## Summary
Three mismatches between PluginRuntime UI and the Rust backend:

| Issue | Before | After |
|---|---|---|
| args type | `string \| null` sent to backend expecting `Vec<String>` | `args.trim().split(/\s+/)` or `[]` |
| manifest filename | setup instructions showed `manifest.json` | corrected to `plugin.json` (what backend discovers) |
| install URL | placeholder suggested `.git` URL | corrected to direct JSON manifest URL |

## Test plan
- [ ] Running a plugin with CLI-style args (e.g. `--verbose output.txt`) passes them correctly as separate argv entries
- [ ] Setup instructions show plugin.json filename
- [ ] Install URL placeholder shows a JSON manifest URL

Fixes #277