### PR TITLE
fix: GitHub sidebar layout — respect container width and min readable size (#304)

### DIFF
--- a/src/components/GitHubSidebar.tsx
+++ b/src/components/GitHubSidebar.tsx
@@ -600,7 +600,11 @@ function ActivityList({ events }: { events: RepoEvent[] }) {
   return (
     <div className="gh-sidebar__list">
       {events.map((event) => (
-        <div key={event.id} className="gh-sidebar__event">
+        <div
+          key={event.id}
+          className="gh-sidebar__event"
+          title={`${event.actor_login} ${eventDescription(event)}`}
+        >
           <span className="gh-sidebar__event-icon">
             {eventIcon(event.event_type, event.payload_action)}
           </span>

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -9,9 +9,9 @@ const SIDEBAR_MAX = 480;
 const SIDEBAR_DEFAULT = 260;
 const STORAGE_KEY = "workroot:sidebar-width";
 
-const RIGHT_SIDEBAR_MIN = 200;
+const RIGHT_SIDEBAR_MIN = 260;
 const RIGHT_SIDEBAR_MAX = 500;
-const RIGHT_SIDEBAR_DEFAULT = 280;
+const RIGHT_SIDEBAR_DEFAULT = 300;
 const RIGHT_STORAGE_KEY = "workroot:right-sidebar-width";
 
 function getSavedWidth(): number {

--- a/src/styles/github-sidebar.css
+++ b/src/styles/github-sidebar.css
@@ -8,9 +8,9 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  width: 280px;
+  width: 100%;
   background-color: var(--bg-surface);
-  border-left: 1px solid var(--border-subtle);
+  border-left: 1px solid var(--border-strong);
   flex-shrink: 0;
   overflow: hidden;
   animation: ghSidebarFadeIn 0.15s ease-out;


### PR DESCRIPTION
## Summary
Three root-cause fixes for the sidebar overlapping/clipping issue:

1. **CSS width mismatch** — `.gh-sidebar` had `width: 280px` hard-coded, so it ignored the parent container's actual width (set by JS). Changed to `width: 100%` so `MainLayout` controls the pixel width.
2. **Too-narrow minimum** — `RIGHT_SIDEBAR_MIN` raised from 200→260px; `RIGHT_SIDEBAR_DEFAULT` raised from 280→300px so the sidebar stays readable on smaller windows.
3. **Truncated activity descriptions** — Added `title` tooltip to each activity event row (PR/issue items already had them).
4. **Border visibility** — Changed sidebar border from `border-subtle` to `border-strong` for a clearer visual boundary.

## Test plan
- [ ] Drag GitHub sidebar narrower — stops at 260px, text remains readable
- [ ] Hover over an activity event with a long description — full text appears in tooltip
- [ ] Sidebar fills its container exactly (no gap or overflow)

Fixes #304