### PR TITLE
feat: auto-show onboarding wizard for first-time users (#53)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -210,6 +210,14 @@ function AppContent({
         const projects = await invoke<ProjectInfo[]>("list_projects");
         setAllProjects(projects);
 
+        // Auto-show onboarding for first-time users (no projects, never completed)
+        if (
+          projects.length === 0 &&
+          !localStorage.getItem("workroot:onboarded")
+        ) {
+          openPanel("onboarding");
+        }
+
         // Fetch worktrees for each project
         const wtResults = await Promise.all(
           projects.map(async (p) => {
@@ -230,7 +238,7 @@ function AppContent({
       }
     }
     loadSwitcherData();
-  }, [selectedProjectId, selectedWorktreeId]);
+  }, [selectedProjectId, selectedWorktreeId, openPanel]);
 
   // Stable refs for worktree selection actions
   const selectWorktree = useCallback(
@@ -1368,7 +1376,12 @@ function AppContent({
       {panels.onboarding && (
         <div className="panel-overlay">
           <div className="panel-dialog panel-dialog--wide">
-            <OnboardingWizard onComplete={() => closePanel("onboarding")} />
+            <OnboardingWizard
+              onComplete={() => {
+                localStorage.setItem("workroot:onboarded", "true");
+                closePanel("onboarding");
+              }}
+            />
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- On app load, after fetching projects: if no projects exist and `localStorage.workroot:onboarded` is not set, automatically open the onboarding panel
- On onboarding completion, set `localStorage.workroot:onboarded = 'true'` so the wizard never reappears after the user has gone through it once
- Manual access via command palette (`help:onboarding`) still works normally

## Test plan
- [ ] Fresh install (no projects, no localStorage flag): onboarding opens automatically on launch
- [ ] Complete onboarding and relaunch: onboarding does NOT reappear
- [ ] Existing user with projects: onboarding does NOT appear on launch
- [ ] Command palette → Setup Wizard: opens onboarding regardless of flag

Closes #53