### PR TITLE
fix: unsupported DB schema returns error + QuickSwitcher opens recent files (#281, #284)

### DIFF
--- a/src-tauri/src/dbconnect/schema.rs
+++ b/src-tauri/src/dbconnect/schema.rs
@@ -89,18 +89,22 @@ pub struct ForeignKeyInfo {
 }
 
 /// Introspect schema from a database config.
-/// Currently supports SQLite. Postgres and MySQL return stub schemas.
+/// Currently only SQLite is supported. Postgres and MySQL return an explicit
+/// unsupported error so callers can surface a clear message instead of a
+/// misleading empty schema.
 pub fn introspect_schema(config: &DbConfig) -> Result<SchemaInfo, String> {
     match config.db_type {
         DbType::Sqlite => introspect_sqlite(config),
-        DbType::Postgres => Ok(SchemaInfo {
-            db_type: "postgres".into(),
-            tables: vec![],
-        }),
-        DbType::Mysql => Ok(SchemaInfo {
-            db_type: "mysql".into(),
-            tables: vec![],
-        }),
+        DbType::Postgres => Err(
+            "PostgreSQL schema introspection is not yet implemented. \
+             Connect to a SQLite database to use this feature."
+                .into(),
+        ),
+        DbType::Mysql => Err(
+            "MySQL schema introspection is not yet implemented. \
+             Connect to a SQLite database to use this feature."
+                .into(),
+        ),
     }
 }
 

--- a/src-tauri/src/dbconnect/schema.rs
+++ b/src-tauri/src/dbconnect/schema.rs
@@ -95,16 +95,12 @@ pub struct ForeignKeyInfo {
 pub fn introspect_schema(config: &DbConfig) -> Result<SchemaInfo, String> {
     match config.db_type {
         DbType::Sqlite => introspect_sqlite(config),
-        DbType::Postgres => Err(
-            "PostgreSQL schema introspection is not yet implemented. \
+        DbType::Postgres => Err("PostgreSQL schema introspection is not yet implemented. \
              Connect to a SQLite database to use this feature."
-                .into(),
-        ),
-        DbType::Mysql => Err(
-            "MySQL schema introspection is not yet implemented. \
+            .into()),
+        DbType::Mysql => Err("MySQL schema introspection is not yet implemented. \
              Connect to a SQLite database to use this feature."
-                .into(),
-        ),
+            .into()),
     }
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2099,6 +2099,11 @@ function AppContent({
           onSwitchBranch={() => {
             closePanel("quickSwitcher");
           }}
+          onOpenFile={(path: string) => {
+            setBlameFilePath(path);
+            openPanel("blameView");
+            closePanel("quickSwitcher");
+          }}
         />
       </PanelBoundary>
       <PanelBoundary name="ErrorDiagnosis">

--- a/src/components/QuickSwitcher.tsx
+++ b/src/components/QuickSwitcher.tsx
@@ -12,6 +12,7 @@ interface QuickSwitcherProps {
   selectedProjectId: number | null;
   onSwitchProject: (id: number) => void;
   onSwitchBranch: (name: string) => void;
+  onOpenFile?: (path: string) => void;
 }
 
 interface ProjectItem {
@@ -80,6 +81,7 @@ export function QuickSwitcher({
   selectedProjectId,
   onSwitchProject,
   onSwitchBranch,
+  onOpenFile,
 }: QuickSwitcherProps) {
   const [query, setQuery] = useState("");
   const [projects, setProjects] = useState<ProjectItem[]>([]);
@@ -216,12 +218,12 @@ export function QuickSwitcher({
           onSwitchBranch((item.data as BranchItem).name);
           break;
         case "files":
-          // placeholder — no action for recent files yet
+          onOpenFile?.((item.data as RecentFileItem).path);
           break;
       }
       onClose();
     },
-    [onSwitchProject, onSwitchBranch, onClose],
+    [onSwitchProject, onSwitchBranch, onOpenFile, onClose],
   );
 
   const handleKeyDown = useCallback(


### PR DESCRIPTION
Two independent UI/backend fixes:

**#281**: Postgres and MySQL `introspect_schema` now return explicit error messages instead of empty stub schemas, so callers can surface a clear unsupported message.

**#284**: QuickSwitcher `case "files"` now calls the new `onOpenFile` prop (wired to open the blame view) instead of being a no-op placeholder.

Fixes #281, fixes #284