### PR TITLE
fix: consolidate CSS imports from main.tsx into styles.css (#282)

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,12 +2,6 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./styles.css";
-import "./styles/sidebar.css";
-import "./styles/terminal.css";
-import "./styles/command-palette.css";
-import "./styles/dashboard.css";
-import "./styles/status-bar.css";
-import "./styles/project-tabs.css";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,4 +1,10 @@
 @import "tailwindcss";
+@import "./styles/sidebar.css";
+@import "./styles/terminal.css";
+@import "./styles/command-palette.css";
+@import "./styles/dashboard.css";
+@import "./styles/status-bar.css";
+@import "./styles/project-tabs.css";
 
 /* ==========================================================
    Design System — Workroot


### PR DESCRIPTION
Moves the 6 remaining CSS imports from main.tsx into styles.css as @import rules. This keeps main.tsx as a pure JS entry point and lets the CSS bundler handle stylesheet ordering.

Fixes #282