### PR TITLE
feat: auto-show onboarding wizard for first-time users (#53)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -548,6 +548,14 @@ function AppContent({
         const projects = await invoke<ProjectInfo[]>("list_projects");
         setAllProjects(projects);
 
+        // Auto-show onboarding for first-time users with no projects
+        if (
+          projects.length === 0 &&
+          !localStorage.getItem("workroot:onboarded")
+        ) {
+          openPanel("onboarding");
+        }
+
         // Fetch worktrees for each project
         const wtResults = await Promise.all(
           projects.map(async (p) => {
@@ -568,7 +576,7 @@ function AppContent({
       }
     }
     loadSwitcherData();
-  }, [selectedProjectId, selectedWorktreeId]);
+  }, [selectedProjectId, selectedWorktreeId, openPanel]);
 
   // Stable refs for worktree selection actions
   const selectWorktree = useCallback(
@@ -1867,7 +1875,10 @@ function AppContent({
               onClick={(e) => e.stopPropagation()}
             >
               <OnboardingWizard
-                onComplete={() => closePanel("onboarding")}
+                onComplete={() => {
+                  localStorage.setItem("workroot:onboarded", "true");
+                  closePanel("onboarding");
+                }}
                 onClose={() => closePanel("onboarding")}
               />
             </div>


### PR DESCRIPTION
After `list_projects` loads on startup, if the user has zero projects and hasn't been onboarded before (checked via `localStorage.getItem('workroot:onboarded')`), the onboarding panel is automatically opened.

When the user completes onboarding, `workroot:onboarded` is set so the wizard never auto-opens again.

Fixes #53