### PR TITLE
feat: surface CLAUDE.md context file in Memory panel (#72)

### DIFF
--- a/src-tauri/src/claudemd/mod.rs
+++ b/src-tauri/src/claudemd/mod.rs
@@ -1,7 +1,8 @@
 pub mod template;
 pub mod watcher;
 
-use crate::db::AppDb;
+use crate::db::{queries, AppDb};
+use std::path::Path;
 use tauri::State;
 
 /// Tauri command: generate and write CLAUDE.md for a worktree.
@@ -14,4 +15,21 @@ pub fn generate_worktree_claude_md(
     let content = template::generate_claude_md(&conn, worktree_id)?;
     template::write_claude_md(&conn, worktree_id, &content)?;
     Ok(content)
+}
+
+/// Tauri command: read CLAUDE.md content for a worktree (returns empty string if not found).
+#[tauri::command]
+pub fn read_worktree_claude_md(db: State<'_, AppDb>, worktree_id: i64) -> Result<String, String> {
+    let conn = db.0.lock().map_err(|e| format!("DB lock error: {}", e))?;
+    let worktree = queries::get_worktree(&conn, worktree_id)
+        .map_err(|e| format!("DB error: {}", e))?
+        .ok_or("Worktree not found")?;
+
+    let claude_path = Path::new(&worktree.path).join("CLAUDE.md");
+    if claude_path.exists() {
+        std::fs::read_to_string(&claude_path)
+            .map_err(|e| format!("Failed to read CLAUDE.md: {}", e))
+    } else {
+        Ok(String::new())
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -176,6 +176,7 @@ pub fn run() {
             proxy::switch::get_active_project,
             proxy::switch::clear_active_project,
             claudemd::generate_worktree_claude_md,
+            claudemd::read_worktree_claude_md,
             shell::install_shell_hook,
             shell::uninstall_shell_hook,
             shell::get_shell_history,

--- a/src/components/MemoryTab.tsx
+++ b/src/components/MemoryTab.tsx
@@ -44,14 +44,52 @@ interface MemoryTabProps {
 }
 
 export function MemoryTab({ worktreeId }: MemoryTabProps) {
+  const [activeTab, setActiveTab] = useState<"notes" | "context">("notes");
   const [notes, setNotes] = useState<MemoryEntry[]>([]);
   const [searchQuery, setSearchQuery] = useState("");
   const [categoryFilter, setCategoryFilter] = useState<Category | "all">("all");
   const [showEditor, setShowEditor] = useState(false);
   const [editingNote, setEditingNote] = useState<MemoryEntry | null>(null);
   const [deleteConfirm, setDeleteConfirm] = useState<number | null>(null);
+  const [contextContent, setContextContent] = useState<string>("");
+  const [contextLoading, setContextLoading] = useState(false);
+  const [contextGenerating, setContextGenerating] = useState(false);
   const searchTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const loadNotesRef = useRef<() => void>(() => {});
+
+  const loadContextFile = useCallback(async () => {
+    setContextLoading(true);
+    try {
+      const content = await invoke<string>("read_worktree_claude_md", {
+        worktreeId,
+      });
+      setContextContent(content);
+    } catch (err) {
+      console.error("Failed to load CLAUDE.md:", err);
+    } finally {
+      setContextLoading(false);
+    }
+  }, [worktreeId]);
+
+  const handleGenerateContext = async () => {
+    setContextGenerating(true);
+    try {
+      const content = await invoke<string>("generate_worktree_claude_md", {
+        worktreeId,
+      });
+      setContextContent(content);
+    } catch (err) {
+      console.error("Failed to generate CLAUDE.md:", err);
+    } finally {
+      setContextGenerating(false);
+    }
+  };
+
+  useEffect(() => {
+    if (activeTab === "context") {
+      loadContextFile();
+    }
+  }, [activeTab, loadContextFile]);
 
   const loadNotes = useCallback(async () => {
     try {
@@ -136,6 +174,53 @@ export function MemoryTab({ worktreeId }: MemoryTabProps) {
 
   return (
     <div className="memory-tab">
+      <div className="memory-tab-switcher">
+        <button
+          className={`memory-tab-btn ${activeTab === "notes" ? "active" : ""}`}
+          onClick={() => setActiveTab("notes")}
+        >
+          Notes
+        </button>
+        <button
+          className={`memory-tab-btn ${activeTab === "context" ? "active" : ""}`}
+          onClick={() => setActiveTab("context")}
+        >
+          Context File
+        </button>
+      </div>
+
+      {activeTab === "context" && (
+        <div className="memory-context">
+          <div className="memory-context-header">
+            <span className="memory-context-label">CLAUDE.md</span>
+            <button
+              className="memory-add-btn"
+              onClick={handleGenerateContext}
+              disabled={contextGenerating}
+            >
+              {contextGenerating ? "Generating..." : "Regenerate"}
+            </button>
+          </div>
+          {contextLoading ? (
+            <div className="memory-empty">
+              <p>Loading...</p>
+            </div>
+          ) : contextContent ? (
+            <pre className="memory-context-content">{contextContent}</pre>
+          ) : (
+            <div className="memory-empty">
+              <p>No CLAUDE.md found for this worktree</p>
+              <p className="memory-empty-hint">
+                Click Regenerate to create a context file from project metadata
+                and memory notes
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+
+      {activeTab === "notes" && (
+      <>
       <div className="memory-toolbar">
         <input
           type="text"
@@ -255,6 +340,8 @@ export function MemoryTab({ worktreeId }: MemoryTabProps) {
           </div>
         ))}
       </div>
+      </>
+      )}
     </div>
   );
 }

--- a/src/components/MemoryTab.tsx
+++ b/src/components/MemoryTab.tsx
@@ -220,127 +220,130 @@ export function MemoryTab({ worktreeId }: MemoryTabProps) {
       )}
 
       {activeTab === "notes" && (
-      <>
-      <div className="memory-toolbar">
-        <input
-          type="text"
-          className="memory-search"
-          placeholder="Search notes..."
-          value={searchQuery}
-          onChange={(e) => setSearchQuery(e.target.value)}
-        />
-        <div className="memory-filters">
-          <button
-            className={`memory-filter ${categoryFilter === "all" ? "active" : ""}`}
-            onClick={() => setCategoryFilter("all")}
-          >
-            All
-          </button>
-          {CATEGORIES.map((cat) => (
-            <button
-              key={cat}
-              className={`memory-filter ${categoryFilter === cat ? "active" : ""}`}
-              style={
-                categoryFilter === cat
-                  ? { borderColor: CATEGORY_COLORS[cat] }
-                  : undefined
-              }
-              onClick={() => setCategoryFilter(cat)}
-            >
-              {CATEGORY_LABELS[cat]}
-            </button>
-          ))}
-        </div>
-        <button
-          className="memory-add-btn"
-          onClick={() => {
-            setEditingNote(null);
-            setShowEditor(true);
-          }}
-        >
-          + Add Note
-        </button>
-      </div>
-
-      {showEditor && (
-        <NoteEditor
-          initialContent={editingNote?.content || ""}
-          initialCategory={editingNote?.category || "note"}
-          onSave={handleSave}
-          onCancel={() => {
-            setShowEditor(false);
-            setEditingNote(null);
-          }}
-        />
-      )}
-
-      <div className="memory-list">
-        {filteredNotes.length === 0 && !showEditor && (
-          <div className="memory-empty">
-            <p>No notes yet</p>
-            <p className="memory-empty-hint">
-              Add notes to capture context, decisions, and dead ends
-            </p>
-          </div>
-        )}
-
-        {filteredNotes.map((note) => (
-          <div key={note.id} className="memory-note">
-            <div className="memory-note-header">
-              <span
-                className="memory-category-badge"
-                style={{ color: CATEGORY_COLORS[note.category as Category] }}
+        <>
+          <div className="memory-toolbar">
+            <input
+              type="text"
+              className="memory-search"
+              placeholder="Search notes..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+            />
+            <div className="memory-filters">
+              <button
+                className={`memory-filter ${categoryFilter === "all" ? "active" : ""}`}
+                onClick={() => setCategoryFilter("all")}
               >
-                {CATEGORY_LABELS[note.category as Category] || note.category}
-              </span>
-              <span className="memory-note-time" title={note.created_at}>
-                {relativeTime(note.created_at)}
-              </span>
-              {note.score !== null && note.score !== undefined && (
-                <span className="memory-note-score">
-                  {(note.score * 100).toFixed(0)}% match
-                </span>
-              )}
-              <div className="memory-note-actions">
+                All
+              </button>
+              {CATEGORIES.map((cat) => (
                 <button
-                  className="memory-action-btn"
-                  onClick={() => {
-                    setEditingNote(note);
-                    setShowEditor(true);
-                  }}
+                  key={cat}
+                  className={`memory-filter ${categoryFilter === cat ? "active" : ""}`}
+                  style={
+                    categoryFilter === cat
+                      ? { borderColor: CATEGORY_COLORS[cat] }
+                      : undefined
+                  }
+                  onClick={() => setCategoryFilter(cat)}
                 >
-                  Edit
+                  {CATEGORY_LABELS[cat]}
                 </button>
-                {deleteConfirm === note.id ? (
-                  <>
-                    <button
-                      className="memory-action-btn danger"
-                      onClick={() => handleDelete(note.id)}
-                    >
-                      Confirm
-                    </button>
+              ))}
+            </div>
+            <button
+              className="memory-add-btn"
+              onClick={() => {
+                setEditingNote(null);
+                setShowEditor(true);
+              }}
+            >
+              + Add Note
+            </button>
+          </div>
+
+          {showEditor && (
+            <NoteEditor
+              initialContent={editingNote?.content || ""}
+              initialCategory={editingNote?.category || "note"}
+              onSave={handleSave}
+              onCancel={() => {
+                setShowEditor(false);
+                setEditingNote(null);
+              }}
+            />
+          )}
+
+          <div className="memory-list">
+            {filteredNotes.length === 0 && !showEditor && (
+              <div className="memory-empty">
+                <p>No notes yet</p>
+                <p className="memory-empty-hint">
+                  Add notes to capture context, decisions, and dead ends
+                </p>
+              </div>
+            )}
+
+            {filteredNotes.map((note) => (
+              <div key={note.id} className="memory-note">
+                <div className="memory-note-header">
+                  <span
+                    className="memory-category-badge"
+                    style={{
+                      color: CATEGORY_COLORS[note.category as Category],
+                    }}
+                  >
+                    {CATEGORY_LABELS[note.category as Category] ||
+                      note.category}
+                  </span>
+                  <span className="memory-note-time" title={note.created_at}>
+                    {relativeTime(note.created_at)}
+                  </span>
+                  {note.score !== null && note.score !== undefined && (
+                    <span className="memory-note-score">
+                      {(note.score * 100).toFixed(0)}% match
+                    </span>
+                  )}
+                  <div className="memory-note-actions">
                     <button
                       className="memory-action-btn"
-                      onClick={() => setDeleteConfirm(null)}
+                      onClick={() => {
+                        setEditingNote(note);
+                        setShowEditor(true);
+                      }}
                     >
-                      Cancel
+                      Edit
                     </button>
-                  </>
-                ) : (
-                  <button
-                    className="memory-action-btn"
-                    onClick={() => setDeleteConfirm(note.id)}
-                  >
-                    Delete
-                  </button>
-                )}
+                    {deleteConfirm === note.id ? (
+                      <>
+                        <button
+                          className="memory-action-btn danger"
+                          onClick={() => handleDelete(note.id)}
+                        >
+                          Confirm
+                        </button>
+                        <button
+                          className="memory-action-btn"
+                          onClick={() => setDeleteConfirm(null)}
+                        >
+                          Cancel
+                        </button>
+                      </>
+                    ) : (
+                      <button
+                        className="memory-action-btn"
+                        onClick={() => setDeleteConfirm(note.id)}
+                      >
+                        Delete
+                      </button>
+                    )}
+                  </div>
+                </div>
+                <div className="memory-note-content">{note.content}</div>
               </div>
-            </div>
-            <div className="memory-note-content">{note.content}</div>
+            ))}
           </div>
-        ))}
-      </div>
-      </>
+        </>
       )}
     </div>
   );

--- a/src/styles/memory-tab.css
+++ b/src/styles/memory-tab.css
@@ -245,7 +245,9 @@
   border-bottom: 2px solid transparent;
   color: var(--text-muted, #888);
   cursor: pointer;
-  transition: color 0.12s, border-color 0.12s;
+  transition:
+    color 0.12s,
+    border-color 0.12s;
 }
 
 .memory-tab-btn:hover {

--- a/src/styles/memory-tab.css
+++ b/src/styles/memory-tab.css
@@ -227,3 +227,69 @@
   opacity: 0.5;
   cursor: not-allowed;
 }
+
+/* Tab switcher */
+.memory-tab-switcher {
+  display: flex;
+  border-bottom: 1px solid var(--border-subtle, #2a2a3e);
+  flex-shrink: 0;
+}
+
+.memory-tab-btn {
+  flex: 1;
+  padding: 6px 0;
+  font-size: 12px;
+  font-weight: 500;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--text-muted, #888);
+  cursor: pointer;
+  transition: color 0.12s, border-color 0.12s;
+}
+
+.memory-tab-btn:hover {
+  color: var(--text-secondary);
+}
+
+.memory-tab-btn.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* Context File */
+.memory-context {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.memory-context-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--border-subtle, #2a2a3e);
+  flex-shrink: 0;
+}
+
+.memory-context-label {
+  font-family: var(--font-mono, monospace);
+  font-size: 12px;
+  color: var(--text-muted, #888);
+}
+
+.memory-context-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px;
+  font-size: 12px;
+  font-family: var(--font-mono, monospace);
+  color: var(--text-secondary);
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin: 0;
+  line-height: 1.5;
+}


### PR DESCRIPTION
Adds a Context File tab to the Memory panel that shows the worktree's CLAUDE.md content and a Regenerate button.

**Backend**: adds `read_worktree_claude_md` Tauri command that reads the CLAUDE.md file from the worktree path (returning empty string if not yet generated).

**Frontend**: MemoryTab gains a "Notes" / "Context File" tab switcher. The Context File tab reads the file on load and shows either the markdown content or a prompt to regenerate.

Fixes #72