### PR TITLE
fix: replace useMemo with useEffect for command registration side effect (#282)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1219,7 +1219,7 @@ function AppContent({
   ]);
 
   // Register commands whenever they change
-  useMemo(() => register(commands), [commands, register]);
+  useEffect(() => register(commands), [commands, register]);
 
   // Global keyboard shortcuts
   const shortcuts = useMemo(


### PR DESCRIPTION
Line 1222 of App.tsx used `useMemo` to call `register(commands)` as a side effect. `useMemo` is for deriving values, not for side effects — React may skip or re-run memos unpredictably. Changed to `useEffect` which is the correct hook for running side effects in response to dependency changes.

Partially fixes #282