### PR TITLE
fix: propagate GitHubSidebar collapsed state to parent via onCollapsedChange (#266)

### DIFF
--- a/src/components/GitHubSidebar.tsx
+++ b/src/components/GitHubSidebar.tsx
@@ -43,6 +43,7 @@ type Tab = "prs" | "issues" | "activity";
 interface GitHubSidebarProps {
   projectId: number | null;
   width?: number;
+  onCollapsedChange?: (collapsed: boolean) => void;
 }
 
 /* ------------------------------------------------------------------ */
@@ -167,9 +168,21 @@ interface DeviceCodeInfo {
   interval: number;
 }
 
-export function GitHubSidebar({ projectId, width }: GitHubSidebarProps) {
+export function GitHubSidebar({
+  projectId,
+  width,
+  onCollapsedChange,
+}: GitHubSidebarProps) {
   const [activeTab, setActiveTab] = useState<Tab>("prs");
   const [collapsed, setCollapsed] = useState(false);
+
+  const handleSetCollapsed = useCallback(
+    (value: boolean) => {
+      setCollapsed(value);
+      onCollapsedChange?.(value);
+    },
+    [onCollapsedChange],
+  );
 
   // Local sign-in state — managed here so we can call fetchData directly on success
   const [patInput, setPatInput] = useState("");
@@ -349,7 +362,7 @@ export function GitHubSidebar({ projectId, width }: GitHubSidebarProps) {
       <div className="gh-sidebar gh-sidebar--collapsed">
         <button
           className="gh-sidebar__expand-btn"
-          onClick={() => setCollapsed(false)}
+          onClick={() => handleSetCollapsed(false)}
           title="Expand GitHub sidebar"
         >
           {"\u276E"}
@@ -367,7 +380,7 @@ export function GitHubSidebar({ projectId, width }: GitHubSidebarProps) {
           <div className="gh-sidebar__header-actions">
             <button
               className="gh-sidebar__icon-btn"
-              onClick={() => setCollapsed(true)}
+              onClick={() => handleSetCollapsed(true)}
               title="Collapse"
             >
               {"\u276F"}
@@ -395,7 +408,7 @@ export function GitHubSidebar({ projectId, width }: GitHubSidebarProps) {
           </button>
           <button
             className="gh-sidebar__icon-btn"
-            onClick={() => setCollapsed(true)}
+            onClick={() => handleSetCollapsed(true)}
             title="Collapse"
           >
             {"\u276F"}


### PR DESCRIPTION
Adds `onCollapsedChange?: (collapsed: boolean) => void` prop to `GitHubSidebar`. All `setCollapsed` calls are replaced with `handleSetCollapsed` which calls both the internal state setter and the optional callback.

This allows parent containers to track collapsed state and adjust their own layout (e.g., reduce width from 300px to 28px when collapsed).

Fixes #266