### PR TITLE
chore: bump version to 0.1.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.1.22",
+  "version": "0.1.23",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.1.22"
+version = "0.1.23"
 edition = "2021"
 authors = ["Saurav Panda <saurav@workroot.dev>"]
 description = "A local-first developer workspace for managing projects, terminals, and Git workflows."

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Version bump to 0.1.23 for release.

## Changes since 0.1.22

Bug fixes:
- Fix updater plugin permissions in ACL capability (#263)
- Fix onboarding invoke payload and extension icons (#278, #280)
- Fix repo registered state comparison (#279)
- Align plugin runtime UI with backend contract (#277)
- Add vitest test scripts to package.json (#283)
- DB schema returns explicit error for unsupported databases (#281)
- QuickSwitcher opens recent files instead of no-op (#284)
- Consolidate CSS imports from main.tsx into styles.css (#282)
- GitHub sidebar respects container width (#304)

Features:
- Auto-show onboarding wizard for first-time users (#53)
- Surface CLAUDE.md context file in Memory panel (#72)