### PR TITLE
feat: Mission Control — filter tabs, activity sort, Cmd+1-9 shortcuts (#313)

### DIFF
--- a/src/components/WorkspaceGrid.tsx
+++ b/src/components/WorkspaceGrid.tsx
@@ -25,7 +25,15 @@ interface WorkspaceGridProps {
   onNewWorktree?: (projectId: number) => void;
 }
 
-type CardStatus = "active" | "attention" | "idle";
+type CardStatus = "current" | "attention" | "done" | "idle";
+type FilterTab = "all" | "attention" | "active" | "done";
+
+const STATUS_RANK: Record<CardStatus, number> = {
+  attention: 0,
+  current: 1,
+  done: 2,
+  idle: 3,
+};
 
 function formatPath(path: string): string {
   return path.replace(/^\/Users\/[^/]+/, "~");
@@ -39,6 +47,8 @@ export function WorkspaceGrid({
 }: WorkspaceGridProps) {
   const { selectedWorktreeId, agentNeedsAttentionIds, agentDoneWorktreeIds } =
     useUiStore();
+
+  const [filterTab, setFilterTab] = useState<FilterTab>("all");
 
   // Fallback in case props are empty — load projects + worktrees ourselves.
   const [fallbackProjects, setFallbackProjects] = useState<ProjectInfo[]>([]);
@@ -83,6 +93,38 @@ export function WorkspaceGrid({
   const activeWorktrees =
     worktrees.length > 0 || projects.length > 0 ? worktrees : fallbackWorktrees;
 
+  const statusFor = useCallback(
+    (wt: WorktreeInfo): CardStatus => {
+      if (agentNeedsAttentionIds.has(wt.id)) return "attention";
+      if (selectedWorktreeId === wt.id) return "current";
+      if (agentDoneWorktreeIds.has(wt.id)) return "done";
+      return "idle";
+    },
+    [selectedWorktreeId, agentNeedsAttentionIds, agentDoneWorktreeIds],
+  );
+
+  // All worktrees sorted by activity (attention > current > done > idle),
+  // used for Cmd+1-9 quick-switch.
+  const sortedWorktrees = useMemo(
+    () =>
+      [...activeWorktrees].sort(
+        (a, b) => STATUS_RANK[statusFor(a)] - STATUS_RANK[statusFor(b)],
+      ),
+    [activeWorktrees, statusFor],
+  );
+
+  // Filtered worktrees for the active tab
+  const filteredWorktrees = useMemo(() => {
+    if (filterTab === "all") return sortedWorktrees;
+    if (filterTab === "attention")
+      return sortedWorktrees.filter((wt) => statusFor(wt) === "attention");
+    if (filterTab === "active")
+      return sortedWorktrees.filter((wt) => statusFor(wt) === "current");
+    if (filterTab === "done")
+      return sortedWorktrees.filter((wt) => statusFor(wt) === "done");
+    return sortedWorktrees;
+  }, [sortedWorktrees, filterTab, statusFor]);
+
   const grouped = useMemo(() => {
     const byProject = new Map<
       number,
@@ -94,43 +136,123 @@ export function WorkspaceGrid({
     for (const p of activeProjects) {
       byProject.set(p.id, { project: p, worktrees: [] });
     }
-    for (const wt of activeWorktrees) {
+    for (const wt of filteredWorktrees) {
       const entry = byProject.get(wt.project_id);
       if (entry) entry.worktrees.push(wt);
     }
-    return Array.from(byProject.values());
-  }, [activeProjects, activeWorktrees]);
+    // Only include projects that have visible worktrees in this filter
+    return Array.from(byProject.values()).filter((g) =>
+      filterTab === "all" ? true : g.worktrees.length > 0,
+    );
+  }, [activeProjects, filteredWorktrees, filterTab]);
 
-  const statusFor = useCallback(
-    (wt: WorktreeInfo): CardStatus => {
-      if (agentNeedsAttentionIds.has(wt.id)) return "attention";
-      if (selectedWorktreeId === wt.id || agentDoneWorktreeIds.has(wt.id)) {
-        return "active";
-      }
-      return "idle";
-    },
-    [selectedWorktreeId, agentNeedsAttentionIds, agentDoneWorktreeIds],
-  );
+  // Cmd+1-9: jump to the nth worktree in activity order
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (!e.metaKey) return;
+      const n = parseInt(e.key, 10);
+      if (isNaN(n) || n < 1 || n > 9) return;
+      const target = sortedWorktrees[n - 1];
+      if (!target) return;
+      e.preventDefault();
+      onSelectWorktree(target);
+    };
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [sortedWorktrees, onSelectWorktree]);
 
   const totalWorktrees = activeWorktrees.length;
+  const attentionCount = activeWorktrees.filter(
+    (wt) => statusFor(wt) === "attention",
+  ).length;
+  const doneCount = activeWorktrees.filter(
+    (wt) => statusFor(wt) === "done",
+  ).length;
 
   return (
     <div className="workspace-grid-root">
       <div className="workspace-grid-inner">
         <div className="workspace-grid-header">
           <div>
-            <h1 className="workspace-grid-title">Workspaces</h1>
+            <h1 className="workspace-grid-title">Mission Control</h1>
             <div className="workspace-grid-subtitle">
               {totalWorktrees === 0
                 ? "No worktrees yet. Create one to get started."
                 : `${totalWorktrees} worktree${totalWorktrees === 1 ? "" : "s"} across ${activeProjects.length} project${activeProjects.length === 1 ? "" : "s"}`}
             </div>
           </div>
+          {totalWorktrees > 0 && (
+            <div className="workspace-filter-tabs">
+              <button
+                type="button"
+                className={
+                  "workspace-filter-tab" +
+                  (filterTab === "all" ? " workspace-filter-tab--active" : "")
+                }
+                onClick={() => setFilterTab("all")}
+              >
+                All
+                <span className="workspace-filter-count">{totalWorktrees}</span>
+              </button>
+              {attentionCount > 0 && (
+                <button
+                  type="button"
+                  className={
+                    "workspace-filter-tab workspace-filter-tab--attention" +
+                    (filterTab === "attention"
+                      ? " workspace-filter-tab--active"
+                      : "")
+                  }
+                  onClick={() => setFilterTab("attention")}
+                >
+                  Attention
+                  <span className="workspace-filter-count workspace-filter-count--attention">
+                    {attentionCount}
+                  </span>
+                </button>
+              )}
+              <button
+                type="button"
+                className={
+                  "workspace-filter-tab" +
+                  (filterTab === "active"
+                    ? " workspace-filter-tab--active"
+                    : "")
+                }
+                onClick={() => setFilterTab("active")}
+              >
+                Active
+              </button>
+              {doneCount > 0 && (
+                <button
+                  type="button"
+                  className={
+                    "workspace-filter-tab" +
+                    (filterTab === "done"
+                      ? " workspace-filter-tab--active"
+                      : "")
+                  }
+                  onClick={() => setFilterTab("done")}
+                >
+                  Done
+                  <span className="workspace-filter-count workspace-filter-count--done">
+                    {doneCount}
+                  </span>
+                </button>
+              )}
+            </div>
+          )}
         </div>
 
-        {grouped.length === 0 && (
+        {grouped.length === 0 && filterTab === "all" && (
           <div className="workspace-grid-empty">
             No projects registered. Add a project to begin.
+          </div>
+        )}
+
+        {grouped.length === 0 && filterTab !== "all" && (
+          <div className="workspace-grid-empty">
+            No worktrees match this filter.
           </div>
         )}
 
@@ -146,28 +268,41 @@ export function WorkspaceGrid({
             <div className="workspace-grid">
               {wts.map((wt) => {
                 const status = statusFor(wt);
+                const idx = sortedWorktrees.indexOf(wt);
+                const shortcutHint = idx >= 0 && idx < 9 ? `⌘${idx + 1}` : null;
                 return (
                   <button
                     key={wt.id}
                     type="button"
-                    className="workspace-card"
+                    className={
+                      "workspace-card" +
+                      (status === "current" ? " workspace-card--current" : "")
+                    }
                     onClick={() => onSelectWorktree(wt)}
+                    title={shortcutHint ? `Open (${shortcutHint})` : undefined}
                   >
                     <div className="workspace-card-top">
                       <span
                         className={
                           "workspace-card-dot" +
-                          (status === "active"
+                          (status === "current"
                             ? " workspace-card-dot--active"
                             : status === "attention"
                               ? " workspace-card-dot--attention"
-                              : "")
+                              : status === "done"
+                                ? " workspace-card-dot--done"
+                                : "")
                         }
                         aria-hidden
                       />
                       <span className="workspace-card-branch">
                         {wt.branch_name}
                       </span>
+                      {shortcutHint && (
+                        <span className="workspace-card-shortcut">
+                          {shortcutHint}
+                        </span>
+                      )}
                     </div>
                     <div className="workspace-card-meta">
                       <span className="workspace-card-project">
@@ -176,32 +311,38 @@ export function WorkspaceGrid({
                       <span
                         className={
                           "workspace-card-status" +
-                          (status === "active"
+                          (status === "current"
                             ? " workspace-card-status--active"
                             : status === "attention"
                               ? " workspace-card-status--attention"
-                              : "")
+                              : status === "done"
+                                ? " workspace-card-status--done"
+                                : "")
                         }
                       >
-                        {status === "active"
-                          ? "Active"
+                        {status === "current"
+                          ? "Open"
                           : status === "attention"
                             ? "Attention"
-                            : "Idle"}
+                            : status === "done"
+                              ? "Done"
+                              : "Idle"}
                       </span>
                     </div>
                   </button>
                 );
               })}
-              <button
-                type="button"
-                className="workspace-card workspace-card--new"
-                onClick={() => onNewWorktree?.(project.id)}
-                aria-label={`New worktree in ${project.name}`}
-              >
-                <span className="workspace-card-plus">+</span>
-                <span className="workspace-card-new-label">New worktree</span>
-              </button>
+              {filterTab === "all" && (
+                <button
+                  type="button"
+                  className="workspace-card workspace-card--new"
+                  onClick={() => onNewWorktree?.(project.id)}
+                  aria-label={`New worktree in ${project.name}`}
+                >
+                  <span className="workspace-card-plus">+</span>
+                  <span className="workspace-card-new-label">New worktree</span>
+                </button>
+              )}
             </div>
           </div>
         ))}

--- a/src/styles/workspace-grid.css
+++ b/src/styles/workspace-grid.css
@@ -240,3 +240,103 @@
   font-size: 0.85em;
   font-weight: 500;
 }
+
+/* Current-worktree card highlight */
+.workspace-card--current {
+  border-color: var(--accent-muted);
+  background: color-mix(in srgb, var(--accent) 4%, var(--bg-surface));
+}
+
+/* "Done" status dot */
+.workspace-card-dot--done {
+  background: var(--success, #10b981);
+  box-shadow: 0 0 0 3px rgba(16, 185, 129, 0.15);
+}
+
+/* "Done" status label */
+.workspace-card-status--done {
+  color: var(--success, #10b981);
+}
+
+/* Shortcut hint badge */
+.workspace-card-shortcut {
+  font-family: var(--font-mono);
+  font-size: 0.68em;
+  color: var(--text-muted);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: 3px;
+  padding: 0 4px;
+  line-height: 1.6;
+  flex-shrink: 0;
+  margin-left: auto;
+  opacity: 0.5;
+}
+
+.workspace-card:hover .workspace-card-shortcut {
+  opacity: 1;
+  color: var(--accent);
+  border-color: var(--accent-muted);
+}
+
+/* Filter tabs */
+.workspace-filter-tabs {
+  display: flex;
+  gap: 0.25em;
+  align-items: center;
+}
+
+.workspace-filter-tab {
+  display: flex;
+  align-items: center;
+  gap: 0.4em;
+  padding: 0.3em 0.75em;
+  border-radius: var(--radius);
+  border: 1px solid var(--border-subtle);
+  background: transparent;
+  color: var(--text-muted);
+  font: inherit;
+  font-size: 0.78em;
+  cursor: pointer;
+  transition:
+    color var(--transition-fast),
+    background-color var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.workspace-filter-tab:hover {
+  color: var(--text-primary);
+  border-color: var(--border);
+}
+
+.workspace-filter-tab--active {
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  border-color: var(--accent-muted);
+}
+
+.workspace-filter-tab--attention {
+  color: var(--warning);
+}
+
+.workspace-filter-count {
+  font-size: 0.85em;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: 10px;
+  padding: 0 5px;
+  line-height: 1.5;
+  font-variant-numeric: tabular-nums;
+}
+
+.workspace-filter-count--attention {
+  background: rgba(245, 158, 11, 0.12);
+  border-color: rgba(245, 158, 11, 0.25);
+  color: var(--warning);
+}
+
+.workspace-filter-count--done {
+  background: rgba(16, 185, 129, 0.1);
+  border-color: rgba(16, 185, 129, 0.2);
+  color: var(--success, #10b981);
+}


### PR DESCRIPTION
## Summary
- Renames Workspaces view to **Mission Control**
- Adds a distinct `done` status (separate from `active/current`) for worktrees where an agent completed
- Worktrees now sort by activity priority: **attention → current → done → idle** — most important surfaces to top
- **Filter tabs**: All | Attention | Active | Done (attention/done tabs only appear when relevant)
- **Cmd+1-9** keyboard shortcuts to jump directly to the nth worktree by activity order
- Shortcut hint (⌘N badge) shown on each card, visible on hover

## Test plan
- [ ] WorkspaceGrid shows as "Mission Control"
- [ ] Worktrees sort correctly by activity level
- [ ] Filter tabs appear and filter correctly
- [ ] Cmd+1 opens the highest-priority (attention/current) worktree
- [ ] Cmd+1-9 navigate to correct worktrees in order
- [ ] Done badge appears for `agentDoneWorktreeIds` entries
- [ ] CI passes

Closes #313