### PR TITLE
feat: multi-model comparison panel (#71)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6131,7 +6131,7 @@ dependencies = [
 
 [[package]]
 name = "workroot"
-version = "0.1.16"
+version = "0.1.23"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/src-tauri/src/agents/pipeline.rs
+++ b/src-tauri/src/agents/pipeline.rs
@@ -484,3 +484,58 @@ pub async fn run_pipeline(
 
     get_pipeline_run(db, run_id)
 }
+
+// ─── Single-agent task run (used by model comparison) ────────────────────────
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct AgentTaskResult {
+    pub command: String,
+    pub label: String,
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_code: i32,
+}
+
+/// Run a single CLI command with a task description and return its output.
+/// The command receives the task via the TASK environment variable.
+#[tauri::command]
+pub async fn run_agent_task(
+    db: State<'_, AppDb>,
+    worktree_id: i64,
+    command: String,
+    label: String,
+    task_desc: String,
+) -> Result<AgentTaskResult, String> {
+    let worktree_path: String = {
+        let conn = db.0.lock().map_err(|e| format!("DB lock: {e}"))?;
+        conn.query_row(
+            "SELECT path FROM worktrees WHERE id = ?1",
+            params![worktree_id],
+            |row| row.get(0),
+        )
+        .map_err(|e| format!("Worktree not found: {e}"))?
+    };
+
+    let parts = split_command(&command);
+    if parts.is_empty() {
+        return Err("Command must not be empty".into());
+    }
+
+    let output = tokio::process::Command::new(&parts[0])
+        .args(&parts[1..])
+        .current_dir(&worktree_path)
+        .env("TASK", &task_desc)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .await
+        .map_err(|e| format!("Failed to run command: {e}"))?;
+
+    Ok(AgentTaskResult {
+        command,
+        label,
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        exit_code: output.status.code().unwrap_or(-1),
+    })
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -358,6 +358,7 @@ pub fn run() {
             agents::pipeline::list_pipeline_runs,
             agents::pipeline::get_pipeline_run,
             agents::pipeline::run_pipeline,
+            agents::pipeline::run_agent_task,
         ])
         .setup(|app| {
             let app_handle = app.handle().clone();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -782,6 +782,14 @@ function AppContent({
         enabled: () => selectedWorktreeId !== null,
         action: () => openPanel("multiAgentPipeline"),
       },
+      {
+        id: "ai:model-comparison",
+        label: "Model Comparison",
+        category: "AI",
+        icon: "\u21C6",
+        enabled: () => selectedWorktreeId !== null,
+        action: () => openPanel("modelComparison"),
+      },
     ];
 
     // Add project switch commands

--- a/src/components/ModelComparisonPanel.tsx
+++ b/src/components/ModelComparisonPanel.tsx
@@ -1,0 +1,235 @@
+import { useState, useCallback } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import "../styles/model-comparison.css";
+
+interface AgentTaskResult {
+  command: string;
+  label: string;
+  stdout: string;
+  stderr: string;
+  exit_code: number;
+}
+
+interface Props {
+  worktreeId: number;
+  onClose: () => void;
+}
+
+export function ModelComparisonPanel({ worktreeId, onClose }: Props) {
+  const [taskDesc, setTaskDesc] = useState("");
+  const [labelA, setLabelA] = useState("Agent A");
+  const [commandA, setCommandA] = useState("");
+  const [labelB, setLabelB] = useState("Agent B");
+  const [commandB, setCommandB] = useState("");
+  const [resultA, setResultA] = useState<AgentTaskResult | null>(null);
+  const [resultB, setResultB] = useState<AgentTaskResult | null>(null);
+  const [runningA, setRunningA] = useState(false);
+  const [runningB, setRunningB] = useState(false);
+  const [error, setError] = useState("");
+
+  const runComparison = useCallback(async () => {
+    if (!taskDesc.trim() || !commandA.trim() || !commandB.trim()) {
+      setError("Please fill in the task description and both commands.");
+      return;
+    }
+    setError("");
+    setResultA(null);
+    setResultB(null);
+    setRunningA(true);
+    setRunningB(true);
+
+    // Run both agents concurrently
+    const [resA, resB] = await Promise.allSettled([
+      invoke<AgentTaskResult>("run_agent_task", {
+        worktreeId,
+        command: commandA,
+        label: labelA || "Agent A",
+        taskDesc,
+      }),
+      invoke<AgentTaskResult>("run_agent_task", {
+        worktreeId,
+        command: commandB,
+        label: labelB || "Agent B",
+        taskDesc,
+      }),
+    ]);
+
+    setRunningA(false);
+    setRunningB(false);
+
+    if (resA.status === "fulfilled") {
+      setResultA(resA.value);
+    } else {
+      setResultA({
+        command: commandA,
+        label: labelA || "Agent A",
+        stdout: "",
+        stderr: String(resA.reason),
+        exit_code: -1,
+      });
+    }
+
+    if (resB.status === "fulfilled") {
+      setResultB(resB.value);
+    } else {
+      setResultB({
+        command: commandB,
+        label: labelB || "Agent B",
+        stdout: "",
+        stderr: String(resB.reason),
+        exit_code: -1,
+      });
+    }
+  }, [worktreeId, taskDesc, commandA, commandB, labelA, labelB]);
+
+  const hasResults = resultA !== null || resultB !== null;
+
+  return (
+    <div className="mc-panel">
+      <div className="mc-header">
+        <div className="mc-header-left">
+          <span className="mc-title">Model Comparison</span>
+          <span className="mc-subtitle">
+            Run the same task with two agents and compare outputs
+          </span>
+        </div>
+        <button className="mc-close" onClick={onClose} aria-label="Close">
+          ×
+        </button>
+      </div>
+
+      <div className="mc-body">
+        {/* Task description */}
+        <div className="mc-section">
+          <label className="mc-label" htmlFor="mc-task">
+            Task Description
+          </label>
+          <textarea
+            id="mc-task"
+            className="mc-textarea"
+            rows={3}
+            placeholder="Describe the task to give both agents (passed as $TASK environment variable)"
+            value={taskDesc}
+            onChange={(e) => setTaskDesc(e.target.value)}
+          />
+        </div>
+
+        {/* Agent config */}
+        <div className="mc-agents-row">
+          <div className="mc-agent-config">
+            <div className="mc-agent-header">
+              <input
+                className="mc-agent-label"
+                value={labelA}
+                onChange={(e) => setLabelA(e.target.value)}
+                placeholder="Agent A label"
+              />
+            </div>
+            <input
+              className="mc-agent-command"
+              placeholder="CLI command (e.g. claude-code --print)"
+              value={commandA}
+              onChange={(e) => setCommandA(e.target.value)}
+            />
+          </div>
+          <div className="mc-vs">vs</div>
+          <div className="mc-agent-config">
+            <div className="mc-agent-header">
+              <input
+                className="mc-agent-label"
+                value={labelB}
+                onChange={(e) => setLabelB(e.target.value)}
+                placeholder="Agent B label"
+              />
+            </div>
+            <input
+              className="mc-agent-command"
+              placeholder="CLI command (e.g. codex --quiet)"
+              value={commandB}
+              onChange={(e) => setCommandB(e.target.value)}
+            />
+          </div>
+        </div>
+
+        {error && <div className="mc-error">{error}</div>}
+
+        <button
+          className="mc-run-btn"
+          onClick={runComparison}
+          disabled={runningA || runningB}
+        >
+          {runningA || runningB ? "Running…" : "Run Comparison"}
+        </button>
+
+        {/* Results */}
+        {(hasResults || runningA || runningB) && (
+          <div className="mc-results-row">
+            <div className="mc-result-col">
+              <div className="mc-result-header">
+                <span className="mc-result-label">{labelA || "Agent A"}</span>
+                {resultA !== null && (
+                  <span
+                    className={
+                      "mc-exit-badge" +
+                      (resultA.exit_code === 0
+                        ? " mc-exit-badge--ok"
+                        : " mc-exit-badge--err")
+                    }
+                  >
+                    exit {resultA.exit_code}
+                  </span>
+                )}
+                {runningA && <span className="mc-running-badge">Running…</span>}
+              </div>
+              {resultA && (
+                <div className="mc-output">
+                  {resultA.stdout && (
+                    <pre className="mc-stdout">{resultA.stdout}</pre>
+                  )}
+                  {resultA.stderr && (
+                    <pre className="mc-stderr">{resultA.stderr}</pre>
+                  )}
+                  {!resultA.stdout && !resultA.stderr && (
+                    <span className="mc-empty">(no output)</span>
+                  )}
+                </div>
+              )}
+            </div>
+            <div className="mc-result-divider" />
+            <div className="mc-result-col">
+              <div className="mc-result-header">
+                <span className="mc-result-label">{labelB || "Agent B"}</span>
+                {resultB !== null && (
+                  <span
+                    className={
+                      "mc-exit-badge" +
+                      (resultB.exit_code === 0
+                        ? " mc-exit-badge--ok"
+                        : " mc-exit-badge--err")
+                    }
+                  >
+                    exit {resultB.exit_code}
+                  </span>
+                )}
+                {runningB && <span className="mc-running-badge">Running…</span>}
+              </div>
+              {resultB && (
+                <div className="mc-output">
+                  {resultB.stdout && (
+                    <pre className="mc-stdout">{resultB.stdout}</pre>
+                  )}
+                  {resultB.stderr && (
+                    <pre className="mc-stderr">{resultB.stderr}</pre>
+                  )}
+                  {!resultB.stdout && !resultB.stderr && (
+                    <span className="mc-empty">(no output)</span>
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/PanelHost.tsx
+++ b/src/components/PanelHost.tsx
@@ -56,6 +56,10 @@ const MultiAgentPipelinePanel = namedLazy(
   () => import("./MultiAgentPipelinePanel"),
   "MultiAgentPipelinePanel",
 );
+const ModelComparisonPanel = namedLazy(
+  () => import("./ModelComparisonPanel"),
+  "ModelComparisonPanel",
+);
 const BlameView = namedLazy(() => import("./BlameView"), "BlameView");
 const BranchCompare = namedLazy(
   () => import("./BranchCompare"),
@@ -381,6 +385,21 @@ export function PanelHost({
             worktreeId={selectedWorktreeId}
             onClose={() => closePanel("multiAgentPipeline")}
           />
+        </PanelBoundary>
+      )}
+      {panels.has("modelComparison") && selectedWorktreeId !== null && (
+        <PanelBoundary name="ModelComparison">
+          <FocusTrapOverlay onClick={() => closePanel("modelComparison")}>
+            <div
+              className="panel-dialog panel-dialog--wide"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <ModelComparisonPanel
+                worktreeId={selectedWorktreeId}
+                onClose={() => closePanel("modelComparison")}
+              />
+            </div>
+          </FocusTrapOverlay>
         </PanelBoundary>
       )}
       {panels.has("blameView") && selectedWorktreeId !== null && (

--- a/src/hooks/usePanels.ts
+++ b/src/hooks/usePanels.ts
@@ -72,7 +72,8 @@ export type PanelKey =
   | "browserEvents"
   | "dbExplorer"
   | "checkpointManager"
-  | "multiAgentPipeline";
+  | "multiAgentPipeline"
+  | "modelComparison";
 
 // ─── State ───────────────────────────────────────────────────────────────────
 

--- a/src/styles/model-comparison.css
+++ b/src/styles/model-comparison.css
@@ -1,0 +1,295 @@
+/* ==========================================================
+   Model Comparison Panel
+   ========================================================== */
+
+.mc-panel {
+  display: flex;
+  flex-direction: column;
+  width: min(900px, 92vw);
+  max-height: 86vh;
+  background: var(--bg-surface);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.mc-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 1em 1.25em 0.75em;
+  border-bottom: 1px solid var(--border-subtle);
+  gap: 1em;
+  flex-shrink: 0;
+}
+
+.mc-header-left {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2em;
+}
+
+.mc-title {
+  font-size: 0.95em;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.mc-subtitle {
+  font-size: 0.75em;
+  color: var(--text-muted);
+}
+
+.mc-close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1.2em;
+  color: var(--text-muted);
+  padding: 0 0.2em;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.mc-close:hover {
+  color: var(--text-primary);
+}
+
+.mc-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1em;
+  padding: 1em 1.25em 1.25em;
+  overflow-y: auto;
+  flex: 1;
+  min-height: 0;
+}
+
+.mc-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4em;
+}
+
+.mc-label {
+  font-size: 0.75em;
+  font-weight: 500;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.mc-textarea {
+  resize: vertical;
+  min-height: 64px;
+  font-family: var(--font-mono);
+  font-size: 0.82em;
+  padding: 0.6em 0.75em;
+  background: var(--bg-base);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text-primary);
+  outline: none;
+  transition: border-color var(--transition-fast);
+}
+
+.mc-textarea:focus {
+  border-color: var(--accent);
+}
+
+/* Agent config row */
+.mc-agents-row {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 0.75em;
+  align-items: start;
+}
+
+.mc-agent-config {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5em;
+}
+
+.mc-agent-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+}
+
+.mc-agent-label {
+  font-size: 0.82em;
+  font-weight: 600;
+  padding: 0.3em 0.6em;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  color: var(--accent);
+  outline: none;
+  width: 100%;
+}
+
+.mc-agent-label:focus {
+  border-color: var(--accent);
+}
+
+.mc-agent-command {
+  font-family: var(--font-mono);
+  font-size: 0.82em;
+  padding: 0.5em 0.75em;
+  background: var(--bg-base);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text-primary);
+  outline: none;
+  transition: border-color var(--transition-fast);
+}
+
+.mc-agent-command:focus {
+  border-color: var(--accent);
+}
+
+.mc-vs {
+  font-size: 0.75em;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  padding-top: 0.7em;
+  align-self: start;
+}
+
+.mc-error {
+  font-size: 0.8em;
+  color: var(--error, #ef4444);
+  padding: 0.5em 0.75em;
+  background: rgba(239, 68, 68, 0.08);
+  border: 1px solid rgba(239, 68, 68, 0.2);
+  border-radius: var(--radius);
+}
+
+.mc-run-btn {
+  align-self: flex-start;
+  padding: 0.5em 1.25em;
+  background: var(--accent);
+  color: var(--bg-base);
+  border: none;
+  border-radius: var(--radius);
+  font: inherit;
+  font-size: 0.85em;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity var(--transition-fast);
+}
+
+.mc-run-btn:hover:not(:disabled) {
+  opacity: 0.88;
+}
+
+.mc-run-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Results */
+.mc-results-row {
+  display: grid;
+  grid-template-columns: 1fr 1px 1fr;
+  gap: 0;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  min-height: 200px;
+}
+
+.mc-result-col {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.mc-result-divider {
+  background: var(--border-subtle);
+  width: 1px;
+}
+
+.mc-result-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+  padding: 0.6em 0.875em;
+  background: var(--bg-elevated);
+  border-bottom: 1px solid var(--border-subtle);
+  flex-shrink: 0;
+}
+
+.mc-result-label {
+  font-size: 0.78em;
+  font-weight: 600;
+  color: var(--accent);
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mc-exit-badge {
+  font-family: var(--font-mono);
+  font-size: 0.7em;
+  padding: 1px 6px;
+  border-radius: 4px;
+}
+
+.mc-exit-badge--ok {
+  background: rgba(16, 185, 129, 0.12);
+  color: var(--success, #10b981);
+  border: 1px solid rgba(16, 185, 129, 0.2);
+}
+
+.mc-exit-badge--err {
+  background: rgba(239, 68, 68, 0.1);
+  color: var(--error, #ef4444);
+  border: 1px solid rgba(239, 68, 68, 0.2);
+}
+
+.mc-running-badge {
+  font-size: 0.7em;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.mc-output {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.75em;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5em;
+  min-height: 0;
+}
+
+.mc-stdout {
+  font-family: var(--font-mono);
+  font-size: 0.75em;
+  white-space: pre-wrap;
+  word-break: break-all;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.mc-stderr {
+  font-family: var(--font-mono);
+  font-size: 0.75em;
+  white-space: pre-wrap;
+  word-break: break-all;
+  color: var(--error, #ef4444);
+  margin: 0;
+  background: rgba(239, 68, 68, 0.04);
+  padding: 0.5em;
+  border-radius: var(--radius);
+}
+
+.mc-empty {
+  font-size: 0.78em;
+  color: var(--text-muted);
+  font-style: italic;
+}


### PR DESCRIPTION
## Summary

- Adds `ModelComparisonPanel` component with side-by-side output view for two agents
- Adds `run_agent_task` Tauri command that runs a CLI command in the worktree directory with `TASK` env var
- Wires up `ai:model-comparison` command palette entry to open the panel
- Both agents run concurrently via `Promise.allSettled`; results show stdout/stderr and exit codes

Closes #71

## Test plan
- [ ] Open command palette and run `ai:model-comparison`
- [ ] Enter a task description and two CLI commands, click Run Comparison
- [ ] Verify both panels show output side by side
- [ ] Verify exit code badges (green/red) render correctly
- [ ] Verify error state when commands are left empty