### PR TITLE
feat: persistent agent status strip in sidebar (#327)

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -44,6 +44,8 @@ export function Sidebar({
     setSelectedWorktreeId,
     setSelectedWorktreePath,
     setSelectedWorktreeName,
+    agentNeedsAttentionIds,
+    agentDoneWorktreeIds,
   } = useUiStore();
 
   const handleAddProject = useCallback(async () => {
@@ -219,6 +221,36 @@ export function Sidebar({
           )}
         </div>
       </ScrollArea>
+
+      {/* Agent status strip — always visible when any agent has state */}
+      {(agentNeedsAttentionIds.size > 0 || agentDoneWorktreeIds.size > 0) && (
+        <div className="sidebar-agent-status">
+          {agentNeedsAttentionIds.size > 0 && (
+            <button
+              className="sidebar-agent-badge sidebar-agent-badge--attention"
+              onClick={handleGoHome}
+              title="Go to Mission Control — agents need your input"
+            >
+              <span className="sidebar-agent-dot sidebar-agent-dot--attention" />
+              {agentNeedsAttentionIds.size === 1
+                ? "1 needs you"
+                : `${agentNeedsAttentionIds.size} need you`}
+            </button>
+          )}
+          {agentDoneWorktreeIds.size > 0 && (
+            <button
+              className="sidebar-agent-badge sidebar-agent-badge--done"
+              onClick={handleGoHome}
+              title="Go to Mission Control — agents finished"
+            >
+              <span className="sidebar-agent-dot sidebar-agent-dot--done" />
+              {agentDoneWorktreeIds.size === 1
+                ? "1 done"
+                : `${agentDoneWorktreeIds.size} done`}
+            </button>
+          )}
+        </div>
+      )}
 
       {/* Bottom toolbar */}
       <div className="sidebar-toolbar">

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -265,6 +265,87 @@
 /* ---- Empty button (now uses shadcn Button) ---- */
 
 /* ==========================================================
+   Agent Status Strip
+   ========================================================== */
+
+@keyframes pulse-attention {
+  0%,
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.55;
+    transform: scale(0.85);
+  }
+}
+
+.sidebar-agent-status {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35em;
+  padding: 0.5em 0.75em;
+  border-top: 1px solid var(--border-subtle);
+  background: var(--bg-surface);
+  flex-shrink: 0;
+}
+
+.sidebar-agent-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4em;
+  padding: 0.22em 0.6em;
+  border-radius: var(--radius);
+  font-size: 0.72em;
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition:
+    background-color var(--transition-fast),
+    border-color var(--transition-fast);
+  white-space: nowrap;
+  line-height: 1.4;
+}
+
+.sidebar-agent-badge--attention {
+  background: rgba(245, 158, 11, 0.1);
+  color: var(--warning, #f59e0b);
+  border-color: rgba(245, 158, 11, 0.2);
+}
+
+.sidebar-agent-badge--attention:hover {
+  background: rgba(245, 158, 11, 0.18);
+  border-color: rgba(245, 158, 11, 0.35);
+}
+
+.sidebar-agent-badge--done {
+  background: rgba(16, 185, 129, 0.1);
+  color: var(--success, #10b981);
+  border-color: rgba(16, 185, 129, 0.2);
+}
+
+.sidebar-agent-badge--done:hover {
+  background: rgba(16, 185, 129, 0.18);
+  border-color: rgba(16, 185, 129, 0.35);
+}
+
+.sidebar-agent-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.sidebar-agent-dot--attention {
+  background: var(--warning, #f59e0b);
+  animation: pulse-attention 1.4s ease-in-out infinite;
+}
+
+.sidebar-agent-dot--done {
+  background: var(--success, #10b981);
+}
+
+/* ==========================================================
    Sidebar Toolbar (bottom)
    ========================================================== */
 


### PR DESCRIPTION
## Summary

Part of the Cockpit UX redesign (#327), Phase 2 — Needs You always draws your eye.

- Adds a persistent status strip at the bottom of the sidebar (above the toolbar)
- Shows an orange pulsing badge (N need you) when any agents are waiting for input
- Shows a green badge (N done) when any agents have completed
- Strip is hidden when there are no pending agent states
- Clicking either badge navigates to the home/Mission Control view
- Agent state is read from agentNeedsAttentionIds / agentDoneWorktreeIds in useUiStore

### Before
Agent attention state was only visible inside Mission Control. If you had a terminal open, you had no way to know other agents needed your input.

### After
The sidebar always surfaces pending agent state via pulsing badges, regardless of what you are currently viewing.

## Test plan
- [ ] Mark an agent as needing attention — badge appears in sidebar
- [ ] Click N need you badge — navigates to home/Mission Control
- [ ] Mark an agent as done — green N done badge appears
- [ ] When both badges exist, they show side by side
- [ ] When no agents have pending state, strip is hidden
- [ ] Attention dot pulses continuously

Closes part of #327