### PR TITLE
feat: inline Squash & Merge button in PR Status panel (#327)

### DIFF
--- a/src-tauri/src/github/pr.rs
+++ b/src-tauri/src/github/pr.rs
@@ -214,6 +214,67 @@ pub fn get_pr_template(db: State<'_, AppDb>, worktree_id: i64) -> Result<Option<
     Ok(None)
 }
 
+/// Merge an open pull request via the GitHub API.
+///
+/// `merge_method` must be one of: "merge", "squash", or "rebase".
+#[tauri::command]
+pub async fn merge_pull_request(
+    db: State<'_, AppDb>,
+    worktree_id: i64,
+    pr_number: i64,
+    merge_method: String,
+) -> Result<(), String> {
+    let (owner, repo_name) = {
+        let conn = db.0.lock().map_err(|e| format!("DB lock: {}", e))?;
+        let worktree = queries::get_worktree(&conn, worktree_id)
+            .map_err(|e| format!("DB: {}", e))?
+            .ok_or("Worktree not found")?;
+        let repo = Repository::open(&worktree.path).map_err(|e| format!("Git: {}", e))?;
+        get_remote_info(&repo)?
+    };
+
+    let token = auth::get_token()?.ok_or("Not authenticated. Please sign in with GitHub first.")?;
+
+    let client = super::api_client()?;
+
+    let url = format!(
+        "https://api.github.com/repos/{}/{}/pulls/{}/merge",
+        owner, repo_name, pr_number
+    );
+
+    let resp = client
+        .put(&url)
+        .header("Authorization", format!("Bearer {}", token))
+        .header("User-Agent", "Workroot")
+        .header("Accept", "application/vnd.github+json")
+        .json(&serde_json::json!({ "merge_method": merge_method }))
+        .send()
+        .await
+        .map_err(|e| format!("Request failed: {}", e))?;
+
+    if resp.status().is_success() {
+        return Ok(());
+    }
+
+    let status = resp.status();
+    let body = resp.text().await.unwrap_or_default();
+
+    // 405 = not mergeable; 409 = head SHA mismatch
+    if status.as_u16() == 405 {
+        return Err(
+            "PR is not mergeable. Check that all required checks pass and there are no conflicts."
+                .to_string(),
+        );
+    }
+    if status.as_u16() == 409 {
+        return Err(
+            "Merge conflict: the head branch is out of date. Rebase and try again.".to_string(),
+        );
+    }
+
+    Err(format!("GitHub API error ({}): {}", status, body))
+}
+
 /// Get the default branch (main or master) for the repo.
 #[tauri::command]
 pub fn get_default_branch(db: State<'_, AppDb>, worktree_id: i64) -> Result<String, String> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -203,6 +203,7 @@ pub fn run() {
             github::pr::get_pr_for_branch,
             github::pr::get_pr_template,
             github::pr::get_default_branch,
+            github::pr::merge_pull_request,
             github::ci::get_pr_status,
             github::activity::list_repo_pulls,
             github::activity::list_repo_issues,

--- a/src/components/PRStatusPanel.tsx
+++ b/src/components/PRStatusPanel.tsx
@@ -82,6 +82,9 @@ export function PRStatusPanel({ worktreeId }: PRStatusPanelProps) {
   const [status, setStatus] = useState<PrStatus | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [merging, setMerging] = useState(false);
+  const [mergeError, setMergeError] = useState<string | null>(null);
+  const [merged, setMerged] = useState(false);
   const intervalRef = useRef<ReturnType<typeof setInterval>>(undefined);
 
   const loadStatus = useCallback(async () => {
@@ -97,6 +100,25 @@ export function PRStatusPanel({ worktreeId }: PRStatusPanelProps) {
       setLoading(false);
     }
   }, [worktreeId]);
+
+  const handleMerge = useCallback(async () => {
+    if (!status) return;
+    setMerging(true);
+    setMergeError(null);
+    try {
+      await invoke("merge_pull_request", {
+        worktreeId,
+        prNumber: status.number,
+        mergeMethod: "squash",
+      });
+      setMerged(true);
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    } catch (err) {
+      setMergeError(String(err));
+    } finally {
+      setMerging(false);
+    }
+  }, [worktreeId, status]);
 
   useEffect(() => {
     loadStatus();
@@ -125,6 +147,16 @@ export function PRStatusPanel({ worktreeId }: PRStatusPanelProps) {
         <p>No open PR for this branch</p>
         <p className="pr-status-empty-hint">
           Create a pull request to see status here
+        </p>
+      </div>
+    );
+  }
+
+  if (merged) {
+    return (
+      <div className="pr-status-empty">
+        <p className="pr-status-merged-msg">
+          &#x2713; PR #{status.number} merged
         </p>
       </div>
     );
@@ -232,14 +264,35 @@ export function PRStatusPanel({ worktreeId }: PRStatusPanelProps) {
           </div>
         )}
 
-        <a
-          className="pr-status-link"
-          href={status.html_url}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          View on GitHub
-        </a>
+        <div className="pr-status-actions">
+          <button
+            className="pr-status-merge-btn"
+            onClick={handleMerge}
+            disabled={
+              merging || status.draft || status.mergeable_state !== "clean"
+            }
+            title={
+              status.draft
+                ? "Cannot merge a draft PR"
+                : status.mergeable_state !== "clean"
+                  ? `Not mergeable (${status.mergeable_state ?? "unknown"})`
+                  : "Squash and merge"
+            }
+          >
+            {merging ? "Merging\u2026" : "Squash \u0026 Merge"}
+          </button>
+          <a
+            className="pr-status-link"
+            href={status.html_url}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            View on GitHub
+          </a>
+        </div>
+        {mergeError && (
+          <div className="pr-status-merge-error">{mergeError}</div>
+        )}
       </div>
     </div>
   );

--- a/src/styles/pr-status.css
+++ b/src/styles/pr-status.css
@@ -249,3 +249,51 @@
   height: 200px;
   color: var(--text-muted, #888);
 }
+
+/* ── Merge action ─────────────────────────────────────────── */
+
+.pr-status-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75em;
+  flex-wrap: wrap;
+}
+
+.pr-status-merge-btn {
+  padding: 0.38em 1em;
+  background: var(--accent, #10b981);
+  color: var(--bg-base, #0a0f0a);
+  border: none;
+  border-radius: var(--radius, 4px);
+  font: inherit;
+  font-size: 0.82em;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.15s;
+  white-space: nowrap;
+}
+
+.pr-status-merge-btn:hover:not(:disabled) {
+  opacity: 0.88;
+}
+
+.pr-status-merge-btn:disabled {
+  opacity: 0.38;
+  cursor: not-allowed;
+}
+
+.pr-status-merge-error {
+  font-size: 0.78em;
+  color: var(--error, #ef4444);
+  padding: 0.4em 0.6em;
+  background: rgba(239, 68, 68, 0.08);
+  border: 1px solid rgba(239, 68, 68, 0.2);
+  border-radius: var(--radius, 4px);
+  margin-top: 0.5em;
+}
+
+.pr-status-merged-msg {
+  color: var(--success, #10b981);
+  font-weight: 600;
+  font-size: 0.9em;
+}


### PR DESCRIPTION
## Summary

Completes Cockpit Phase 3 from #327 — inline merge actions without leaving the app.

### Backend
- New `merge_pull_request(worktree_id, pr_number, merge_method)` Tauri command
- Calls GitHub API `PUT /repos/:owner/:repo/pulls/:number/merge` with squash method
- Returns friendly error messages for 405 (not mergeable) and 409 (head SHA mismatch)

### Frontend
- Squash & Merge button added to PRStatusPanel
- Disabled when PR is a draft or mergeable_state is not 'clean'
- Shows Merging while in progress, inline error on failure, merged confirmation on success
- Stops the 30s auto-refresh poll after a successful merge

## Test plan
- [ ] Open PR Status tab for a worktree with an open, mergeable PR
- [ ] Squash & Merge button is enabled (green) when mergeable_state is clean
- [ ] Button is disabled (greyed) for drafts or blocked PRs
- [ ] Clicking merges the PR and shows confirmation message
- [ ] Error shown if merge fails (e.g. not mergeable)

Closes part of #327