### PR TITLE
feat: Mission Control command bar — task-driven worktree creation (#327)

### DIFF
--- a/src/components/WorkspaceGrid.tsx
+++ b/src/components/WorkspaceGrid.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, useCallback } from "react";
+import { useEffect, useMemo, useState, useCallback, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { useUiStore } from "../stores/uiStore";
 import "../styles/workspace-grid.css";
@@ -39,6 +39,19 @@ function formatPath(path: string): string {
   return path.replace(/^\/Users\/[^/]+/, "~");
 }
 
+/** Convert a free-text task description into a valid git branch name. */
+function slugifyTask(task: string): string {
+  const slug = task
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .trim()
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .slice(0, 50)
+    .replace(/-$/, "");
+  return slug ? `task/${slug}` : "task/new";
+}
+
 export function WorkspaceGrid({
   projects,
   worktrees,
@@ -49,6 +62,13 @@ export function WorkspaceGrid({
     useUiStore();
 
   const [filterTab, setFilterTab] = useState<FilterTab>("all");
+
+  // Command bar state
+  const [cmdTask, setCmdTask] = useState("");
+  const [cmdProjectId, setCmdProjectId] = useState<number | null>(null);
+  const [spawning, setSpawning] = useState(false);
+  const [spawnError, setSpawnError] = useState<string | null>(null);
+  const cmdInputRef = useRef<HTMLInputElement>(null);
 
   // Fallback in case props are empty — load projects + worktrees ourselves.
   const [fallbackProjects, setFallbackProjects] = useState<ProjectInfo[]>([]);
@@ -92,6 +112,10 @@ export function WorkspaceGrid({
   const activeProjects = projects.length > 0 ? projects : fallbackProjects;
   const activeWorktrees =
     worktrees.length > 0 || projects.length > 0 ? worktrees : fallbackWorktrees;
+
+  // Resolve command bar project: explicit selection, or first available project
+  const cmdProject =
+    activeProjects.find((p) => p.id === cmdProjectId) ?? activeProjects[0];
 
   const statusFor = useCallback(
     (wt: WorktreeInfo): CardStatus => {
@@ -160,6 +184,28 @@ export function WorkspaceGrid({
     window.addEventListener("keydown", handleKey);
     return () => window.removeEventListener("keydown", handleKey);
   }, [sortedWorktrees, onSelectWorktree]);
+
+  // Create a new worktree from the command bar task description
+  const handleSpawn = useCallback(async () => {
+    const task = cmdTask.trim();
+    if (!task || !cmdProject || spawning) return;
+    setSpawning(true);
+    setSpawnError(null);
+    try {
+      const branchName = slugifyTask(task);
+      const wt = await invoke<WorktreeInfo>("create_worktree", {
+        projectId: cmdProject.id,
+        branchName,
+        createNewBranch: true,
+      });
+      setCmdTask("");
+      onSelectWorktree(wt);
+    } catch (err) {
+      setSpawnError(String(err));
+    } finally {
+      setSpawning(false);
+    }
+  }, [cmdTask, cmdProject, spawning, onSelectWorktree]);
 
   const totalWorktrees = activeWorktrees.length;
   const attentionCount = activeWorktrees.filter(
@@ -346,6 +392,55 @@ export function WorkspaceGrid({
             </div>
           </div>
         ))}
+
+        {/* ── Phase 4: Command Bar ───────────────────────────────────── */}
+        {activeProjects.length > 0 && (
+          <div className="workspace-cmd-bar">
+            <span className="workspace-cmd-icon" aria-hidden>
+              &#9889;
+            </span>
+            <input
+              ref={cmdInputRef}
+              className="workspace-cmd-input"
+              type="text"
+              placeholder="Describe a task to start a new worktree&#8230;"
+              value={cmdTask}
+              onChange={(e) => {
+                setCmdTask(e.target.value);
+                setSpawnError(null);
+              }}
+              onKeyDown={(e) => e.key === "Enter" && handleSpawn()}
+              disabled={spawning}
+              aria-label="Task description"
+            />
+            {activeProjects.length > 1 && (
+              <select
+                className="workspace-cmd-project"
+                value={cmdProject?.id ?? ""}
+                onChange={(e) => setCmdProjectId(Number(e.target.value))}
+                disabled={spawning}
+                aria-label="Project"
+              >
+                {activeProjects.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.name}
+                  </option>
+                ))}
+              </select>
+            )}
+            <button
+              type="button"
+              className="workspace-cmd-run"
+              onClick={handleSpawn}
+              disabled={!cmdTask.trim() || spawning || !cmdProject}
+            >
+              {spawning ? "Creating\u2026" : "Run"}
+            </button>
+            {spawnError && (
+              <div className="workspace-cmd-error">{spawnError}</div>
+            )}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/styles/workspace-grid.css
+++ b/src/styles/workspace-grid.css
@@ -340,3 +340,101 @@
   border-color: rgba(16, 185, 129, 0.2);
   color: var(--success, #10b981);
 }
+
+/* ==========================================================
+   Command Bar (Phase 4 — Cockpit)
+   ========================================================== */
+
+.workspace-cmd-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.6em;
+  flex-wrap: wrap;
+  margin-top: 2.5em;
+  padding: 0.75em 1em;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  transition: border-color var(--transition-fast);
+}
+
+.workspace-cmd-bar:focus-within {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 15%, transparent);
+}
+
+.workspace-cmd-icon {
+  font-size: 1em;
+  color: var(--accent);
+  flex-shrink: 0;
+  line-height: 1;
+}
+
+.workspace-cmd-input {
+  flex: 1;
+  min-width: 0;
+  background: transparent;
+  border: none;
+  outline: none;
+  font: inherit;
+  font-size: 0.88em;
+  color: var(--text-primary);
+}
+
+.workspace-cmd-input::placeholder {
+  color: var(--text-muted);
+}
+
+.workspace-cmd-input:disabled {
+  opacity: 0.5;
+}
+
+.workspace-cmd-project {
+  background: var(--bg-base);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 0.78em;
+  padding: 0.25em 0.5em;
+  outline: none;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.workspace-cmd-project:focus {
+  border-color: var(--accent);
+}
+
+.workspace-cmd-run {
+  padding: 0.35em 1em;
+  background: var(--accent);
+  color: var(--bg-base);
+  border: none;
+  border-radius: var(--radius);
+  font: inherit;
+  font-size: 0.82em;
+  font-weight: 600;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: opacity var(--transition-fast);
+}
+
+.workspace-cmd-run:hover:not(:disabled) {
+  opacity: 0.88;
+}
+
+.workspace-cmd-run:disabled {
+  opacity: 0.38;
+  cursor: not-allowed;
+}
+
+.workspace-cmd-error {
+  width: 100%;
+  font-size: 0.78em;
+  color: var(--error, #ef4444);
+  padding: 0.35em 0.6em;
+  background: rgba(239, 68, 68, 0.08);
+  border: 1px solid rgba(239, 68, 68, 0.2);
+  border-radius: var(--radius);
+}


### PR DESCRIPTION
## Summary

Completes **Cockpit Phase 4** from #327 — natural language task input.

Adds a persistent command bar at the bottom of Mission Control:

- Type a task description (e.g. "Fix pagination bug in browser-use")
- Press **Enter** or click **Run**
- A new worktree is created with branch name `task/<slug>` derived from the description
- The app navigates directly to the new worktree terminal

When multiple projects are registered, a project dropdown appears to the left of Run.

### Branch naming
`"Fix the pagination bug in browser-use"` → `task/fix-the-pagination-bug-in-browser-use`

## Test plan
- [ ] Type a task and press Enter — new worktree created, terminal opens
- [ ] Project dropdown appears when >1 project registered
- [ ] Error shown if branch already exists (e.g. same task twice)
- [ ] Run button disabled when input is empty or spawning
- [ ] Command bar focused state shows accent border glow

Closes #327