### PR TITLE
chore: bump version to 0.1.24

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.1.23",
+  "version": "0.1.24",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6131,7 +6131,7 @@ dependencies = [
 
 [[package]]
 name = "workroot"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.1.23"
+version = "0.1.24"
 edition = "2021"
 authors = ["Saurav Panda <saurav@workroot.dev>"]
 description = "A local-first developer workspace for managing projects, terminals, and Git workflows."

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## v0.1.24 — Cockpit Release

### Features
- **Mission Control** (#351) — tile grid of all worktrees with status sort, filter tabs (All/Attention/Active/Done), Cmd+1-9 shortcuts
- **Agent status strip** (#353) — persistent pulsing sidebar badge shows attention/done agent counts at all times
- **Model comparison panel** (#352) — run the same task with two CLI agents side-by-side, compare stdout/stderr
- **PR merge action** (#354) — Squash & Merge button directly in PR Status panel; no need to leave the app
- **Command bar** (#355) — type a task description at the bottom of Mission Control, press Enter to create a worktree and open the terminal
- **CLAUDE.md in Memory panel** (#346) — surfaces project context file in the Memory tab
- **First-time onboarding wizard** (#345) — auto-shown for new users

### Bug fixes
- GitHub sidebar respects container width (#344)
- Command registration uses useEffect not useMemo (#347)
- GitHubSidebar collapsed state propagates to parent (#348)

### Refactor
- App.tsx split into focused hooks and PanelHost (#350) — 49% size reduction

Closes #327