### PR TITLE
feat: agent presets, pipeline progress, terminal snapshots

### DIFF
--- a/src-tauri/src/agents/pipeline.rs
+++ b/src-tauri/src/agents/pipeline.rs
@@ -2,7 +2,7 @@ use crate::db::AppDb;
 use rusqlite::params;
 use serde::{Deserialize, Serialize};
 use std::process::Stdio;
-use tauri::State;
+use tauri::{AppHandle, Emitter, State};
 use tokio::io::AsyncWriteExt;
 
 #[tauri::command]
@@ -53,6 +53,15 @@ pub struct StepOutput {
     pub stdout: String,
     pub stderr: String,
     pub exit_code: i32,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct PipelineProgressEvent {
+    pub run_id: i64,
+    pub iteration: u32,
+    pub max_iterations: u32,
+    pub phase: String,
+    pub status: String,
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -316,6 +325,7 @@ pub fn get_pipeline_run(db: State<'_, AppDb>, run_id: i64) -> Result<PipelineRun
 
 #[tauri::command]
 pub async fn run_pipeline(
+    app: AppHandle,
     db: State<'_, AppDb>,
     pipeline_id: i64,
     worktree_id: i64,
@@ -395,6 +405,17 @@ pub async fn run_pipeline(
 
     for i in 0..max {
         // ── Generator ──
+        let _ = app.emit(
+            "pipeline:progress",
+            PipelineProgressEvent {
+                run_id,
+                iteration: i,
+                max_iterations: max,
+                phase: "generator".into(),
+                status: "running".into(),
+            },
+        );
+
         let gen_result = tokio::process::Command::new(&gen_parts[0])
             .args(&gen_parts[1..])
             .current_dir(&worktree_path)
@@ -422,10 +443,31 @@ pub async fn run_pipeline(
             exit_code: gen_exit,
         });
 
+        let _ = app.emit(
+            "pipeline:progress",
+            PipelineProgressEvent {
+                run_id,
+                iteration: i,
+                max_iterations: max,
+                phase: "generator".into(),
+                status: "done".into(),
+            },
+        );
+
         // ── Get diff ──
         let diff = get_git_diff(&worktree_path);
 
         // ── Reviewer ──
+        let _ = app.emit(
+            "pipeline:progress",
+            PipelineProgressEvent {
+                run_id,
+                iteration: i,
+                max_iterations: max,
+                phase: "reviewer".into(),
+                status: "running".into(),
+            },
+        );
         let stdin_payload = format!(
             "=== TASK ===\n{}\n\n=== GENERATOR OUTPUT ===\n{}\n\n=== GIT DIFF ===\n{}",
             task_desc, gen_stdout, diff
@@ -467,6 +509,21 @@ pub async fn run_pipeline(
             stderr: rev_stderr,
             exit_code: rev_exit,
         });
+
+        let _ = app.emit(
+            "pipeline:progress",
+            PipelineProgressEvent {
+                run_id,
+                iteration: i,
+                max_iterations: max,
+                phase: "reviewer".into(),
+                status: if approved {
+                    "approved".into()
+                } else {
+                    "rejected".into()
+                },
+            },
+        );
 
         if approved {
             final_status = "approved".to_string();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -141,6 +141,8 @@ function AppContent({
     lastWorktreeNameRef.current = selectedWorktreeName;
   }
 
+  const terminalSnapshotMapRef = useRef(new Map<string, string>());
+
   const openPanelRef = useRef(openPanel);
   openPanelRef.current = openPanel;
 
@@ -995,6 +997,7 @@ function AppContent({
             }}
             shell={terminalShell}
             themeId={terminalThemeId}
+            snapshotMap={terminalSnapshotMapRef}
           />
         </PanelBoundary>
       ) : null}
@@ -1031,6 +1034,7 @@ function AppContent({
               themeId={terminalThemeId}
               onAgentComplete={handleAgentComplete}
               onAgentNeedsAttention={handleAgentNeedsAttention}
+              snapshotRef={terminalSnapshotMapRef}
             />
           </PanelBoundary>
         </div>

--- a/src/components/MultiAgentPipelinePanel.tsx
+++ b/src/components/MultiAgentPipelinePanel.tsx
@@ -1,5 +1,7 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import type { UnlistenFn } from "@tauri-apps/api/event";
 import { save } from "@tauri-apps/plugin-dialog";
 import "../styles/multi-agent-pipeline.css";
 
@@ -7,14 +9,30 @@ import "../styles/multi-agent-pipeline.css";
 
 interface CliPreset {
   label: string;
+  role: "generator" | "reviewer";
   command: string;
 }
 
-const CLI_PRESETS: CliPreset[] = [
-  { label: "Claude Code", command: "claude --print" },
-  { label: "Aider", command: "aider --message" },
-  { label: "Codex", command: "codex --quiet" },
-  { label: "Custom", command: "" },
+const GENERATOR_PRESETS: CliPreset[] = [
+  { label: "Claude Code", role: "generator", command: "claude --print" },
+  { label: "Aider", role: "generator", command: "aider --message" },
+  { label: "Codex", role: "generator", command: "codex --quiet" },
+  { label: "Custom", role: "generator", command: "" },
+];
+
+const REVIEWER_PRESETS: CliPreset[] = [
+  {
+    label: "Claude Code",
+    role: "reviewer",
+    command:
+      'claude --print "Review the changes and respond with APPROVED or request fixes"',
+  },
+  {
+    label: "Aider",
+    role: "reviewer",
+    command: 'aider --message "Review the following changes"',
+  },
+  { label: "Custom", role: "reviewer", command: "" },
 ];
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -95,6 +113,8 @@ export function MultiAgentPipelinePanel({ worktreeId, onClose }: Props) {
   const [expandedStep, setExpandedStep] = useState<number | null>(null);
   const [running, setRunning] = useState(false);
   const [runError, setRunError] = useState("");
+  const [progress, setProgress] = useState("");
+  const unlistenRef = useRef<UnlistenFn | null>(null);
 
   // Load agents
   const loadAgents = useCallback(async () => {
@@ -140,6 +160,13 @@ export function MultiAgentPipelinePanel({ worktreeId, onClose }: Props) {
       setRuns([]);
     }
   }, [selectedPipelineId, loadRuns]);
+
+  // Cleanup progress listener on unmount
+  useEffect(() => {
+    return () => {
+      unlistenRef.current?.();
+    };
+  }, []);
 
   // ─── Agent handlers ──────────────────────────────────────────────────────
 
@@ -218,6 +245,30 @@ export function MultiAgentPipelinePanel({ worktreeId, onClose }: Props) {
     setRunning(true);
     setActiveRun(null);
     setExpandedStep(null);
+    setProgress("Starting pipeline...");
+
+    // Subscribe to progress events
+    unlistenRef.current?.();
+    unlistenRef.current = await listen<{
+      run_id: number;
+      iteration: number;
+      max_iterations: number;
+      phase: string;
+      status: string;
+    }>("pipeline:progress", (event) => {
+      const { iteration, max_iterations, phase, status } = event.payload;
+      const iter = `Iteration ${iteration + 1}/${max_iterations}`;
+      if (status === "running") {
+        setProgress(`${iter} — ${phase} running...`);
+      } else if (status === "approved") {
+        setProgress(`${iter} — reviewer approved`);
+      } else if (status === "rejected") {
+        setProgress(`${iter} — reviewer requested changes`);
+      } else {
+        setProgress(`${iter} — ${phase} ${status}`);
+      }
+    });
+
     try {
       const result = await invoke<PipelineRun>("run_pipeline", {
         pipelineId: Number(selectedPipelineId),
@@ -230,6 +281,9 @@ export function MultiAgentPipelinePanel({ worktreeId, onClose }: Props) {
       setRunError(String(e));
     } finally {
       setRunning(false);
+      setProgress("");
+      unlistenRef.current?.();
+      unlistenRef.current = null;
     }
   }
 
@@ -324,22 +378,51 @@ export function MultiAgentPipelinePanel({ worktreeId, onClose }: Props) {
                 wire them together on the Pipelines tab.
               </div>
 
-              <h3 className="map-section-title">CLI Tool</h3>
+              <h3 className="map-section-title">Generator Presets</h3>
               <div className="map-presets">
-                {CLI_PRESETS.map((p) => (
+                {GENERATOR_PRESETS.map((p) => (
                   <button
-                    key={p.label}
+                    key={p.label + p.role}
                     type="button"
                     className={
                       "map-preset" +
-                      (agentCommand === p.command && p.command
+                      (agentCommand === p.command &&
+                      agentRole === "generator" &&
+                      p.command
                         ? " map-preset--active"
                         : "")
                     }
                     onClick={() => {
                       setAgentCommand(p.command);
+                      setAgentRole("generator");
                       if (!agentName && p.command)
-                        setAgentName(p.label + " " + agentRole);
+                        setAgentName(p.label + " generator");
+                    }}
+                  >
+                    {p.label}
+                  </button>
+                ))}
+              </div>
+
+              <h3 className="map-section-title">Reviewer Presets</h3>
+              <div className="map-presets">
+                {REVIEWER_PRESETS.map((p) => (
+                  <button
+                    key={p.label + p.role}
+                    type="button"
+                    className={
+                      "map-preset" +
+                      (agentCommand === p.command &&
+                      agentRole === "reviewer" &&
+                      p.command
+                        ? " map-preset--active"
+                        : "")
+                    }
+                    onClick={() => {
+                      setAgentCommand(p.command);
+                      setAgentRole("reviewer");
+                      if (!agentName && p.command)
+                        setAgentName(p.label + " reviewer");
                     }}
                   >
                     {p.label}
@@ -573,6 +656,10 @@ export function MultiAgentPipelinePanel({ worktreeId, onClose }: Props) {
                   {running ? "Running…" : "Run"}
                 </button>
               </div>
+
+              {running && progress && (
+                <div className="map-progress">{progress}</div>
+              )}
 
               {/* Current run result */}
               {activeRun && (

--- a/src/components/TerminalGrid.tsx
+++ b/src/components/TerminalGrid.tsx
@@ -132,3 +132,15 @@ export function TerminalPreview({ cwd, shell, themeId }: TerminalPreviewProps) {
 
   return <div className="terminal-preview" ref={containerRef} />;
 }
+
+/* ------------------------------------------------------------------ */
+/*  TerminalSnapshot — static text preview from existing PTY buffer    */
+/* ------------------------------------------------------------------ */
+
+interface TerminalSnapshotProps {
+  text: string;
+}
+
+export function TerminalSnapshot({ text }: TerminalSnapshotProps) {
+  return <pre className="terminal-snapshot">{text || "\n  No output yet"}</pre>;
+}

--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -27,6 +27,8 @@ interface TerminalTab {
   paneTree: PaneNode;
 }
 
+export type TerminalSnapshotMap = Map<string, string>;
+
 interface TerminalPanelProps {
   cwd: string;
   worktreeName: string;
@@ -35,6 +37,7 @@ interface TerminalPanelProps {
   themeId?: string;
   onAgentComplete?: () => void;
   onAgentNeedsAttention?: () => void;
+  snapshotRef?: React.MutableRefObject<TerminalSnapshotMap>;
 }
 
 let paneCounter = 0;
@@ -80,6 +83,7 @@ export function TerminalPanel({
   themeId,
   onAgentComplete,
   onAgentNeedsAttention,
+  snapshotRef,
 }: TerminalPanelProps) {
   // All per-worktree tab states, keyed by cwd path.
   const [pathStates, setPathStates] = useState<Record<string, PathTabState>>(
@@ -422,6 +426,7 @@ export function TerminalPanel({
                       onAgentNeedsAttention={
                         isActivePathAndTab ? onAgentNeedsAttention : undefined
                       }
+                      snapshotRef={snapshotRef}
                     />,
                     container,
                     paneId,
@@ -445,6 +450,7 @@ interface TerminalInstanceProps {
   themeId?: string;
   onAgentComplete?: () => void;
   onAgentNeedsAttention?: () => void;
+  snapshotRef?: React.MutableRefObject<TerminalSnapshotMap>;
 }
 
 // Image MIME types accepted for drag-and-drop into the terminal.
@@ -497,6 +503,9 @@ const ACTIVITY_THRESHOLD_BYTES = 500;
 // How long the terminal must be idle (ms) after activity before we fire onAgentComplete.
 const IDLE_TIMEOUT_MS = 4000;
 
+const SNAPSHOT_LINES = 24;
+const SNAPSHOT_DEBOUNCE_MS = 2000;
+
 function TerminalInstance({
   cwd,
   active,
@@ -506,6 +515,7 @@ function TerminalInstance({
   themeId,
   onAgentComplete,
   onAgentNeedsAttention,
+  snapshotRef,
 }: TerminalInstanceProps) {
   const initialThemeIdRef = useRef(themeId || DEFAULT_THEME_ID);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -518,6 +528,25 @@ function TerminalInstance({
   onAgentCompleteRef.current = onAgentComplete;
   const onAgentNeedsAttentionRef = useRef(onAgentNeedsAttention);
   onAgentNeedsAttentionRef.current = onAgentNeedsAttention;
+  const snapshotTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const snapshotMapRef = useRef(snapshotRef);
+  snapshotMapRef.current = snapshotRef;
+
+  // Capture last N lines from xterm buffer into the shared snapshot map.
+  const updateSnapshot = useCallback(() => {
+    const term = termRef.current;
+    const map = snapshotMapRef.current?.current;
+    if (!term || !map) return;
+    const buf = term.buffer.active;
+    const lines: string[] = [];
+    const start = Math.max(0, buf.length - SNAPSHOT_LINES);
+    for (let i = start; i < buf.length; i++) {
+      const line = buf.getLine(i);
+      if (line) lines.push(line.translateToString(true));
+    }
+    map.set(cwd, lines.join("\n"));
+  }, [cwd]);
+
   // Keep shell/initCommand in refs so the main useEffect only depends on
   // `cwd`.  Otherwise the terminal is destroyed and recreated when the async
   // settings load resolves (shell goes from default "/bin/zsh" → saved value),
@@ -731,6 +760,13 @@ function TerminalInstance({
               activityBytesRef.current = 0;
             }, IDLE_TIMEOUT_MS);
           }
+
+          // Debounced snapshot update for grid preview tiles
+          if (snapshotTimerRef.current) clearTimeout(snapshotTimerRef.current);
+          snapshotTimerRef.current = setTimeout(
+            updateSnapshot,
+            SNAPSHOT_DEBOUNCE_MS,
+          );
         });
 
         pty.onExit(() => {
@@ -782,6 +818,10 @@ function TerminalInstance({
         clearTimeout(idleTimerRef.current);
         idleTimerRef.current = null;
       }
+      if (snapshotTimerRef.current) {
+        clearTimeout(snapshotTimerRef.current);
+        snapshotTimerRef.current = null;
+      }
       activityBytesRef.current = 0;
       window.removeEventListener("keydown", preventBrowserNav, true);
       try {
@@ -794,7 +834,7 @@ function TerminalInstance({
       ptyRef.current = null;
       fitAddonRef.current = null;
     };
-  }, [cwd]);
+  }, [cwd, updateSnapshot]);
 
   // Only the currently visible terminal should react to native file drops.
   useEffect(() => {

--- a/src/components/WorkspaceGrid.tsx
+++ b/src/components/WorkspaceGrid.tsx
@@ -15,6 +15,11 @@ import "../styles/terminal-grid.css";
 const TerminalPreviewLazy = lazy(() =>
   import("./TerminalGrid").then((m) => ({ default: m.TerminalPreview })),
 );
+const TerminalSnapshotLazy = lazy(() =>
+  import("./TerminalGrid").then((m) => ({ default: m.TerminalSnapshot })),
+);
+
+type TerminalSnapshotMap = Map<string, string>;
 
 interface ProjectInfo {
   id: number;
@@ -38,6 +43,7 @@ interface WorkspaceGridProps {
   onNewWorktree?: (projectId: number) => void;
   shell?: string;
   themeId?: string;
+  snapshotMap?: React.MutableRefObject<TerminalSnapshotMap>;
 }
 
 type CardStatus = "current" | "attention" | "done" | "idle";
@@ -76,6 +82,7 @@ export function WorkspaceGrid({
   onNewWorktree,
   shell,
   themeId,
+  snapshotMap,
 }: WorkspaceGridProps) {
   const { selectedWorktreeId, agentNeedsAttentionIds, agentDoneWorktreeIds } =
     useUiStore();
@@ -457,11 +464,17 @@ export function WorkspaceGrid({
                     {viewMode === "terminals" && shell && (
                       <div className="workspace-card-terminal">
                         <Suspense fallback={null}>
-                          <TerminalPreviewLazy
-                            cwd={wt.path}
-                            shell={shell}
-                            themeId={themeId}
-                          />
+                          {snapshotMap?.current?.has(wt.path) ? (
+                            <TerminalSnapshotLazy
+                              text={snapshotMap.current.get(wt.path) ?? ""}
+                            />
+                          ) : (
+                            <TerminalPreviewLazy
+                              cwd={wt.path}
+                              shell={shell}
+                              themeId={themeId}
+                            />
+                          )}
                         </Suspense>
                       </div>
                     )}

--- a/src/styles/multi-agent-pipeline.css
+++ b/src/styles/multi-agent-pipeline.css
@@ -474,3 +474,21 @@
 .map-btn--export:hover:not(:disabled) {
   background: var(--color-border, #313244);
 }
+
+/* Progress indicator */
+.map-progress {
+  font-size: 12px;
+  color: var(--color-accent, #89b4fa);
+  padding: 8px 0;
+  animation: map-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes map-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}

--- a/src/styles/terminal-grid.css
+++ b/src/styles/terminal-grid.css
@@ -69,3 +69,21 @@
   background: var(--bg-surface, #1a1a2e);
   color: var(--accent, #10b981);
 }
+
+/* ── Terminal snapshot (static text preview) ──────────────────────── */
+
+.terminal-snapshot {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 4px 8px;
+  background: #0c0c0e;
+  color: #ededef;
+  font-family: "JetBrains Mono", "Menlo", "Monaco", monospace;
+  font-size: 10px;
+  line-height: 1.35;
+  overflow: hidden;
+  white-space: pre;
+  pointer-events: none;
+  box-sizing: border-box;
+}


### PR DESCRIPTION
## Summary
- **Separate generator/reviewer presets** — CLI tool preset buttons split by role (Claude Code, Aider, Codex for generators; Claude Code, Aider for reviewers). Clicking auto-sets both command and role.
- **Pipeline progress streaming** — `run_pipeline` now emits `pipeline:progress` events after each generator/reviewer step. Frontend shows live "Iteration 2/3 — generator running..." with a pulsing indicator.
- **Terminal snapshot tiles** — Workspace grid terminal view prefers static text snapshots from existing PTY buffers over spawning new PTYs. Falls back to live preview for worktrees not yet visited.

## Files changed
- `src/components/MultiAgentPipelinePanel.tsx` — preset groups, progress listener
- `src-tauri/src/agents/pipeline.rs` — `PipelineProgressEvent`, emit calls, `AppHandle` param
- `src/components/TerminalPanel.tsx` — `snapshotRef` prop, buffer capture
- `src/components/TerminalGrid.tsx` — `TerminalSnapshot` component
- `src/components/WorkspaceGrid.tsx` — snapshot-first rendering
- `src/App.tsx` — wire snapshot map between TerminalPanel and WorkspaceGrid

## Test plan
- [ ] Open Multi-Agent Pipeline > Agents tab — verify generator and reviewer preset groups
- [ ] Click a preset — should auto-set command AND role
- [ ] Run a pipeline — verify live progress indicator below the Run button
- [ ] Open Mission Control terminal view — tiles should show snapshot text for visited worktrees
- [ ] New/unvisited worktrees should fall back to live terminal preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)