### PR TITLE
feat: context menu, snapshot refresh, shortcuts, presets, history, config export

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -779,6 +779,7 @@ function AppContent({
       {
         id: "ai:multi-agent-pipeline",
         label: "Multi-Agent Pipeline",
+        shortcut: "Cmd+Shift+R",
         category: "AI",
         icon: "\u25B6",
         enabled: () => selectedWorktreeId !== null,
@@ -903,6 +904,12 @@ function AppContent({
         shift: true,
         action: () => togglePanel("errorDiagnosis"),
       },
+      {
+        key: "r",
+        meta: true,
+        shift: true,
+        action: () => togglePanel("multiAgentPipeline"),
+      },
     ],
     [
       setShowSettings,
@@ -995,6 +1002,8 @@ function AppContent({
             onNewWorktree={(projectId: number) => {
               setSelectedProjectId(projectId);
             }}
+            onOpenAgent={() => openPanel("multiAgentPipeline")}
+            onOpenDiff={() => openPanel("gitDiff")}
             shell={terminalShell}
             themeId={terminalThemeId}
             snapshotMap={terminalSnapshotMapRef}

--- a/src/components/MultiAgentPipelinePanel.tsx
+++ b/src/components/MultiAgentPipelinePanel.tsx
@@ -17,6 +17,17 @@ const GENERATOR_PRESETS: CliPreset[] = [
   { label: "Claude Code", role: "generator", command: "claude --print" },
   { label: "Aider", role: "generator", command: "aider --message" },
   { label: "Codex", role: "generator", command: "codex --quiet" },
+  {
+    label: "Test Writer",
+    role: "generator",
+    command: 'claude --print "Write tests for the following code"',
+  },
+  {
+    label: "PR Description",
+    role: "generator",
+    command:
+      'claude --print "Write a pull request description for the current changes"',
+  },
   { label: "Custom", role: "generator", command: "" },
 ];
 
@@ -31,6 +42,18 @@ const REVIEWER_PRESETS: CliPreset[] = [
     label: "Aider",
     role: "reviewer",
     command: 'aider --message "Review the following changes"',
+  },
+  {
+    label: "Lint Checker",
+    role: "reviewer",
+    command:
+      'claude --print "Check for lint issues, type errors, and style problems. Respond APPROVED if clean"',
+  },
+  {
+    label: "Security Review",
+    role: "reviewer",
+    command:
+      'claude --print "Review for security vulnerabilities (XSS, injection, secrets). Respond APPROVED if safe"',
   },
   { label: "Custom", role: "reviewer", command: "" },
 ];
@@ -150,6 +173,11 @@ export function MultiAgentPipelinePanel({ worktreeId, onClose }: Props) {
   const [progress, setProgress] = useState("");
   const unlistenRef = useRef<UnlistenFn | null>(null);
 
+  // Pipeline run history for sparkline display
+  const [pipelineHistory, setPipelineHistory] = useState<
+    Record<number, PipelineRun[]>
+  >({});
+
   // Load agents
   const loadAgents = useCallback(async () => {
     try {
@@ -160,11 +188,24 @@ export function MultiAgentPipelinePanel({ worktreeId, onClose }: Props) {
     }
   }, []);
 
-  // Load pipelines
+  // Load pipelines + their recent run history
   const loadPipelines = useCallback(async () => {
     try {
       const result = await invoke<PipelineDef[]>("list_pipelines");
       setPipelines(result);
+      // Load last 5 runs per pipeline for sparkline
+      const history: Record<number, PipelineRun[]> = {};
+      for (const p of result) {
+        try {
+          const r = await invoke<PipelineRun[]>("list_pipeline_runs", {
+            pipelineId: p.id,
+          });
+          history[p.id] = r.slice(0, 5);
+        } catch {
+          history[p.id] = [];
+        }
+      }
+      setPipelineHistory(history);
     } catch {
       // ignore
     }
@@ -265,6 +306,83 @@ export function MultiAgentPipelinePanel({ worktreeId, onClose }: Props) {
       void loadPipelines();
     } catch {
       // ignore
+    }
+  }
+
+  // ─── Pipeline config export/import ────────────────────────────────────────
+
+  async function handleExportConfig() {
+    const config = {
+      agents: agents.map(({ name, role, command }) => ({
+        name,
+        role,
+        command,
+      })),
+      pipelines: pipelines.map((p) => ({
+        name: p.name,
+        generator: agentName_(p.generator_id),
+        reviewer: agentName_(p.reviewer_id),
+        max_iterations: p.max_iterations,
+      })),
+    };
+    try {
+      const path = await save({
+        defaultPath: "pipeline-config.json",
+        filters: [{ name: "JSON", extensions: ["json"] }],
+      });
+      if (path) {
+        await invoke("save_text_file", {
+          path,
+          contents: JSON.stringify(config, null, 2),
+        });
+      }
+    } catch {
+      // cancelled
+    }
+  }
+
+  async function handleImportConfig(file: File) {
+    try {
+      const text = await file.text();
+      const config = JSON.parse(text) as {
+        agents: { name: string; role: string; command: string }[];
+        pipelines: {
+          name: string;
+          generator: string;
+          reviewer: string;
+          max_iterations: number;
+        }[];
+      };
+      // Create agents
+      for (const a of config.agents) {
+        await invoke("create_agent", {
+          name: a.name,
+          role: a.role,
+          command: a.command,
+        });
+      }
+      await loadAgents();
+      const updatedAgents = await invoke<AgentDef[]>("list_agents");
+      // Create pipelines
+      for (const p of config.pipelines) {
+        const gen = updatedAgents.find(
+          (a) => a.name === p.generator && a.role === "generator",
+        );
+        const rev = updatedAgents.find(
+          (a) => a.name === p.reviewer && a.role === "reviewer",
+        );
+        if (gen && rev) {
+          await invoke("create_pipeline", {
+            name: p.name,
+            generatorId: gen.id,
+            reviewerId: rev.id,
+            maxIterations: p.max_iterations,
+          });
+        }
+      }
+      await loadPipelines();
+    } catch {
+      // ignore parse errors
     }
   }
 
@@ -746,6 +864,28 @@ export function MultiAgentPipelinePanel({ worktreeId, onClose }: Props) {
                 runs in the worktree and can edit files. The reviewer receives
                 the task, generator output, and git diff via stdin.
               </div>
+              <div className="map-config-actions">
+                <button
+                  className="map-btn map-btn--export"
+                  onClick={() => void handleExportConfig()}
+                  disabled={agents.length === 0 && pipelines.length === 0}
+                >
+                  Export Config
+                </button>
+                <label className="map-btn map-btn--export map-import-label">
+                  Import Config
+                  <input
+                    type="file"
+                    accept=".json"
+                    hidden
+                    onChange={(e) => {
+                      const f = e.target.files?.[0];
+                      if (f) void handleImportConfig(f);
+                      e.target.value = "";
+                    }}
+                  />
+                </label>
+              </div>
               <h3 className="map-section-title">Create Pipeline</h3>
               <div className="map-form">
                 <input
@@ -823,6 +963,7 @@ export function MultiAgentPipelinePanel({ worktreeId, onClose }: Props) {
                       <th>Generator</th>
                       <th>Reviewer</th>
                       <th>Max iters</th>
+                      <th>History</th>
                       <th></th>
                     </tr>
                   </thead>
@@ -833,6 +974,20 @@ export function MultiAgentPipelinePanel({ worktreeId, onClose }: Props) {
                         <td>{agentName_(p.generator_id)}</td>
                         <td>{agentName_(p.reviewer_id)}</td>
                         <td>{p.max_iterations}</td>
+                        <td>
+                          <div className="map-sparkline">
+                            {(pipelineHistory[p.id] ?? []).map((r) => (
+                              <span
+                                key={r.id}
+                                className={`map-spark-dot map-spark-dot--${r.status}`}
+                                title={`#${r.id}: ${r.status}`}
+                              />
+                            ))}
+                            {!pipelineHistory[p.id]?.length && (
+                              <span className="map-muted">—</span>
+                            )}
+                          </div>
+                        </td>
                         <td>
                           <button
                             className="map-btn map-btn--danger"

--- a/src/components/TerminalGrid.tsx
+++ b/src/components/TerminalGrid.tsx
@@ -139,8 +139,20 @@ export function TerminalPreview({ cwd, shell, themeId }: TerminalPreviewProps) {
 
 interface TerminalSnapshotProps {
   text: string;
+  themeId?: string;
 }
 
-export function TerminalSnapshot({ text }: TerminalSnapshotProps) {
-  return <pre className="terminal-snapshot">{text || "\n  No output yet"}</pre>;
+export function TerminalSnapshot({ text, themeId }: TerminalSnapshotProps) {
+  const theme = getThemeById(themeId || DEFAULT_THEME_ID);
+  return (
+    <pre
+      className="terminal-snapshot"
+      style={{
+        background: theme.theme.background,
+        color: theme.theme.foreground,
+      }}
+    >
+      {text || "\n  No output yet"}
+    </pre>
+  );
 }

--- a/src/components/WorkspaceGrid.tsx
+++ b/src/components/WorkspaceGrid.tsx
@@ -5,6 +5,7 @@ import {
   useMemo,
   useState,
   useCallback,
+  useReducer,
   useRef,
 } from "react";
 import { invoke } from "@tauri-apps/api/core";
@@ -43,6 +44,8 @@ interface WorkspaceGridProps {
   worktrees: Array<WorktreeInfo & { projectName: string }>;
   onSelectWorktree: (wt: WorktreeInfo) => void;
   onNewWorktree?: (projectId: number) => void;
+  onOpenAgent?: (wt: WorktreeInfo) => void;
+  onOpenDiff?: (wt: WorktreeInfo) => void;
   shell?: string;
   themeId?: string;
   snapshotMap?: React.MutableRefObject<TerminalSnapshotMap>;
@@ -82,6 +85,8 @@ export function WorkspaceGrid({
   worktrees,
   onSelectWorktree,
   onNewWorktree,
+  onOpenAgent,
+  onOpenDiff,
   shell,
   themeId,
   snapshotMap,
@@ -91,6 +96,38 @@ export function WorkspaceGrid({
 
   const [filterTab, setFilterTab] = useState<FilterTab>("all");
   const [viewMode, setViewMode] = useState<ViewMode>("cards");
+
+  // Auto-refresh snapshot tiles every 5s when in terminal view
+  const [, bumpSnapshot] = useReducer((n: number) => n + 1, 0);
+  useEffect(() => {
+    if (viewMode !== "terminals" || !snapshotMap) return;
+    const id = setInterval(bumpSnapshot, 5000);
+    return () => clearInterval(id);
+  }, [viewMode, snapshotMap]);
+
+  // Context menu state
+  const [ctxMenu, setCtxMenu] = useState<{
+    x: number;
+    y: number;
+    wt: WorktreeInfo & { projectName: string };
+  } | null>(null);
+
+  const handleContextMenu = useCallback(
+    (e: React.MouseEvent, wt: WorktreeInfo & { projectName: string }) => {
+      e.preventDefault();
+      e.stopPropagation();
+      setCtxMenu({ x: e.clientX, y: e.clientY, wt });
+    },
+    [],
+  );
+
+  // Close context menu on click anywhere
+  useEffect(() => {
+    if (!ctxMenu) return;
+    const close = () => setCtxMenu(null);
+    window.addEventListener("click", close);
+    return () => window.removeEventListener("click", close);
+  }, [ctxMenu]);
 
   // Command bar state
   const [cmdTask, setCmdTask] = useState("");
@@ -413,6 +450,7 @@ export function WorkspaceGrid({
                       (status === "current" ? " workspace-card--current" : "")
                     }
                     onClick={() => onSelectWorktree(wt)}
+                    onContextMenu={(e) => handleContextMenu(e, wt)}
                     title={shortcutHint ? `Open (${shortcutHint})` : undefined}
                   >
                     <div className="workspace-card-top">
@@ -475,6 +513,7 @@ export function WorkspaceGrid({
                           {snapshotMap?.current?.has(wt.path) ? (
                             <TerminalSnapshotLazy
                               text={snapshotMap.current.get(wt.path) ?? ""}
+                              themeId={themeId}
                             />
                           ) : (
                             <TerminalPreviewLazy
@@ -553,6 +592,51 @@ export function WorkspaceGrid({
           </div>
         )}
       </div>
+
+      {/* Context menu */}
+      {ctxMenu && (
+        <div
+          className="workspace-ctx-menu"
+          style={{ top: ctxMenu.y, left: ctxMenu.x }}
+        >
+          <button
+            type="button"
+            className="workspace-ctx-item"
+            onClick={() => {
+              onSelectWorktree(ctxMenu.wt);
+              setCtxMenu(null);
+            }}
+          >
+            Open Terminal
+          </button>
+          {onOpenAgent && (
+            <button
+              type="button"
+              className="workspace-ctx-item"
+              onClick={() => {
+                onSelectWorktree(ctxMenu.wt);
+                onOpenAgent(ctxMenu.wt);
+                setCtxMenu(null);
+              }}
+            >
+              Run Agent
+            </button>
+          )}
+          {onOpenDiff && (
+            <button
+              type="button"
+              className="workspace-ctx-item"
+              onClick={() => {
+                onSelectWorktree(ctxMenu.wt);
+                onOpenDiff(ctxMenu.wt);
+                setCtxMenu(null);
+              }}
+            >
+              View Changes
+            </button>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/styles/multi-agent-pipeline.css
+++ b/src/styles/multi-agent-pipeline.css
@@ -537,3 +537,43 @@
   font-size: 11px;
   color: var(--color-text-muted, #6c7086);
 }
+
+/* Sparkline history dots */
+.map-sparkline {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+}
+
+.map-spark-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.map-spark-dot--approved {
+  background: #a6e3a1;
+}
+
+.map-spark-dot--failed {
+  background: #f38ba8;
+}
+
+.map-spark-dot--max_iterations {
+  background: #cba6f7;
+}
+
+.map-spark-dot--running {
+  background: #f9e2af;
+}
+
+/* Config export/import actions */
+.map-config-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.map-import-label {
+  cursor: pointer;
+}

--- a/src/styles/terminal-grid.css
+++ b/src/styles/terminal-grid.css
@@ -77,8 +77,6 @@
   height: 100%;
   margin: 0;
   padding: 4px 8px;
-  background: #0c0c0e;
-  color: #ededef;
   font-family: "JetBrains Mono", "Menlo", "Monaco", monospace;
   font-size: 10px;
   line-height: 1.35;

--- a/src/styles/workspace-grid.css
+++ b/src/styles/workspace-grid.css
@@ -459,3 +459,32 @@
   border: 1px solid rgba(239, 68, 68, 0.2);
   border-radius: var(--radius);
 }
+
+/* Context menu */
+.workspace-ctx-menu {
+  position: fixed;
+  z-index: 1000;
+  background: var(--bg-elevated, #16162a);
+  border: 1px solid var(--border-subtle, #2a2a3e);
+  border-radius: 6px;
+  padding: 4px 0;
+  min-width: 160px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+}
+
+.workspace-ctx-item {
+  display: block;
+  width: 100%;
+  background: none;
+  border: none;
+  color: var(--text-primary, #e2e8f0);
+  font-size: 0.82em;
+  padding: 6px 14px;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.workspace-ctx-item:hover {
+  background: var(--bg-surface, #1a1a2e);
+}


### PR DESCRIPTION
## Summary
7 improvements in one PR:

- **Right-click context menu** on workspace grid cards — Open Terminal, Run Agent, View Changes
- **Auto-refresh terminal snapshots** — tiles refresh every 5s in terminal view mode
- **Cmd+Shift+R shortcut** — open Multi-Agent Pipeline from anywhere
- **Theme-aware terminal snapshots** — snapshot tiles use the user's terminal theme colors
- **Expanded agent presets** — Test Writer, PR Description, Lint Checker, Security Review
- **Pipeline run history sparkline** — colored dots showing last 5 run statuses per pipeline
- **Pipeline config export/import** — export agents + pipelines as JSON, import to share configs

## Test plan
- [ ] Right-click a worktree card — context menu with 3 options
- [ ] Click "Run Agent" — should navigate to worktree and open agent panel
- [ ] Switch to terminal view — tiles should refresh every 5s
- [ ] Press Cmd+Shift+R — should toggle Multi-Agent Pipeline panel
- [ ] Terminal snapshots should match the selected terminal theme
- [ ] Agents tab — verify Test Writer, PR Description, Lint Checker, Security Review presets
- [ ] Pipelines tab — verify colored history dots next to each pipeline
- [ ] Export Config button — saves JSON file with agents + pipelines
- [ ] Import Config — creates agents and pipelines from JSON file

🤖 Generated with [Claude Code](https://claude.com/claude-code)