### PR TITLE
feat: streaming output, git ahead/behind, bulk actions

### DIFF
--- a/src-tauri/src/agents/pipeline.rs
+++ b/src-tauri/src/agents/pipeline.rs
@@ -2,8 +2,11 @@ use crate::db::AppDb;
 use rusqlite::params;
 use serde::{Deserialize, Serialize};
 use std::process::Stdio;
+use std::sync::atomic::{AtomicI64, Ordering};
 use tauri::{AppHandle, Emitter, State};
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+static AGENT_RUN_COUNTER: AtomicI64 = AtomicI64::new(0);
 
 #[tauri::command]
 pub async fn save_text_file(path: String, contents: String) -> Result<(), String> {
@@ -602,4 +605,107 @@ pub async fn run_agent_task(
         stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
         exit_code: output.status.code().unwrap_or(-1),
     })
+}
+
+#[derive(Debug, Serialize, Clone)]
+struct AgentOutputEvent {
+    run_id: i64,
+    stream: String,
+    line: String,
+}
+
+#[derive(Debug, Serialize, Clone)]
+struct AgentDoneEvent {
+    run_id: i64,
+    exit_code: i32,
+}
+
+/// Run an agent task with streaming output via events.
+/// Returns a run_id immediately; output arrives via `agent:output` events.
+/// Completion is signalled by an `agent:done` event.
+#[tauri::command]
+pub async fn run_agent_task_streaming(
+    app: AppHandle,
+    db: State<'_, AppDb>,
+    worktree_id: i64,
+    command: String,
+    task_desc: String,
+) -> Result<i64, String> {
+    let worktree_path: String = {
+        let conn = db.0.lock().map_err(|e| format!("DB lock: {e}"))?;
+        conn.query_row(
+            "SELECT path FROM worktrees WHERE id = ?1",
+            params![worktree_id],
+            |row| row.get(0),
+        )
+        .map_err(|e| format!("Worktree not found: {e}"))?
+    };
+
+    let parts = split_command(&command);
+    if parts.is_empty() {
+        return Err("Command must not be empty".into());
+    }
+
+    let run_id = AGENT_RUN_COUNTER.fetch_add(1, Ordering::Relaxed);
+
+    let mut child = tokio::process::Command::new(&parts[0])
+        .args(&parts[1..])
+        .current_dir(&worktree_path)
+        .env("TASK", &task_desc)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("Failed to spawn: {e}"))?;
+
+    let stdout = child.stdout.take();
+    let stderr = child.stderr.take();
+
+    // Stream stdout
+    if let Some(out) = stdout {
+        let app_clone = app.clone();
+        tokio::spawn(async move {
+            let reader = BufReader::new(out);
+            let mut lines = reader.lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                let _ = app_clone.emit(
+                    "agent:output",
+                    AgentOutputEvent {
+                        run_id,
+                        stream: "stdout".into(),
+                        line,
+                    },
+                );
+            }
+        });
+    }
+
+    // Stream stderr
+    if let Some(err) = stderr {
+        let app_clone = app.clone();
+        tokio::spawn(async move {
+            let reader = BufReader::new(err);
+            let mut lines = reader.lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                let _ = app_clone.emit(
+                    "agent:output",
+                    AgentOutputEvent {
+                        run_id,
+                        stream: "stderr".into(),
+                        line,
+                    },
+                );
+            }
+        });
+    }
+
+    // Wait for exit in background
+    tokio::spawn(async move {
+        let exit_code = match child.wait().await {
+            Ok(status) => status.code().unwrap_or(-1),
+            Err(_) => -1,
+        };
+        let _ = app.emit("agent:done", AgentDoneEvent { run_id, exit_code });
+    });
+
+    Ok(run_id)
 }

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -29,6 +29,8 @@ pub struct WorktreeInfo {
     pub status: String,
     pub is_dirty: bool,
     pub port: Option<i64>,
+    pub ahead: u32,
+    pub behind: u32,
     pub created_at: String,
     pub deleted_at: Option<String>,
     pub hidden_at: Option<String>,

--- a/src-tauri/src/git/worktree.rs
+++ b/src-tauri/src/git/worktree.rs
@@ -27,6 +27,7 @@ fn check_is_dirty(path: &str) -> bool {
 
 fn row_to_info(row: queries::WorktreeRow) -> WorktreeInfo {
     let is_dirty = check_is_dirty(&row.path);
+    let (ahead, behind) = count_ahead_behind(&row.path);
     WorktreeInfo {
         id: row.id,
         project_id: row.project_id,
@@ -35,6 +36,8 @@ fn row_to_info(row: queries::WorktreeRow) -> WorktreeInfo {
         status: row.status,
         is_dirty,
         port: row.port,
+        ahead,
+        behind,
         created_at: row.created_at,
         deleted_at: row.deleted_at,
         hidden_at: row.hidden_at,
@@ -190,6 +193,34 @@ pub fn delete_worktree(db: State<'_, AppDb>, worktree_id: i64) -> Result<bool, S
 }
 
 /// Counts commits on the local branch that have not been pushed to its upstream remote.
+fn count_ahead_behind(path: &str) -> (u32, u32) {
+    let repo = match Repository::open(path) {
+        Ok(r) => r,
+        Err(_) => return (0, 0),
+    };
+    let head = match repo.head() {
+        Ok(h) => h,
+        Err(_) => return (0, 0),
+    };
+    let local_oid = match head.target() {
+        Some(oid) => oid,
+        None => return (0, 0),
+    };
+    let branch_name = match head.shorthand() {
+        Some(name) => name.to_string(),
+        None => return (0, 0),
+    };
+    let upstream_ref = format!("refs/remotes/origin/{}", branch_name);
+    let remote_oid = match repo.refname_to_id(&upstream_ref) {
+        Ok(oid) => oid,
+        Err(_) => return (0, 0), // no tracking branch
+    };
+    match repo.graph_ahead_behind(local_oid, remote_oid) {
+        Ok((ahead, behind)) => (ahead as u32, behind as u32),
+        Err(_) => (0, 0),
+    }
+}
+
 fn count_unpushed_commits(path: &str) -> u32 {
     let repo = match Repository::open(path) {
         Ok(r) => r,
@@ -297,6 +328,8 @@ pub fn get_worktree_status(db: State<'_, AppDb>, worktree_id: i64) -> Result<Wor
         row.status.clone()
     };
 
+    let (ahead, behind) = count_ahead_behind(&row.path);
+
     Ok(WorktreeInfo {
         id: row.id,
         project_id: row.project_id,
@@ -305,6 +338,8 @@ pub fn get_worktree_status(db: State<'_, AppDb>, worktree_id: i64) -> Result<Wor
         status,
         is_dirty,
         port: row.port,
+        ahead,
+        behind,
         created_at: row.created_at,
         deleted_at: row.deleted_at,
         hidden_at: row.hidden_at,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -360,6 +360,7 @@ pub fn run() {
             agents::pipeline::get_pipeline_run,
             agents::pipeline::run_pipeline,
             agents::pipeline::run_agent_task,
+            agents::pipeline::run_agent_task_streaming,
             agents::pipeline::save_text_file,
         ])
         .setup(|app| {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1061,6 +1061,7 @@ function AppContent({
         closePanel={closePanel}
         selectedProjectId={selectedProjectId}
         selectedWorktreeId={selectedWorktreeId}
+        allWorktreeIds={allWorktrees.map((wt) => wt.id)}
         selectedWorktreePath={selectedWorktreePath}
         selectedWorktreeName={selectedWorktreeName}
         blameFilePath={blameFilePath}

--- a/src/components/MultiAgentPipelinePanel.tsx
+++ b/src/components/MultiAgentPipelinePanel.tsx
@@ -101,6 +101,7 @@ interface PipelineRun {
 
 interface Props {
   worktreeId: number;
+  allWorktreeIds?: number[];
   onClose: () => void;
 }
 
@@ -142,7 +143,11 @@ const PIPELINE_TEMPLATES: PipelineTemplate[] = [
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
-export function MultiAgentPipelinePanel({ worktreeId, onClose }: Props) {
+export function MultiAgentPipelinePanel({
+  worktreeId,
+  allWorktreeIds,
+  onClose,
+}: Props) {
   const [tab, setTab] = useState<Tab>("quick");
 
   // Agents state
@@ -236,10 +241,11 @@ export function MultiAgentPipelinePanel({ worktreeId, onClose }: Props) {
     }
   }, [selectedPipelineId, loadRuns]);
 
-  // Cleanup progress listener on unmount
+  // Cleanup listeners on unmount
   useEffect(() => {
     return () => {
       unlistenRef.current?.();
+      for (const fn of quickUnlistenRef.current) fn();
     };
   }, []);
 
@@ -430,17 +436,17 @@ export function MultiAgentPipelinePanel({ worktreeId, onClose }: Props) {
     }
   }
 
-  // ─── Quick Run handler ──────────────────────────────────────────────────
+  // ─── Quick Run handler (streaming) ────────────────────────────────────
 
   const [quickCommand, setQuickCommand] = useState("");
   const [quickTask, setQuickTask] = useState("");
   const [quickRunning, setQuickRunning] = useState(false);
-  const [quickResult, setQuickResult] = useState<{
-    stdout: string;
-    stderr: string;
-    exit_code: number;
-  } | null>(null);
+  const [quickLines, setQuickLines] = useState<
+    { stream: string; line: string }[]
+  >([]);
+  const [quickExitCode, setQuickExitCode] = useState<number | null>(null);
   const [quickError, setQuickError] = useState("");
+  const quickUnlistenRef = useRef<UnlistenFn[]>([]);
 
   async function handleQuickRun() {
     setQuickError("");
@@ -449,21 +455,109 @@ export function MultiAgentPipelinePanel({ worktreeId, onClose }: Props) {
       return;
     }
     setQuickRunning(true);
-    setQuickResult(null);
+    setQuickLines([]);
+    setQuickExitCode(null);
+
+    // Clean up prior listeners
+    for (const fn of quickUnlistenRef.current) fn();
+    quickUnlistenRef.current = [];
+
     try {
-      const result = await invoke<{
-        command: string;
-        label: string;
-        stdout: string;
-        stderr: string;
-        exit_code: number;
-      }>("run_agent_task", {
+      const runId = await invoke<number>("run_agent_task_streaming", {
         worktreeId,
         command: quickCommand.trim(),
-        label: "Quick run",
         taskDesc: quickTask.trim(),
       });
-      setQuickResult(result);
+
+      // Listen for output lines
+      const unOutput = await listen<{
+        run_id: number;
+        stream: string;
+        line: string;
+      }>("agent:output", (event) => {
+        if (event.payload.run_id !== runId) return;
+        setQuickLines((prev) => [
+          ...prev,
+          { stream: event.payload.stream, line: event.payload.line },
+        ]);
+      });
+
+      // Listen for completion
+      const unDone = await listen<{
+        run_id: number;
+        exit_code: number;
+      }>("agent:done", (event) => {
+        if (event.payload.run_id !== runId) return;
+        setQuickExitCode(event.payload.exit_code);
+        setQuickRunning(false);
+        // Notify if backgrounded
+        if (
+          !document.hasFocus() &&
+          "Notification" in window &&
+          Notification.permission === "granted"
+        ) {
+          new Notification("Quick Run completed", {
+            body: `Exit code: ${event.payload.exit_code}`,
+            silent: false,
+          });
+        }
+      });
+
+      quickUnlistenRef.current = [unOutput, unDone];
+    } catch (e) {
+      setQuickError(String(e));
+      setQuickRunning(false);
+    }
+  }
+
+  // ─── Bulk Run handler ────────────────────────────────────────────────────
+
+  async function handleBulkRun() {
+    if (!allWorktreeIds || !quickCommand.trim() || !quickTask.trim()) return;
+    setQuickRunning(true);
+    setQuickLines([]);
+    setQuickExitCode(null);
+    setQuickError("");
+
+    try {
+      const results = await Promise.all(
+        allWorktreeIds.map((wtId) =>
+          invoke<{
+            command: string;
+            label: string;
+            stdout: string;
+            stderr: string;
+            exit_code: number;
+          }>("run_agent_task", {
+            worktreeId: wtId,
+            command: quickCommand.trim(),
+            label: `Bulk run (wt ${wtId})`,
+            taskDesc: quickTask.trim(),
+          }).catch((e) => ({
+            command: quickCommand,
+            label: `wt ${wtId}`,
+            stdout: "",
+            stderr: String(e),
+            exit_code: -1,
+          })),
+        ),
+      );
+      const lines = results.flatMap((r) => [
+        { stream: "stdout", line: `── ${r.label} (exit ${r.exit_code}) ──` },
+        ...(r.stdout
+          ? r.stdout
+              .split("\n")
+              .map((l: string) => ({ stream: "stdout", line: l }))
+          : []),
+        ...(r.stderr
+          ? r.stderr
+              .split("\n")
+              .map((l: string) => ({ stream: "stderr", line: l }))
+          : []),
+      ]);
+      setQuickLines(lines);
+      const allPassed = results.every((r) => r.exit_code === 0);
+      setQuickExitCode(allPassed ? 0 : 1);
     } catch (e) {
       setQuickError(String(e));
     } finally {
@@ -663,35 +757,49 @@ export function MultiAgentPipelinePanel({ worktreeId, onClose }: Props) {
                 >
                   {quickRunning ? "Running..." : "Run"}
                 </button>
+                {allWorktreeIds && allWorktreeIds.length > 1 && (
+                  <button
+                    className="map-btn map-btn--export"
+                    onClick={() => void handleBulkRun()}
+                    disabled={quickRunning}
+                    title={`Run on all ${allWorktreeIds.length} worktrees`}
+                  >
+                    Run All ({allWorktreeIds.length})
+                  </button>
+                )}
               </div>
 
-              {quickResult && (
+              {(quickLines.length > 0 || quickExitCode !== null) && (
                 <div className="map-run-result">
                   <div className="map-run-result-header">
                     <span>Quick Run</span>
-                    <span
-                      className={`map-badge map-badge--${quickResult.exit_code === 0 ? "approved" : "failed"}`}
-                    >
-                      exit {quickResult.exit_code}
-                    </span>
+                    {quickExitCode !== null ? (
+                      <span
+                        className={`map-badge map-badge--${quickExitCode === 0 ? "approved" : "failed"}`}
+                      >
+                        exit {quickExitCode}
+                      </span>
+                    ) : (
+                      <span className="map-badge map-badge--running">
+                        running
+                      </span>
+                    )}
                   </div>
                   <div className="map-step-body">
-                    {quickResult.stdout && (
-                      <>
-                        <p className="map-step-label">stdout</p>
-                        <pre className="map-pre">{quickResult.stdout}</pre>
-                      </>
-                    )}
-                    {quickResult.stderr && (
-                      <>
-                        <p className="map-step-label map-step-label--err">
-                          stderr
-                        </p>
-                        <pre className="map-pre map-pre--err">
-                          {quickResult.stderr}
-                        </pre>
-                      </>
-                    )}
+                    <pre className="map-pre map-pre--stream">
+                      {quickLines.map((l, i) => (
+                        <span
+                          key={i}
+                          className={
+                            l.stream === "stderr" ? "map-line--err" : ""
+                          }
+                        >
+                          {l.line}
+                          {"\n"}
+                        </span>
+                      ))}
+                      {quickRunning && <span className="map-cursor">_</span>}
+                    </pre>
                   </div>
                 </div>
               )}

--- a/src/components/PanelHost.tsx
+++ b/src/components/PanelHost.tsx
@@ -242,6 +242,7 @@ interface PanelHostProps {
   closePanel: (name: PanelKey) => void;
   selectedProjectId: number | null;
   selectedWorktreeId: number | null;
+  allWorktreeIds?: number[];
   selectedWorktreePath: string | null;
   selectedWorktreeName: string | null;
   blameFilePath: string;
@@ -268,6 +269,7 @@ export function PanelHost({
   closePanel,
   selectedProjectId,
   selectedWorktreeId,
+  allWorktreeIds,
   selectedWorktreePath,
   selectedWorktreeName,
   blameFilePath,
@@ -383,6 +385,7 @@ export function PanelHost({
         <PanelBoundary name="MultiAgentPipeline">
           <MultiAgentPipelinePanel
             worktreeId={selectedWorktreeId}
+            allWorktreeIds={allWorktreeIds}
             onClose={() => closePanel("multiAgentPipeline")}
           />
         </PanelBoundary>

--- a/src/components/WorkspaceGrid.tsx
+++ b/src/components/WorkspaceGrid.tsx
@@ -37,6 +37,8 @@ interface WorktreeInfo {
   status: string;
   is_dirty?: boolean;
   port?: number | null;
+  ahead?: number;
+  behind?: number;
 }
 
 interface WorkspaceGridProps {
@@ -505,6 +507,20 @@ export function WorkspaceGrid({
                       )}
                       {wt.port ? (
                         <span className="workspace-card-port">:{wt.port}</span>
+                      ) : null}
+                      {(wt.ahead ?? 0) > 0 || (wt.behind ?? 0) > 0 ? (
+                        <span className="workspace-card-sync">
+                          {(wt.ahead ?? 0) > 0 && (
+                            <span className="workspace-card-ahead">
+                              {wt.ahead}↑
+                            </span>
+                          )}
+                          {(wt.behind ?? 0) > 0 && (
+                            <span className="workspace-card-behind">
+                              {wt.behind}↓
+                            </span>
+                          )}
+                        </span>
                       ) : null}
                     </div>
                     {viewMode === "terminals" && shell && (

--- a/src/styles/multi-agent-pipeline.css
+++ b/src/styles/multi-agent-pipeline.css
@@ -577,3 +577,27 @@
 .map-import-label {
   cursor: pointer;
 }
+
+/* Streaming output */
+.map-pre--stream {
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.map-line--err {
+  color: var(--color-red, #f38ba8);
+}
+
+.map-cursor {
+  animation: map-blink 1s step-end infinite;
+}
+
+@keyframes map-blink {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0;
+  }
+}

--- a/src/styles/workspace-grid.css
+++ b/src/styles/workspace-grid.css
@@ -460,6 +460,23 @@
   border-radius: var(--radius);
 }
 
+/* Git sync indicators */
+.workspace-card-sync {
+  font-family: var(--font-mono);
+  font-size: 0.65em;
+  display: flex;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.workspace-card-ahead {
+  color: #3b82f6;
+}
+
+.workspace-card-behind {
+  color: #f59e0b;
+}
+
 /* Context menu */
 .workspace-ctx-menu {
   position: fixed;


### PR DESCRIPTION
## Summary
The final 3 improvements that needed Rust backend work:

- **Streaming agent output** — Quick Run now streams stdout/stderr line-by-line in real time via `agent:output` Tauri events. Output appears as it's generated with a blinking cursor, instead of blocking until completion.
- **Git ahead/behind on cards** — Workspace grid cards show commit sync status (e.g. "2↑ 1↓") computed via git2's `graph_ahead_behind`. Blue for ahead (unpushed), amber for behind (needs pull).
- **Bulk worktree actions** — "Run All" button on Quick Run tab runs the same agent command across all worktrees in parallel via `Promise.all`, with aggregated results.

## Backend changes
- `src-tauri/src/agents/pipeline.rs` — new `run_agent_task_streaming` command, `AgentOutputEvent`/`AgentDoneEvent` structs
- `src-tauri/src/git/mod.rs` — added `ahead: u32, behind: u32` to `WorktreeInfo`
- `src-tauri/src/git/worktree.rs` — new `count_ahead_behind()` function, updated `row_to_info()`

## Test plan
- [ ] Quick Run: enter a command + task, click Run — output should stream line-by-line
- [ ] Stderr lines should appear in red
- [ ] Blinking cursor visible while running
- [ ] Mission Control cards: worktrees with unpushed commits show "N↑" in blue
- [ ] Worktrees behind upstream show "N↓" in amber
- [ ] Quick Run "Run All" button visible when multiple worktrees exist
- [ ] Click "Run All" — runs on all worktrees in parallel, shows aggregated output

🤖 Generated with [Claude Code](https://claude.com/claude-code)