### PR TITLE
chore: bump version to 0.1.25

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.1.24",
+  "version": "0.1.25",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6131,7 +6131,7 @@ dependencies = [
 
 [[package]]
 name = "workroot"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.1.24"
+version = "0.1.25"
 edition = "2021"
 authors = ["Saurav Panda <saurav@workroot.dev>"]
 description = "A local-first developer workspace for managing projects, terminals, and Git workflows."

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary
- Bump version to 0.1.25 across package.json, Cargo.toml, tauri.conf.json

## What's in this release
- Terminal grid view in Mission Control with live terminal previews
- Multi-agent pipeline: Quick Run, pipeline templates, streaming output
- Generator/reviewer preset groups with expanded presets (Test Writer, Security Review, etc.)
- Pipeline progress streaming with live status indicators
- Terminal snapshots (theme-aware, auto-refreshing)
- Right-click context menu on worktree cards
- Pipeline config JSON export/import
- Pipeline run history sparkline
- Git ahead/behind commit counts on workspace cards
- Bulk worktree actions (Run All)
- Cmd+Shift+R shortcut for Multi-Agent Pipeline
- Pipeline completion browser notifications
- Run log export to Markdown