### PR TITLE
fix: remove broken green highlight on show hidden worktrees button

### DIFF
--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -727,6 +727,8 @@
   font-size: 0.65em;
   background: none;
   border: none;
+  outline: none;
+  -webkit-appearance: none;
   color: var(--text-muted);
   cursor: pointer;
   text-align: left;
@@ -739,6 +741,13 @@
 .show-hidden-btn:hover {
   opacity: 1;
   color: var(--text-secondary);
+}
+
+.show-hidden-btn:focus-visible {
+  opacity: 1;
+  color: var(--text-secondary);
+  outline: 1px solid var(--border);
+  border-radius: var(--radius-sm);
 }
 
 .worktree-list-hidden {


### PR DESCRIPTION
## Summary
- Reset `outline` and `-webkit-appearance` on `.show-hidden-btn` to prevent browser/Tailwind default focus styling from bleeding a green background over the button text
- Added a subtle `focus-visible` style for keyboard navigation accessibility

Fixes #363

## Test plan
- [ ] Open a repo with no active worktrees and verify the "Show hidden worktrees" button has no green background
- [ ] Tab-navigate to the button and verify a subtle border appears on focus