### PR TITLE
fix: make sidebar repo names more prominent

### DIFF
--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -468,7 +468,7 @@
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 1px;
+  gap: 2px;
 }
 
 .project-name-row {
@@ -480,7 +480,8 @@
 
 .project-name {
   font-weight: 600;
-  font-size: 0.88em;
+  font-size: 0.92em;
+  color: var(--text-primary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -492,12 +493,12 @@
 
 .project-path {
   font-family: var(--font-mono);
-  font-size: 0.74em;
+  font-size: 0.68em;
   color: var(--text-muted);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  opacity: 0.6;
+  opacity: 0.5;
   transition: opacity var(--transition-fast);
   line-height: 1.3;
 }


### PR DESCRIPTION
## Summary
- Increased project name font size (0.88em -> 0.92em) and added explicit `color: var(--text-primary)` so repo names are the clear primary label
- Reduced path font size (0.74em -> 0.68em) and opacity (0.6 -> 0.5) to make it clearly secondary
- Increased gap between name and path (1px -> 2px) for better visual separation

Fixes #366

## Test plan
- [ ] Verify repo names in sidebar are clearly readable and prominent
- [ ] Verify paths appear as secondary/dimmed info below the name
- [ ] Check across different sidebar widths that names don't get cut off prematurely