### PR TITLE
fix: sanitize branch names from prompt text to avoid path failures

### DIFF
--- a/src/components/WorkspaceGrid.tsx
+++ b/src/components/WorkspaceGrid.tsx
@@ -75,9 +75,9 @@ function slugifyTask(task: string): string {
     .trim()
     .replace(/\s+/g, "-")
     .replace(/-+/g, "-")
-    .slice(0, 50)
+    .slice(0, 40)
     .replace(/-$/, "");
-  return slug ? `task/${slug}` : "task/new";
+  return slug ? `task-${slug}` : `task-${Date.now()}`;
 }
 
 type ViewMode = "cards" | "terminals";


### PR DESCRIPTION
## Summary
- Changed branch name prefix from `task/` to `task-` to avoid nested directory issues in `.git/worktrees/`
- Reduced slug max length from 50 to 40 chars to stay within filesystem path limits
- Use timestamp fallback when slugification produces an empty string

Fixes #369

## Test plan
- [ ] Enter a long prompt text (e.g. "are there any security vulnerabilities we should review?") and verify worktree creation succeeds
- [ ] Enter a prompt with special characters and verify a clean branch name is generated
- [ ] Enter an empty/whitespace-only prompt and verify it's handled gracefully