### PR TITLE
fix: show friendly message for repos without commits

### DIFF
--- a/src/components/ProjectGroup.tsx
+++ b/src/components/ProjectGroup.tsx
@@ -184,7 +184,13 @@ export function ProjectGroup({
 
         <CollapsibleContent>
           <div className="project-children">
-            {error && <div className="project-error">{error}</div>}
+            {error && (
+              <div className="project-error">
+                {error.includes("no commits yet")
+                  ? "This repo has no commits yet — make an initial commit to enable worktrees."
+                  : error}
+              </div>
+            )}
 
             {filteredWorktrees.length === 0 && !showNewWorktree && (
               <div className="project-empty">

--- a/src/components/WorkspaceGrid.tsx
+++ b/src/components/WorkspaceGrid.tsx
@@ -603,7 +603,11 @@ export function WorkspaceGrid({
               {spawning ? "Creating\u2026" : "Run"}
             </button>
             {spawnError && (
-              <div className="workspace-cmd-error">{spawnError}</div>
+              <div className="workspace-cmd-error">
+                {spawnError.includes("no commits yet")
+                  ? "This repo has no commits yet — make an initial commit to enable worktrees."
+                  : spawnError}
+              </div>
             )}
           </div>
         )}


### PR DESCRIPTION
## Summary
- Detect "no commits yet" errors from the backend and replace with a clear, actionable message
- Applied to both the sidebar worktree creation form (ProjectGroup) and the Mission Control spawn command bar (WorkspaceGrid)

Fixes #367

## Test plan
- [ ] Try to create a worktree from sidebar for a repo with no commits — verify friendly message appears
- [ ] Try to run a prompt from Mission Control targeting a repo with no commits — verify friendly message appears
- [ ] Verify normal worktree creation still works for repos with commits