### PR TITLE
fix: auto-expand sidebar repo when worktree selected from Mission Control

### DIFF
--- a/src/components/ProjectGroup.tsx
+++ b/src/components/ProjectGroup.tsx
@@ -65,6 +65,13 @@ export function ProjectGroup({
     }
   }, [filter, expanded]);
 
+  // Auto-expand when this project is selected (e.g. from Mission Control).
+  useEffect(() => {
+    if (isSelected && !expanded) {
+      setExpanded(true);
+    }
+  }, [isSelected, expanded]);
+
   const q = filter.trim().toLowerCase();
   const filteredWorktrees = q
     ? worktrees.filter((wt) => wt.branch_name.toLowerCase().includes(q))


### PR DESCRIPTION
## Summary
- Added an effect in ProjectGroup that auto-expands the project section when it becomes the selected project (e.g. from Mission Control navigation)
- Worktree highlighting was already working via `selectedWorktreeId` in the UI store — this fix ensures the parent repo is also expanded to reveal it

Fixes #368

## Test plan
- [ ] Click a worktree card in Mission Control — verify the sidebar expands the parent repo and highlights the worktree
- [ ] Manually collapse a repo in sidebar, then select its worktree from Mission Control — verify it re-expands
- [ ] Verify manually expanding/collapsing repos in the sidebar still works normally