### PR TITLE
fix: wire up new worktree button in Mission Control to command bar

### DIFF
--- a/src/components/WorkspaceGrid.tsx
+++ b/src/components/WorkspaceGrid.tsx
@@ -548,7 +548,11 @@ export function WorkspaceGrid({
                 <button
                   type="button"
                   className="workspace-card workspace-card--new"
-                  onClick={() => onNewWorktree?.(project.id)}
+                  onClick={() => {
+                    setCmdProjectId(project.id);
+                    cmdInputRef.current?.focus();
+                    onNewWorktree?.(project.id);
+                  }}
                   aria-label={`New worktree in ${project.name}`}
                 >
                   <span className="workspace-card-plus">+</span>


### PR DESCRIPTION
## Summary
- Clicking "+ Worktree" on a project card in Mission Control now pre-selects that project in the command bar and focuses the task input
- Users can immediately type a task description and hit Enter to create the worktree

Fixes #364

## Test plan
- [ ] Click "+ Worktree" on a project in Mission Control — verify the command bar focuses with the project pre-selected
- [ ] Type a task and press Enter — verify the worktree is created for the correct project
- [ ] Verify the command bar still works normally when typing without clicking "+ Worktree" first