### PR TITLE
fix: remove language/framework badges from sidebar repo list

### DIFF
--- a/src/components/ProjectGroup.tsx
+++ b/src/components/ProjectGroup.tsx
@@ -165,9 +165,6 @@ export function ProjectGroup({
               </span>
             </span>
             <span className="project-badges">
-              {project.framework && (
-                <span className="project-framework">{project.framework}</span>
-              )}
               {expanded && worktrees.length > 0 && (
                 <span className="project-wt-count">
                   {q && filteredWorktrees.length !== worktrees.length

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -509,16 +509,6 @@
   flex-shrink: 0;
 }
 
-.project-framework {
-  font-family: var(--font-mono);
-  font-size: 0.7em;
-  background: var(--bg-elevated);
-  border: 1px solid var(--border-subtle);
-  padding: 1px 5px;
-  border-radius: var(--radius-sm);
-  color: var(--text-muted);
-  letter-spacing: 0.03em;
-}
 
 .project-wt-count {
   font-size: 0.7em;

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -509,7 +509,6 @@
   flex-shrink: 0;
 }
 
-
 .project-wt-count {
   font-size: 0.7em;
   font-weight: 700;


### PR DESCRIPTION
## Summary
- Removed framework badges (Python, Vite, etc.) from sidebar project headers
- Removed the associated `.project-framework` CSS class

Fixes #374

## Test plan
- [ ] Verify sidebar shows repo names without framework badges
- [ ] Verify worktree count badge and "missing" badge still display correctly