### PR TITLE
fix: remove Changes and PR buttons from top content toolbar

### DIFF
--- a/src/components/ContentToolbar.tsx
+++ b/src/components/ContentToolbar.tsx
@@ -1,6 +1,3 @@
-import { TabsRoot, TabsList, TabsTrigger } from "./ui/tabs";
-import { ScrollArea, ScrollBar } from "./ui/scroll-area";
-
 interface ContentToolbarProps {
   activeTab: string;
   onTabChange: (tab: string) => void;
@@ -8,53 +5,7 @@ interface ContentToolbarProps {
   projectName?: string;
 }
 
-const TABS = [
-  {
-    id: "changes",
-    label: "Changes",
-    icon: (
-      <svg
-        viewBox="0 0 16 16"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        className="size-3.5 shrink-0"
-      >
-        <path d="M8 2v12" />
-        <path d="M4 6l4-4 4 4" />
-        <path d="M3 10h10" />
-      </svg>
-    ),
-  },
-  {
-    id: "pr",
-    label: "PR",
-    icon: (
-      <svg
-        viewBox="0 0 16 16"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="1.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        className="size-3.5 shrink-0"
-      >
-        <circle cx="5" cy="3.5" r="1.5" />
-        <circle cx="5" cy="12.5" r="1.5" />
-        <circle cx="11" cy="12.5" r="1.5" />
-        <path d="M5 5v6" />
-        <path d="M11 5v6" />
-        <path d="M11 5c0-1.5-1-2-3-2" />
-      </svg>
-    ),
-  },
-] as const;
-
 export function ContentToolbar({
-  activeTab,
-  onTabChange,
   worktreeName,
   projectName,
 }: ContentToolbarProps) {
@@ -85,30 +36,6 @@ export function ContentToolbar({
           {worktreeName}
         </span>
       </div>
-
-      {/* Divider */}
-      <div className="mx-1 h-4 w-px shrink-0 bg-[var(--border-subtle)] opacity-60" />
-
-      {/* Scrollable tabs */}
-      <TabsRoot
-        value={activeTab}
-        onValueChange={onTabChange}
-        className="min-w-0 flex-1 overflow-hidden self-stretch"
-      >
-        <ScrollArea className="h-full w-full" type="scroll">
-          <TabsList className="h-10 w-max flex-nowrap">
-            {TABS.map((tab) => (
-              <TabsTrigger key={tab.id} value={tab.id}>
-                <span className="opacity-50 transition-opacity duration-150 group-data-[state=active]:opacity-100 group-data-[state=active]:text-[var(--accent)]">
-                  {tab.icon}
-                </span>
-                <span className="leading-none">{tab.label}</span>
-              </TabsTrigger>
-            ))}
-          </TabsList>
-          <ScrollBar orientation="horizontal" />
-        </ScrollArea>
-      </TabsRoot>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Removed the Changes and PR tab buttons from the content toolbar
- Kept the project/worktree breadcrumb for context
- These panels are still accessible from worktree context menus and sidebar

Fixes #371

## Test plan
- [ ] Verify the top bar shows only the breadcrumb (project / worktree name)
- [ ] Verify Changes panel is still accessible from worktree context menu
- [ ] Verify PR panel is still accessible from worktree context menu