### PR TITLE
fix: ensure terminal content area fills all available window space

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -123,8 +123,14 @@
   box-sizing: border-box;
 }
 
-body {
+html,
+body,
+#root {
+  height: 100%;
   margin: 0;
+}
+
+body {
   background-color: var(--bg-base);
 }
 

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -59,7 +59,7 @@
 .content-area {
   flex: 1;
   min-width: 0;
-  height: 100%;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   overflow: hidden;


### PR DESCRIPTION
## Summary
- Added `height: 100%` to `html`, `body`, and `#root` to establish a proper height chain for percentage-based sizing
- Replaced `height: 100%` with `min-height: 0` on `.content-area` — `flex: 1` handles sizing in flex containers while the explicit height could cause overflow

Fixes #372

## Test plan
- [ ] Verify terminal fills the full available width and height with no dead gaps
- [ ] Verify the status bar stays at the bottom edge
- [ ] Verify sidebar resize still works correctly
- [ ] Test with and without sidebar visible (Mission Control vs worktree view)