### PR TITLE
fix: track and display running agent status in Mission Control

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -82,6 +82,8 @@ function AppContent({
     setSelectedWorktreeName,
     markAgentDone,
     markAgentNeedsAttention,
+    markAgentRunning,
+    clearAgentRunning,
   } = useUiStore();
 
   const [isGitHubConnected, setIsGitHubConnected] = useState(false);
@@ -149,10 +151,18 @@ function AppContent({
   const contentTabRef = useRef(contentTab);
   contentTabRef.current = contentTab;
 
+  const handleAgentActivity = useCallback(() => {
+    const id = selectedWorktreeIdRef.current;
+    if (id !== null) markAgentRunning(id);
+  }, [markAgentRunning]);
+
   const handleAgentComplete = useCallback(() => {
     const id = selectedWorktreeIdRef.current;
     const name = selectedWorktreeNameRef.current ?? "Terminal";
-    if (id !== null) markAgentDone(id);
+    if (id !== null) {
+      markAgentDone(id);
+      clearAgentRunning(id);
+    }
     if (!document.hasFocus()) {
       if ("Notification" in window && Notification.permission === "granted") {
         new Notification("Agent completed", {
@@ -163,11 +173,14 @@ function AppContent({
     } else if (contentTabRef.current !== "terminal") {
       setAgentDoneToast(name);
     }
-  }, [markAgentDone]);
+  }, [markAgentDone, clearAgentRunning]);
 
   const handleAgentNeedsAttention = useCallback(() => {
     const id = selectedWorktreeIdRef.current;
-    if (id !== null) markAgentNeedsAttention(id);
+    if (id !== null) {
+      markAgentNeedsAttention(id);
+      clearAgentRunning(id);
+    }
     if (!document.hasFocus()) {
       if ("Notification" in window && Notification.permission === "granted") {
         new Notification("Agent needs attention", {
@@ -176,7 +189,7 @@ function AppContent({
         });
       }
     }
-  }, [markAgentNeedsAttention]);
+  }, [markAgentNeedsAttention, clearAgentRunning]);
 
   // Reset content tab and close tab-launched panels when switching worktrees
   useEffect(() => {
@@ -1041,6 +1054,7 @@ function AppContent({
               shell={terminalShell}
               initCommand={terminalInitCommand}
               themeId={terminalThemeId}
+              onAgentActivity={handleAgentActivity}
               onAgentComplete={handleAgentComplete}
               onAgentNeedsAttention={handleAgentNeedsAttention}
               snapshotRef={terminalSnapshotMapRef}

--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -35,6 +35,7 @@ interface TerminalPanelProps {
   shell: string;
   initCommand: string | null;
   themeId?: string;
+  onAgentActivity?: () => void;
   onAgentComplete?: () => void;
   onAgentNeedsAttention?: () => void;
   snapshotRef?: React.MutableRefObject<TerminalSnapshotMap>;
@@ -81,6 +82,7 @@ export function TerminalPanel({
   shell,
   initCommand,
   themeId,
+  onAgentActivity,
   onAgentComplete,
   onAgentNeedsAttention,
   snapshotRef,
@@ -420,6 +422,9 @@ export function TerminalPanel({
                       shell={shell}
                       initCommand={initCommand}
                       themeId={themeId}
+                      onAgentActivity={
+                        isActivePathAndTab ? onAgentActivity : undefined
+                      }
                       onAgentComplete={
                         isActivePathAndTab ? onAgentComplete : undefined
                       }
@@ -448,6 +453,7 @@ interface TerminalInstanceProps {
   shell: string;
   initCommand: string | null;
   themeId?: string;
+  onAgentActivity?: () => void;
   onAgentComplete?: () => void;
   onAgentNeedsAttention?: () => void;
   snapshotRef?: React.MutableRefObject<TerminalSnapshotMap>;
@@ -513,6 +519,7 @@ function TerminalInstance({
   shell,
   initCommand,
   themeId,
+  onAgentActivity,
   onAgentComplete,
   onAgentNeedsAttention,
   snapshotRef,
@@ -524,6 +531,8 @@ function TerminalInstance({
   const fitAddonRef = useRef<FitAddon | null>(null);
   const activityBytesRef = useRef(0);
   const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const onAgentActivityRef = useRef(onAgentActivity);
+  onAgentActivityRef.current = onAgentActivity;
   const onAgentCompleteRef = useRef(onAgentComplete);
   onAgentCompleteRef.current = onAgentComplete;
   const onAgentNeedsAttentionRef = useRef(onAgentNeedsAttention);
@@ -727,7 +736,15 @@ function TerminalInstance({
           // Activity tracking for agent-complete detection.
           const byteLen =
             typeof data === "string" ? data.length : (data?.length ?? 0);
+          const wasBelowThreshold =
+            activityBytesRef.current < ACTIVITY_THRESHOLD_BYTES;
           activityBytesRef.current += byteLen;
+          if (
+            wasBelowThreshold &&
+            activityBytesRef.current >= ACTIVITY_THRESHOLD_BYTES
+          ) {
+            onAgentActivityRef.current?.();
+          }
 
           // Check for patterns that suggest the agent needs user input.
           try {

--- a/src/components/WorkspaceGrid.tsx
+++ b/src/components/WorkspaceGrid.tsx
@@ -53,14 +53,15 @@ interface WorkspaceGridProps {
   snapshotMap?: React.MutableRefObject<TerminalSnapshotMap>;
 }
 
-type CardStatus = "current" | "attention" | "done" | "idle";
+type CardStatus = "current" | "attention" | "done" | "running" | "idle";
 type FilterTab = "all" | "attention" | "active" | "done";
 
 const STATUS_RANK: Record<CardStatus, number> = {
   attention: 0,
   current: 1,
-  done: 2,
-  idle: 3,
+  running: 2,
+  done: 3,
+  idle: 4,
 };
 
 function formatPath(path: string): string {
@@ -93,8 +94,12 @@ export function WorkspaceGrid({
   themeId,
   snapshotMap,
 }: WorkspaceGridProps) {
-  const { selectedWorktreeId, agentNeedsAttentionIds, agentDoneWorktreeIds } =
-    useUiStore();
+  const {
+    selectedWorktreeId,
+    agentNeedsAttentionIds,
+    agentDoneWorktreeIds,
+    agentRunningWorktreeIds,
+  } = useUiStore();
 
   const [filterTab, setFilterTab] = useState<FilterTab>("all");
   const [viewMode, setViewMode] = useState<ViewMode>("cards");
@@ -190,9 +195,15 @@ export function WorkspaceGrid({
       if (agentNeedsAttentionIds.has(wt.id)) return "attention";
       if (selectedWorktreeId === wt.id) return "current";
       if (agentDoneWorktreeIds.has(wt.id)) return "done";
+      if (agentRunningWorktreeIds.has(wt.id)) return "running";
       return "idle";
     },
-    [selectedWorktreeId, agentNeedsAttentionIds, agentDoneWorktreeIds],
+    [
+      selectedWorktreeId,
+      agentNeedsAttentionIds,
+      agentDoneWorktreeIds,
+      agentRunningWorktreeIds,
+    ],
   );
 
   // All worktrees sorted by activity (attention > current > done > idle),
@@ -465,7 +476,9 @@ export function WorkspaceGrid({
                               ? " workspace-card-dot--attention"
                               : status === "done"
                                 ? " workspace-card-dot--done"
-                                : "")
+                                : status === "running"
+                                  ? " workspace-card-dot--running"
+                                  : "")
                         }
                         aria-hidden
                       />
@@ -491,7 +504,9 @@ export function WorkspaceGrid({
                               ? " workspace-card-status--attention"
                               : status === "done"
                                 ? " workspace-card-status--done"
-                                : "")
+                                : status === "running"
+                                  ? " workspace-card-status--running"
+                                  : "")
                         }
                       >
                         {status === "current"
@@ -500,7 +515,9 @@ export function WorkspaceGrid({
                             ? "Attention"
                             : status === "done"
                               ? "Done"
-                              : "Idle"}
+                              : status === "running"
+                                ? "Running"
+                                : "Idle"}
                       </span>
                       {wt.is_dirty && (
                         <span className="workspace-card-dirty">M</span>

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -72,6 +72,9 @@ export function MainLayout({
   const [agentNeedsAttentionIds, setAgentNeedsAttentionIds] = useState<
     Set<number>
   >(() => new Set());
+  const [agentRunningWorktreeIds, setAgentRunningWorktreeIds] = useState<
+    Set<number>
+  >(() => new Set());
 
   // Project tabs state
   const [allProjects, setAllProjects] = useState<ProjectTab[]>([]);
@@ -177,6 +180,18 @@ export function MainLayout({
     });
   }, []);
 
+  const markAgentRunning = useCallback((id: number) => {
+    setAgentRunningWorktreeIds((prev) => new Set(prev).add(id));
+  }, []);
+
+  const clearAgentRunning = useCallback((id: number) => {
+    setAgentRunningWorktreeIds((prev) => {
+      const next = new Set(prev);
+      next.delete(id);
+      return next;
+    });
+  }, []);
+
   const dragging = useRef(false);
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
@@ -239,6 +254,9 @@ export function MainLayout({
           agentNeedsAttentionIds,
           markAgentNeedsAttention,
           clearAgentNeedsAttention,
+          agentRunningWorktreeIds,
+          markAgentRunning,
+          clearAgentRunning,
         }),
         [
           selectedProjectId,
@@ -253,6 +271,9 @@ export function MainLayout({
           agentNeedsAttentionIds,
           markAgentNeedsAttention,
           clearAgentNeedsAttention,
+          agentRunningWorktreeIds,
+          markAgentRunning,
+          clearAgentRunning,
         ],
       )}
     >

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -17,6 +17,9 @@ interface UiContextValue {
   agentNeedsAttentionIds: Set<number>;
   markAgentNeedsAttention: (id: number) => void;
   clearAgentNeedsAttention: (id: number) => void;
+  agentRunningWorktreeIds: Set<number>;
+  markAgentRunning: (id: number) => void;
+  clearAgentRunning: (id: number) => void;
 }
 
 export const UiContext = createContext<UiContextValue>({
@@ -36,6 +39,9 @@ export const UiContext = createContext<UiContextValue>({
   agentNeedsAttentionIds: new Set(),
   markAgentNeedsAttention: () => {},
   clearAgentNeedsAttention: () => {},
+  agentRunningWorktreeIds: new Set(),
+  markAgentRunning: () => {},
+  clearAgentRunning: () => {},
 });
 
 export function useUiStore() {

--- a/src/styles/workspace-grid.css
+++ b/src/styles/workspace-grid.css
@@ -258,6 +258,17 @@
   color: var(--success, #10b981);
 }
 
+/* "Running" status dot */
+.workspace-card-dot--running {
+  background: var(--warning, #f59e0b);
+  box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.15);
+}
+
+/* "Running" status label */
+.workspace-card-status--running {
+  color: var(--warning, #f59e0b);
+}
+
 /* Shortcut hint badge */
 .workspace-card-shortcut {
   font-family: var(--font-mono);


### PR DESCRIPTION
## Summary
- Added `agentRunningWorktreeIds` to UI store for tracking active agent state
- Terminal fires `onAgentActivity` when output exceeds the activity threshold (500 bytes)
- Running state is cleared when agent completes or needs attention
- Mission Control now shows "Running" with a yellow dot/label instead of "Idle" for active worktrees
- Added CSS styles for the new running status indicator

Fixes #377

## Test plan
- [ ] Start an agent in a worktree, open Mission Control — verify it shows "Running" with yellow indicator
- [ ] Wait for agent to complete — verify status changes from "Running" to "Done"
- [ ] Verify worktrees without active agents still show "Idle"