### PR TITLE
fix: auto-clean stale worktree paths instead of erroring

### DIFF
--- a/src-tauri/src/git/worktree.rs
+++ b/src-tauri/src/git/worktree.rs
@@ -106,10 +106,40 @@ pub fn create_worktree(
     }
 
     if worktree_path.exists() {
-        return Err(format!(
-            "Worktree path already exists: {}",
-            worktree_path.display()
-        ));
+        // Check if this is a stale worktree directory (exists on disk but not
+        // registered in git). If so, clean it up and continue.
+        let is_registered = repo
+            .worktrees()
+            .map(|wts| {
+                (0..wts.len()).any(|i| {
+                    wts.get(i)
+                        .map(|name| name == branch_name)
+                        .unwrap_or(false)
+                })
+            })
+            .unwrap_or(false);
+        if is_registered {
+            return Err(format!(
+                "Worktree path already exists: {}",
+                worktree_path.display()
+            ));
+        }
+        // Stale directory — remove it so we can recreate the worktree
+        std::fs::remove_dir_all(&worktree_path).map_err(|e| {
+            format!(
+                "Failed to clean up stale worktree path '{}': {}",
+                worktree_path.display(),
+                e
+            )
+        })?;
+        // Also clean up stale git worktree metadata if it exists
+        let git_wt_meta = Path::new(&project.local_path)
+            .join(".git")
+            .join("worktrees")
+            .join(&branch_name);
+        if git_wt_meta.exists() {
+            let _ = std::fs::remove_dir_all(&git_wt_meta);
+        }
     }
 
     if create_new_branch {

--- a/src-tauri/src/git/worktree.rs
+++ b/src-tauri/src/git/worktree.rs
@@ -111,11 +111,7 @@ pub fn create_worktree(
         let is_registered = repo
             .worktrees()
             .map(|wts| {
-                (0..wts.len()).any(|i| {
-                    wts.get(i)
-                        .map(|name| name == branch_name)
-                        .unwrap_or(false)
-                })
+                (0..wts.len()).any(|i| wts.get(i).map(|name| name == branch_name).unwrap_or(false))
             })
             .unwrap_or(false);
         if is_registered {


### PR DESCRIPTION
## Summary
- When a worktree directory exists on disk but isn't registered in git (stale state), automatically remove the directory and its `.git/worktrees/` metadata instead of returning an error
- Only error if the worktree is still actively registered in git
- Prevents the contradictory UI state of showing "path already exists" alongside "No worktrees"

Fixes #381

## Test plan
- [ ] Create a worktree, then manually delete the git registration (leave directory on disk) — verify recreating the worktree works
- [ ] Verify creating a worktree at a path that doesn't exist still works
- [ ] Verify creating a worktree for a branch that already has an active worktree still errors