### PR TITLE
fix: prevent UTF-8 string slice panic in search title truncation

### DIFF
--- a/src-tauri/src/search.rs
+++ b/src-tauri/src/search.rs
@@ -186,8 +186,9 @@ pub fn unified_search(
                 .to_string();
 
                 // Truncate content for the title
-                let title = if content.len() > 80 {
-                    format!("{}...", &content[..80])
+                let title = if content.chars().count() > 80 {
+                    let truncated: String = content.chars().take(80).collect();
+                    format!("{truncated}...")
                 } else {
                     content
                 };


### PR DESCRIPTION
## Summary
- Replace byte slicing `&content[..80]` with `chars().take(80).collect()` to safely truncate strings
- Fixes both occurrences in search.rs (file content and notes search)

Fixes #389

## Test plan
- [ ] Search for content containing emoji or CJK characters — verify no panic
- [ ] Verify search results still show truncated titles correctly