### PR TITLE
fix: validate blob length before deserializing embeddings

### DIFF
--- a/src-tauri/src/memory/embeddings.rs
+++ b/src-tauri/src/memory/embeddings.rs
@@ -86,7 +86,7 @@ pub fn to_blob(embedding: &[f32]) -> Vec<u8> {
 /// Deserialize embedding from SQLite BLOB.
 /// Returns an empty vector if the blob length is not a multiple of 4.
 pub fn from_blob(blob: &[u8]) -> Vec<f32> {
-    if blob.len() % 4 != 0 {
+    if !blob.len().is_multiple_of(4) {
         return Vec::new();
     }
     blob.chunks_exact(4)

--- a/src-tauri/src/memory/embeddings.rs
+++ b/src-tauri/src/memory/embeddings.rs
@@ -84,7 +84,11 @@ pub fn to_blob(embedding: &[f32]) -> Vec<u8> {
 }
 
 /// Deserialize embedding from SQLite BLOB.
+/// Returns an empty vector if the blob length is not a multiple of 4.
 pub fn from_blob(blob: &[u8]) -> Vec<f32> {
+    if blob.len() % 4 != 0 {
+        return Vec::new();
+    }
     blob.chunks_exact(4)
         .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
         .collect()


### PR DESCRIPTION
## Summary
- Added length validation in `from_blob()` — returns empty vec if blob isn't a multiple of 4 bytes
- Prevents silent data corruption from malformed DB data

Fixes #390

## Test plan
- [ ] Verify embedding search still works with valid data
- [ ] Verify malformed blobs don't produce corrupted results