### PR TITLE
perf: optimize ring buffer trigger to avoid COUNT(*) on every insert

### DIFF
--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -201,9 +201,9 @@ mod tests {
         )
         .unwrap();
 
-        // Insert 50,010 log rows
+        // Insert 51,000 log rows (trigger fires every 1000 inserts)
         let tx = conn.unchecked_transaction().unwrap();
-        for i in 0..50_010 {
+        for i in 0..51_000 {
             tx.execute(
                 "INSERT INTO logs (process_id, stream, content) VALUES (1, 'stdout', ?1)",
                 [format!("line {}", i)],
@@ -219,9 +219,16 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
+        // Trigger fires at id 51000 and cleans rows beyond 50k.
+        // Allow up to 50,999 since cleanup is batched every 1000 inserts.
         assert!(
-            count <= 50_000,
-            "ring buffer should cap logs at 50,000 but found {}",
+            count <= 51_000,
+            "ring buffer should cap logs near 50,000 but found {}",
+            count
+        );
+        assert!(
+            count >= 50_000,
+            "ring buffer should keep at least 50,000 logs but found {}",
             count
         );
     }

--- a/src-tauri/src/db/schema.sql
+++ b/src-tauri/src/db/schema.sql
@@ -238,17 +238,23 @@ CREATE INDEX IF NOT EXISTS idx_ai_chat_messages_session ON ai_chat_messages(sess
 -- Ring Buffer Trigger: keep at most 50,000 log rows per process
 -- ============================================================
 
+-- Only check every 1000 inserts to amortize the cleanup cost.
+-- Uses OFFSET-based cutoff instead of COUNT(*) for efficiency.
 CREATE TRIGGER IF NOT EXISTS logs_ring_buffer
 AFTER INSERT ON logs
-WHEN (SELECT COUNT(*) FROM logs WHERE process_id = NEW.process_id) > 50000
+WHEN NEW.id % 1000 = 0
 BEGIN
     DELETE FROM logs
-    WHERE id IN (
-        SELECT id FROM logs
-        WHERE process_id = NEW.process_id
-        ORDER BY id ASC
-        LIMIT (SELECT COUNT(*) - 50000 FROM logs WHERE process_id = NEW.process_id)
-    );
+    WHERE process_id = NEW.process_id
+      AND id < (
+          SELECT COALESCE(
+              (SELECT id FROM logs
+               WHERE process_id = NEW.process_id
+               ORDER BY id DESC
+               LIMIT 1 OFFSET 50000),
+              0
+          )
+      );
 END;
 
 -- ============================================================


### PR DESCRIPTION
## Summary
- Run cleanup every 1000 inserts (via `NEW.id % 1000 = 0`) instead of on every insert
- Use OFFSET-based subquery to find the cutoff ID instead of COUNT(*)
- Greatly reduces overhead for processes with heavy logging

Fixes #392

## Test plan
- [ ] Verify logs still get cleaned up when exceeding 50k per process
- [ ] Verify normal logging performance is not degraded