### PR TITLE
perf: add LIMIT 500 to list_projects query

### DIFF
--- a/src-tauri/src/db/queries.rs
+++ b/src-tauri/src/db/queries.rs
@@ -151,7 +151,7 @@ pub fn get_project(conn: &Connection, id: i64) -> Result<Option<ProjectRow>, rus
 pub fn list_projects(conn: &Connection) -> Result<Vec<ProjectRow>, rusqlite::Error> {
     let mut stmt = conn.prepare(
         "SELECT id, name, github_url, local_path, framework, created_at, updated_at
-         FROM projects ORDER BY created_at DESC",
+         FROM projects ORDER BY created_at DESC LIMIT 500",
     )?;
     let rows = stmt.query_map([], |row| {
         Ok(ProjectRow {


### PR DESCRIPTION
## Summary
- Added `LIMIT 500` to the `list_projects()` SQL query to bound memory usage
- 500 is well beyond typical usage while preventing unbounded growth

Fixes #399

## Test plan
- [ ] Verify all projects still load correctly in the sidebar
- [ ] Verify project list is still ordered by creation date