### PR TITLE
perf: use specific tokio features instead of 'full'

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -14,7 +14,7 @@ tauri-plugin-shell = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 rusqlite = { version = "0.32", features = ["bundled"] }
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["rt-multi-thread", "io-util", "process", "time", "sync", "net", "fs", "macros"] }
 thiserror = "1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 keyring = { version = "3", features = ["apple-native", "windows-native", "linux-native"] }


### PR DESCRIPTION
## Summary
- Replaced `features = ["full"]` with specific features: `rt-multi-thread`, `io-util`, `process`, `time`, `sync`, `net`, `fs`, `macros`
- Reduces binary size and compile time by excluding unused tokio subsystems

Fixes #400

## Test plan
- [ ] Verify all Rust tests pass
- [ ] Verify the app starts and all features work (processes, proxies, file watching)