### PR TITLE
fix: wrap AppDb in Arc to enable spawn_blocking for DB operations

### DIFF
--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -1,7 +1,7 @@
 use rusqlite::Connection;
 use std::fs;
-use std::sync::Mutex;
 use std::sync::MutexGuard;
+use std::sync::{Arc, Mutex};
 use tauri::{AppHandle, Manager};
 use thiserror::Error;
 
@@ -26,7 +26,8 @@ impl From<DbError> for tauri::Error {
 }
 
 /// Thread-safe wrapper around a SQLite connection for use as Tauri managed state.
-pub struct AppDb(pub Mutex<Connection>);
+/// Uses Arc<Mutex<...>> so the inner mutex can be cloned into spawn_blocking tasks.
+pub struct AppDb(pub Arc<Mutex<Connection>>);
 
 impl AppDb {
     /// Acquire the database connection.
@@ -65,7 +66,7 @@ pub fn init_db(app: &AppHandle) -> Result<AppDb, DbError> {
 
     run_migrations(&conn)?;
 
-    Ok(AppDb(Mutex::new(conn)))
+    Ok(AppDb(Arc::new(Mutex::new(conn))))
 }
 
 /// Applies the schema from schema.sql. All statements use IF NOT EXISTS,

--- a/src-tauri/src/filewatcher/tracker.rs
+++ b/src-tauri/src/filewatcher/tracker.rs
@@ -190,7 +190,7 @@ mod tests {
         )
         .unwrap();
 
-        let db = AppDb(std::sync::Mutex::new(conn));
+        let db = AppDb(std::sync::Arc::new(std::sync::Mutex::new(conn)));
         record_event(&db, 1, "/tmp/src/main.rs", "modify").unwrap();
         record_event(&db, 1, "/tmp/src/lib.rs", "create").unwrap();
 

--- a/src-tauri/src/metrics/dora.rs
+++ b/src-tauri/src/metrics/dora.rs
@@ -236,7 +236,7 @@ mod tests {
             [],
         )
         .unwrap();
-        AppDb(std::sync::Mutex::new(conn))
+        AppDb(std::sync::Arc::new(std::sync::Mutex::new(conn)))
     }
 
     #[test]

--- a/src-tauri/src/process/lifecycle.rs
+++ b/src-tauri/src/process/lifecycle.rs
@@ -152,15 +152,19 @@ pub fn monitor_process(
             let exit_code = status.ok().and_then(|s| s.code());
             let is_crash = exit_code.map(|c| c != 0).unwrap_or(true);
 
-            // Update DB status
-            let db = app.state::<AppDb>();
-            if let Ok(conn) = db.0.lock() {
-                if is_crash {
-                    let _ = queries::update_process_status(&conn, process_id, "crashed");
-                } else {
-                    let _ = queries::update_process_stopped(&conn, process_id);
+            // Update DB status via spawn_blocking to avoid blocking the tokio runtime
+            let db_ref = app.state::<AppDb>();
+            let db_inner = db_ref.0.clone();
+            let _ = tokio::task::spawn_blocking(move || {
+                if let Ok(conn) = db_inner.lock() {
+                    if is_crash {
+                        let _ = queries::update_process_status(&conn, process_id, "crashed");
+                    } else {
+                        let _ = queries::update_process_stopped(&conn, process_id);
+                    }
                 }
-            };
+            })
+            .await;
 
             // Emit event
             let event_name = if is_crash { "crashed" } else { "stopped" };
@@ -204,13 +208,17 @@ pub fn monitor_process(
 
             // Re-read the process info from DB to get the command
             let process_info = {
-                let db = app.state::<AppDb>();
-                let result = if let Ok(conn) = db.0.lock() {
-                    queries::get_process(&conn, process_id).ok().flatten()
-                } else {
-                    None
-                };
-                result
+                let db_ref = app.state::<AppDb>();
+                let db_inner = db_ref.0.clone();
+                tokio::task::spawn_blocking(move || {
+                    db_inner
+                        .lock()
+                        .ok()
+                        .and_then(|conn| queries::get_process(&conn, process_id).ok().flatten())
+                })
+                .await
+                .ok()
+                .flatten()
             };
 
             let proc = match process_info {
@@ -220,16 +228,20 @@ pub fn monitor_process(
 
             // Get worktree path for cwd
             let worktree_path = {
-                let db = app.state::<AppDb>();
-                let result = if let Ok(conn) = db.0.lock() {
-                    queries::get_worktree(&conn, proc.worktree_id)
-                        .ok()
-                        .flatten()
-                        .map(|w| w.path)
-                } else {
-                    None
-                };
-                result
+                let db_ref = app.state::<AppDb>();
+                let db_inner = db_ref.0.clone();
+                let wt_id = proc.worktree_id;
+                tokio::task::spawn_blocking(move || {
+                    db_inner.lock().ok().and_then(|conn| {
+                        queries::get_worktree(&conn, wt_id)
+                            .ok()
+                            .flatten()
+                            .map(|w| w.path)
+                    })
+                })
+                .await
+                .ok()
+                .flatten()
             };
 
             let cwd = match worktree_path {
@@ -259,13 +271,17 @@ pub fn monitor_process(
                     let new_pid = new_child.id();
 
                     // Update DB with new PID
-                    let db = app.state::<AppDb>();
-                    if let Ok(conn) = db.0.lock() {
-                        let _ = queries::update_process_status(&conn, process_id, "running");
-                        if let Some(pid) = new_pid {
-                            let _ = queries::update_process_pid(&conn, process_id, pid as i64);
+                    let db_ref = app.state::<AppDb>();
+                    let db_inner = db_ref.0.clone();
+                    let _ = tokio::task::spawn_blocking(move || {
+                        if let Ok(conn) = db_inner.lock() {
+                            let _ = queries::update_process_status(&conn, process_id, "running");
+                            if let Some(pid) = new_pid {
+                                let _ = queries::update_process_pid(&conn, process_id, pid as i64);
+                            }
                         }
-                    };
+                    })
+                    .await;
 
                     // Register new PID
                     if let Some(pid) = new_pid {

--- a/src-tauri/src/search.rs
+++ b/src-tauri/src/search.rs
@@ -262,7 +262,7 @@ mod tests {
             [],
         )
         .unwrap();
-        AppDb(std::sync::Mutex::new(conn))
+        AppDb(std::sync::Arc::new(std::sync::Mutex::new(conn)))
     }
 
     /// Run the search logic directly against the connection (bypassing Tauri State).

--- a/src-tauri/src/snippets.rs
+++ b/src-tauri/src/snippets.rs
@@ -165,7 +165,7 @@ mod tests {
             [],
         )
         .unwrap();
-        AppDb(std::sync::Mutex::new(conn))
+        AppDb(std::sync::Arc::new(std::sync::Mutex::new(conn)))
     }
 
     /// Helper: insert a snippet directly via SQL and return its rowid.

--- a/src-tauri/src/ssh/connections.rs
+++ b/src-tauri/src/ssh/connections.rs
@@ -275,7 +275,7 @@ mod tests {
     use crate::db::{init_test_db, AppDb};
 
     fn setup_db() -> AppDb {
-        AppDb(std::sync::Mutex::new(init_test_db()))
+        AppDb(std::sync::Arc::new(std::sync::Mutex::new(init_test_db())))
     }
 
     #[test]

--- a/src-tauri/src/terminal/recording.rs
+++ b/src-tauri/src/terminal/recording.rs
@@ -173,7 +173,7 @@ mod tests {
             [],
         )
         .unwrap();
-        AppDb(std::sync::Mutex::new(conn))
+        AppDb(std::sync::Arc::new(std::sync::Mutex::new(conn)))
     }
 
     #[test]

--- a/src-tauri/src/vault/diff.rs
+++ b/src-tauri/src/vault/diff.rs
@@ -115,7 +115,7 @@ mod tests {
             [],
         )
         .unwrap();
-        AppDb(std::sync::Mutex::new(conn))
+        AppDb(std::sync::Arc::new(std::sync::Mutex::new(conn)))
     }
 
     /// Helper: run the diff logic directly against the connection.


### PR DESCRIPTION
## Summary
- Refactored \`AppDb\` from \`Mutex<Connection>\` to \`Arc<Mutex<Connection>>\` so the inner mutex can be cloned into blocking tasks
- Updated all DB accesses in the async process lifecycle monitor to use \`tokio::task::spawn_blocking\`
- Updated all test \`AppDb\` constructors to use the new Arc wrapper
- Prevents synchronous mutex from blocking the tokio runtime during DB operations

Fixes #394

## Test plan
- [ ] Verify all Rust tests pass
- [ ] Verify process spawning and monitoring still works
- [ ] Verify no deadlocks under concurrent process management