### PR TITLE
chore: bump version to 0.1.26

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.1.25",
+  "version": "0.1.26",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4868,7 +4868,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -6131,7 +6130,7 @@ dependencies = [
 
 [[package]]
 name = "workroot"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.1.25"
+version = "0.1.26"
 edition = "2021"
 authors = ["Saurav Panda <saurav@workroot.dev>"]
 description = "A local-first developer workspace for managing projects, terminals, and Git workflows."

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Release 0.1.26

### UI/UX Fixes
- **#363** Fixed green highlight bleeding on "Show hidden worktrees" button
- **#364** Wired up "+ Worktree" button in Mission Control to command bar
- **#365** Removed redundant top project tabs (sidebar is now the single nav)
- **#366** Made sidebar repo names more prominent with better contrast
- **#367** Friendly error message for repos without commits
- **#368** Sidebar auto-expands when navigating from Mission Control
- **#371** Removed Changes/PR buttons from top bar to reduce clutter
- **#372** Fixed terminal content area to fill all available window space
- **#374** Removed framework badges from sidebar for cleaner look
- **#377** Added "Running" status with yellow indicator in Mission Control
- **#383** Polished settings modal (nav icons, spacing, visual hierarchy)

### Features
- **#386** Added syntax highlighting (12 languages) to the file viewer
- **#397** Vite vendor code splitting — main bundle reduced from 374KB to 278KB

### Bug Fixes
- **#369** Sanitized branch names from prompt text to prevent path failures
- **#381** Auto-clean stale worktree paths instead of erroring
- **#389** Fixed UTF-8 string slice panic in search on multi-byte characters
- **#390** Added blob length validation for embedding deserialization
- **#393** Capped proxy response buffering at 50MB to prevent OOM
- **#394** Wrapped AppDb in Arc + spawn_blocking to unblock tokio runtime
- **#395** Removed spurious dummy Mutex in file watcher
- **#396** Mitigated XSS risk in terminal recording playback
- **#398** Emit service-error events when startup services exit unexpectedly

### Performance
- **#391** Replaced N+1 query with single JOIN for port collection
- **#392** Optimized ring buffer trigger (batched cleanup, no COUNT per insert)
- **#399** Added LIMIT 500 to unbounded list_projects query
- **#400** Reduced tokio features from "full" to only what's needed