### PR TITLE
fix: add close button to settings page (#417)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -998,7 +998,7 @@ function AppContent({
     <Suspense fallback={null}>
       {showSettings ? (
         <PanelBoundary name="Settings">
-          <SettingsTab />
+          <SettingsTab onClose={() => setShowSettings(false)} />
         </PanelBoundary>
       ) : !selectedWorktreePath ? (
         <PanelBoundary name="WorkspaceGrid">

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -84,7 +84,11 @@ type UpdateStatus =
   | { state: "downloading" }
   | { state: "error"; message: string };
 
-export function SettingsTab() {
+interface SettingsTabProps {
+  onClose?: () => void;
+}
+
+export function SettingsTab({ onClose }: SettingsTabProps = {}) {
   const [values, setValues] = useState<Record<string, string>>({});
   const [saved, setSaved] = useState<Record<string, boolean>>({});
   const [loading, setLoading] = useState(true);
@@ -177,6 +181,24 @@ export function SettingsTab() {
   if (loading) {
     return (
       <div className="settings-tab">
+        {onClose && (
+          <button
+            type="button"
+            className="settings-close-btn"
+            onClick={onClose}
+            aria-label="Close settings"
+            title="Close settings (Esc)"
+          >
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+              <path
+                d="M3 3L11 11M11 3L3 11"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+              />
+            </svg>
+          </button>
+        )}
         <p className="settings-loading">Loading settings...</p>
       </div>
     );
@@ -237,6 +259,24 @@ export function SettingsTab() {
 
   return (
     <div className="settings-tab">
+      {onClose && (
+        <button
+          type="button"
+          className="settings-close-btn"
+          onClick={onClose}
+          aria-label="Close settings"
+          title="Close settings (Esc)"
+        >
+          <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+            <path
+              d="M3 3L11 11M11 3L3 11"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+            />
+          </svg>
+        </button>
+      )}
       <h2 className="settings-title">Settings</h2>
 
       <section className="settings-section">

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -7,6 +7,38 @@
   max-width: 560px;
   overflow-y: auto;
   height: 100%;
+  position: relative;
+}
+
+.settings-close-btn {
+  position: absolute;
+  top: 1em;
+  right: 1em;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.settings-close-btn:hover {
+  background-color: var(--bg-hover);
+  color: var(--text-primary);
+  border-color: var(--border-subtle);
+}
+
+.settings-close-btn:focus-visible {
+  outline: none;
+  border-color: var(--accent);
 }
 
 .settings-title {


### PR DESCRIPTION
## Summary
- Closes #417
- Adds an X button in the top-right of the Settings full-page view
- Wires `onClose` from `App.tsx` so clicking it returns to the previous view

## Why
`SettingsTab` renders as a full-page view (replacing the workspace), but there was no in-UI affordance to dismiss it — users had to know the command palette entry or the Esc shortcut. The new button mirrors the pattern already in place on `SettingsPage.tsx`.

## Test plan
- [ ] Open Settings via the sidebar / command palette
- [ ] Click the X — view returns to home / previous worktree
- [ ] Esc still works (existing keybinding untouched)
- [ ] Loading state also shows the close button