### PR TITLE
chore: bump version to 0.1.27

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.1.26",
+  "version": "0.1.27",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6130,7 +6130,7 @@ dependencies = [
 
 [[package]]
 name = "workroot"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.1.26"
+version = "0.1.27"
 edition = "2021"
 authors = ["Saurav Panda <saurav@workroot.dev>"]
 description = "A local-first developer workspace for managing projects, terminals, and Git workflows."

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary
Release v0.1.27 — bumps version in package.json, Cargo.toml, Cargo.lock, and tauri.conf.json.

### Changes since v0.1.26
- fix: add close button to settings page (#417, PR #419)

## Test plan
- [ ] CI green
- [ ] After merge: tag `v0.1.27` to trigger the release workflow