### PR TITLE
fix: terminal view breaks with many terminals across worktrees

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@tauri-apps/plugin-updater": "^2.10.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",
-    "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",
     "ansi-to-html": "^0.7.2",
     "class-variance-authority": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,9 +41,6 @@ importers:
       '@xterm/addon-web-links':
         specifier: ^0.12.0
         version: 0.12.0
-      '@xterm/addon-webgl':
-        specifier: ^0.19.0
-        version: 0.19.0
       '@xterm/xterm':
         specifier: ^6.0.0
         version: 6.0.0
@@ -1663,9 +1660,6 @@ packages:
 
   '@xterm/addon-web-links@0.12.0':
     resolution: {integrity: sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==}
-
-  '@xterm/addon-webgl@0.19.0':
-    resolution: {integrity: sha512-b3fMOsyLVuCeNJWxolACEUED0vm7qC0cy4wRvf3oURSzDTYVQiGPhTnhWZwIHdvC48Y+oLhvYXnY4XDXPoJo6A==}
 
   '@xterm/xterm@6.0.0':
     resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==}
@@ -4225,8 +4219,6 @@ snapshots:
   '@xterm/addon-fit@0.11.0': {}
 
   '@xterm/addon-web-links@0.12.0': {}
-
-  '@xterm/addon-webgl@0.19.0': {}
 
   '@xterm/xterm@6.0.0': {}
 

--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -379,8 +379,7 @@ export function TerminalPanel({
                         paneContainersRef.current.set(paneId, div);
                         triggerUpdate();
                       }
-                      const container =
-                        paneContainersRef.current.get(paneId)!;
+                      const container = paneContainersRef.current.get(paneId)!;
                       if (!slotEl.contains(container)) {
                         slotEl.replaceChildren(container);
                         triggerUpdate();
@@ -399,8 +398,7 @@ export function TerminalPanel({
               {collectLeafIds(tab.paneTree).map((paneId) => {
                 const container = paneContainersRef.current.get(paneId);
                 if (!container) return null;
-                const isFocusedPane =
-                  isActiveTab && paneId === focusedPaneId;
+                const isFocusedPane = isActiveTab && paneId === focusedPaneId;
                 return createPortal(
                   <TerminalInstance
                     cwd={activeCwd}
@@ -409,12 +407,8 @@ export function TerminalPanel({
                     shell={shell}
                     initCommand={initCommand}
                     themeId={themeId}
-                    onAgentActivity={
-                      isActiveTab ? onAgentActivity : undefined
-                    }
-                    onAgentComplete={
-                      isActiveTab ? onAgentComplete : undefined
-                    }
+                    onAgentActivity={isActiveTab ? onAgentActivity : undefined}
+                    onAgentComplete={isActiveTab ? onAgentComplete : undefined}
                     onAgentNeedsAttention={
                       isActiveTab ? onAgentNeedsAttention : undefined
                     }

--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -2,7 +2,6 @@ import { useEffect, useRef, useState, useCallback, useReducer } from "react";
 import { createPortal } from "react-dom";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
-import { WebglAddon } from "@xterm/addon-webgl";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
@@ -104,8 +103,11 @@ export function TerminalPanel({
   const [, triggerUpdate] = useReducer((n: number) => n + 1, 0);
 
   // When the cwd prop changes (user switches worktree), create a new path state
-  // if one doesn't exist yet — but never destroy existing states so PTY
-  // processes on other paths stay alive.
+  // if one doesn't exist yet. Tab/split structure for other worktrees is kept
+  // in state but their TerminalInstances unmount — their PTYs are killed.
+  // Rendering every worktree's terminals blew past the browser's WebGL context
+  // limit and piled up ResizeObservers, causing panes to render blank once a
+  // user accumulated many tabs across worktrees.
   useEffect(() => {
     setActiveCwd(cwd);
     setPathStates((prev) => {
@@ -113,6 +115,12 @@ export function TerminalPanel({
       return { ...prev, [cwd]: makeInitialPathState(worktreeName, cwd) };
     });
   }, [cwd, worktreeName]);
+
+  // Drop stale pane containers when the active path changes. Keeping them
+  // around after their portal target unmounts just leaks detached divs.
+  useEffect(() => {
+    paneContainersRef.current.clear();
+  }, [activeCwd]);
 
   // Convenience: current path's state + derived values.
   const currentState = pathStates[activeCwd];
@@ -331,116 +339,94 @@ export function TerminalPanel({
         )}
       </div>
       <div className="terminal-tab-content">
-        {/* Render ALL paths' tabs so their TerminalInstance components stay
-            mounted and PTY processes survive worktree switches. Only the
-            active path + active tab is made visible. */}
-        {Object.entries(pathStates).flatMap(([path, state]) =>
-          state.tabs.map((tab) => {
-            const isActivePathAndTab =
-              path === activeCwd && tab.id === state.activeTabId;
-            return (
-              <div
-                key={tab.id}
-                className={`terminal-instance ${isActivePathAndTab ? "terminal-instance-active" : ""}`}
-              >
-                <SplitPane
-                  node={tab.paneTree}
-                  onUpdateNode={(newTree) =>
-                    setPathStates((prev) => {
-                      const s = prev[path];
-                      if (!s) return prev;
-                      return {
-                        ...prev,
-                        [path]: {
-                          ...s,
-                          tabs: s.tabs.map((t) =>
-                            t.id === tab.id ? { ...t, paneTree: newTree } : t,
-                          ),
-                        },
-                      };
-                    })
-                  }
-                  renderLeaf={(paneId) => (
-                    // Each leaf renders a thin slot div.  The ref callback
-                    // places (or moves) the stable per-pane container into this
-                    // slot so the terminal content appears in the right place.
-                    <div
-                      style={{ width: "100%", height: "100%" }}
-                      ref={(slotEl) => {
-                        if (!slotEl) return;
-                        // Create a stable container for this pane on first use.
-                        if (!paneContainersRef.current.has(paneId)) {
-                          const div = document.createElement("div");
-                          div.style.cssText =
-                            "width:100%;height:100%;display:flex;flex-direction:column;";
-                          paneContainersRef.current.set(paneId, div);
-                          triggerUpdate();
-                        }
-                        const container =
-                          paneContainersRef.current.get(paneId)!;
-                        // Move the container into this slot if it isn't already
-                        // there (e.g. after a split restructures the tree).
-                        if (!slotEl.contains(container)) {
-                          slotEl.replaceChildren(container);
-                          triggerUpdate();
-                        }
-                      }}
-                    />
-                  )}
-                  focusedId={
-                    path === activeCwd && tab.id === activeTabId
-                      ? focusedPaneId
-                      : null
-                  }
-                  onFocusLeaf={
-                    path === activeCwd && tab.id === activeTabId
-                      ? setFocusedPaneId
-                      : () => {}
-                  }
-                  leafCount={collectLeafIds(tab.paneTree).length}
-                  onCloseLeaf={
-                    isActivePathAndTab ? handleClosePaneById : undefined
-                  }
-                  onSplitLeaf={isActivePathAndTab ? handleSplitLeaf : undefined}
-                />
-                {/* Render TerminalInstances via portals into the stable per-pane
-                    containers. The portal key (paneId) and container object are
-                    both stable across splits, so React never unmounts an existing
-                    TerminalInstance — the PTY process is preserved. */}
-                {collectLeafIds(tab.paneTree).map((paneId) => {
-                  const container = paneContainersRef.current.get(paneId);
-                  if (!container) return null;
-                  const isFocusedPane =
-                    path === activeCwd &&
-                    tab.id === state.activeTabId &&
-                    paneId === focusedPaneId;
-                  return createPortal(
-                    <TerminalInstance
-                      cwd={path}
-                      active={isActivePathAndTab && isFocusedPane}
-                      visible={isActivePathAndTab}
-                      shell={shell}
-                      initCommand={initCommand}
-                      themeId={themeId}
-                      onAgentActivity={
-                        isActivePathAndTab ? onAgentActivity : undefined
+        {/* Render only the active path's tabs. All tabs in the active path stay
+            mounted (so switching tabs within a worktree is free); other
+            worktrees' live terminals are torn down but their tab/split
+            structure is preserved in pathStates and recreated on return. */}
+        {tabs.map((tab) => {
+          const isActiveTab = tab.id === activeTabId;
+          return (
+            <div
+              key={tab.id}
+              className={`terminal-instance ${isActiveTab ? "terminal-instance-active" : ""}`}
+            >
+              <SplitPane
+                node={tab.paneTree}
+                onUpdateNode={(newTree) =>
+                  setPathStates((prev) => {
+                    const s = prev[activeCwd];
+                    if (!s) return prev;
+                    return {
+                      ...prev,
+                      [activeCwd]: {
+                        ...s,
+                        tabs: s.tabs.map((t) =>
+                          t.id === tab.id ? { ...t, paneTree: newTree } : t,
+                        ),
+                      },
+                    };
+                  })
+                }
+                renderLeaf={(paneId) => (
+                  <div
+                    style={{ width: "100%", height: "100%" }}
+                    ref={(slotEl) => {
+                      if (!slotEl) return;
+                      if (!paneContainersRef.current.has(paneId)) {
+                        const div = document.createElement("div");
+                        div.style.cssText =
+                          "width:100%;height:100%;display:flex;flex-direction:column;";
+                        paneContainersRef.current.set(paneId, div);
+                        triggerUpdate();
                       }
-                      onAgentComplete={
-                        isActivePathAndTab ? onAgentComplete : undefined
+                      const container =
+                        paneContainersRef.current.get(paneId)!;
+                      if (!slotEl.contains(container)) {
+                        slotEl.replaceChildren(container);
+                        triggerUpdate();
                       }
-                      onAgentNeedsAttention={
-                        isActivePathAndTab ? onAgentNeedsAttention : undefined
-                      }
-                      snapshotRef={snapshotRef}
-                    />,
-                    container,
-                    paneId,
-                  );
-                })}
-              </div>
-            );
-          }),
-        )}
+                    }}
+                  />
+                )}
+                focusedId={isActiveTab ? focusedPaneId : null}
+                onFocusLeaf={isActiveTab ? setFocusedPaneId : () => {}}
+                leafCount={collectLeafIds(tab.paneTree).length}
+                onCloseLeaf={isActiveTab ? handleClosePaneById : undefined}
+                onSplitLeaf={isActiveTab ? handleSplitLeaf : undefined}
+              />
+              {/* Portals keep TerminalInstance mounted across split
+                  restructuring within the same tab (stable paneId + container). */}
+              {collectLeafIds(tab.paneTree).map((paneId) => {
+                const container = paneContainersRef.current.get(paneId);
+                if (!container) return null;
+                const isFocusedPane =
+                  isActiveTab && paneId === focusedPaneId;
+                return createPortal(
+                  <TerminalInstance
+                    cwd={activeCwd}
+                    active={isActiveTab && isFocusedPane}
+                    visible={isActiveTab}
+                    shell={shell}
+                    initCommand={initCommand}
+                    themeId={themeId}
+                    onAgentActivity={
+                      isActiveTab ? onAgentActivity : undefined
+                    }
+                    onAgentComplete={
+                      isActiveTab ? onAgentComplete : undefined
+                    }
+                    onAgentNeedsAttention={
+                      isActiveTab ? onAgentNeedsAttention : undefined
+                    }
+                    snapshotRef={snapshotRef}
+                  />,
+                  container,
+                  paneId,
+                );
+              })}
+            </div>
+          );
+        })}
       </div>
     </div>
   );
@@ -669,14 +655,8 @@ function TerminalInstance({
     // once layout settles.
     term.open(el);
 
-    // GPU-accelerated renderer; fall back silently if WebGL is unavailable.
-    try {
-      const webgl = new WebglAddon();
-      webgl.onContextLoss(() => webgl.dispose());
-      term.loadAddon(webgl);
-    } catch {
-      // WebGL not available — xterm falls back to its canvas renderer.
-    }
+    // Canvas renderer only. WebGL was dropped because browsers cap concurrent
+    // WebGL contexts at ~8-16; terminals past the limit silently fail to init.
 
     termRef.current = term;
     fitAddonRef.current = fitAddon;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,7 +19,6 @@ export default defineConfig(async () => ({
           xterm: [
             "@xterm/xterm",
             "@xterm/addon-fit",
-            "@xterm/addon-webgl",
             "@xterm/addon-web-links",
           ],
           "react-vendor": ["react", "react-dom"],


### PR DESCRIPTION
## Summary
Fixes a reported bug where the terminal view breaks after accumulating many terminals across worktrees.

Two compounding root causes:

1. **WebGL context exhaustion.** Every `TerminalInstance` in `TerminalPanel.tsx` loaded `WebglAddon`. Browsers cap concurrent WebGL contexts at ~8–16 — past that, new terminals silently failed to initialize their GPU renderer, showing blank or unresponsive panes. `TerminalGrid.tsx` already uses the canvas renderer explicitly to avoid this; `TerminalPanel` now matches. The `@xterm/addon-webgl` package is removed entirely.

2. **All worktrees' terminals stayed mounted forever.** The render body was `Object.entries(pathStates).flatMap(...)` with `visibility:hidden` for inactive paths — every worktree the user visited kept its xterm instances, PTYs, and ResizeObservers alive for the life of the session. Memory and WebGL pressure grew unbounded.

   Now only the active path's tabs render. Tab/split structure for other worktrees stays in `pathStates` and is recreated on return with fresh shells. Pane-container refs are cleared on path switch so detached divs don't leak.

## Behavior change
Switching to another worktree no longer preserves the running shell — users get the same tab/split layout back, but with new PTYs. Same-worktree tab switching is unaffected (all tabs in the active path stay mounted, same as before).

## Test plan
- [ ] Open many terminals within one worktree (10+) — no blank panes, renders stay responsive
- [ ] Create 4-pane splits across 3+ tabs — still works, no blank panes
- [ ] Switch to a second worktree, make terminals there, switch back — first worktree's tab structure is preserved; shells are fresh
- [ ] Rapid worktree switching doesn't leak memory (DevTools Memory profiler, multiple cycles)
- [ ] Drag-and-drop image into active terminal still works
- [ ] Split / close-pane / new-tab still all functional
- [ ] `pnpm typecheck` / `pnpm lint` / `pnpm build` clean