### PR TITLE
fix: drop dead get_file_hotspots call from MorningBriefing

### DIFF
--- a/src/components/MorningBriefing.tsx
+++ b/src/components/MorningBriefing.tsx
@@ -2,11 +2,6 @@ import { useState, useEffect } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import "../styles/morning-briefing.css";
 
-interface FileHotspot {
-  file_path: string;
-  change_count: number;
-}
-
 interface MemoryNote {
   id: number;
   content: string;
@@ -22,7 +17,6 @@ interface DeadEnd {
 }
 
 interface BriefingData {
-  hotFiles: FileHotspot[];
   recentNotes: MemoryNote[];
   deadEnds: DeadEnd[];
 }
@@ -41,11 +35,7 @@ export function MorningBriefing({ projectId }: MorningBriefingProps) {
     async function load() {
       setLoading(true);
       try {
-        const [hotFiles, recentNotes, deadEnds] = await Promise.allSettled([
-          invoke<FileHotspot[]>("get_file_hotspots", {
-            projectId,
-            period: "24h",
-          }).catch(() => []),
+        const [recentNotes, deadEnds] = await Promise.allSettled([
           invoke<MemoryNote[]>("get_memory_notes", {
             worktreeId: projectId,
             limit: 5,
@@ -58,10 +48,6 @@ export function MorningBriefing({ projectId }: MorningBriefingProps) {
 
         if (!cancelled) {
           setData({
-            hotFiles:
-              hotFiles.status === "fulfilled"
-                ? (hotFiles.value as FileHotspot[])
-                : [],
             recentNotes:
               recentNotes.status === "fulfilled"
                 ? (recentNotes.value as MemoryNote[])
@@ -108,24 +94,6 @@ export function MorningBriefing({ projectId }: MorningBriefingProps) {
 
       {data && (
         <div className="briefing-sections">
-          <section className="briefing-section">
-            <h4>Hot Files (24h)</h4>
-            {data.hotFiles.length === 0 ? (
-              <p className="briefing-empty">No recent file activity.</p>
-            ) : (
-              <ul className="briefing-list">
-                {data.hotFiles.slice(0, 5).map((f) => (
-                  <li key={f.file_path} className="briefing-item">
-                    <span className="briefing-file">{f.file_path}</span>
-                    <span className="briefing-count">
-                      {f.change_count} changes
-                    </span>
-                  </li>
-                ))}
-              </ul>
-            )}
-          </section>
-
           <section className="briefing-section">
             <h4>Recent Notes</h4>
             {data.recentNotes.length === 0 ? (


### PR DESCRIPTION
## Summary

Follow-up to #439 (file-watcher removal). \`get_file_hotspots\` was an MCP-only tool, never registered as a Tauri command, so the \`invoke()\` call in MorningBriefing has been failing on every render since the component was written — the \`.catch(() => [])\` silently produced an empty \`hotFiles\` array.

The MCP backing was removed in #439, so the call is now doubly dead. This PR drops:

- the \`get_file_hotspots\` invocation from \`Promise.allSettled\`
- the \`FileHotspot\` interface and the \`hotFiles\` field on \`BriefingData\`
- the entire \`Hot Files (24h)\` section in the rendered briefing

Notes and dead-ends invocations stay — \`get_memory_notes\` and \`get_dead_ends\` are real Tauri commands and still load successfully.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm format:check\` clean
- [x] \`pnpm build\` clean
- [ ] CI green