### PR TITLE
feat: foundation for helm machines (Phase 1.1)

### DIFF
--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -124,6 +124,7 @@ mod tests {
             "memory_notes",
             "browser_events",
             "settings",
+            "helm_machines",
         ];
         for table in &expected {
             let count: i64 = conn
@@ -152,6 +153,7 @@ mod tests {
             "idx_memory_notes_worktree_id",
             "idx_browser_events_timestamp",
             "idx_browser_events_type",
+            "idx_helm_machines_enabled",
         ];
         for idx in &expected_indexes {
             let count: i64 = conn

--- a/src-tauri/src/db/queries.rs
+++ b/src-tauri/src/db/queries.rs
@@ -923,6 +923,101 @@ pub fn delete_bookmark(conn: &Connection, id: i64) -> Result<bool, rusqlite::Err
     Ok(affected > 0)
 }
 
+// ============================================================
+// Helm Machines
+// ============================================================
+
+#[derive(Debug, Serialize)]
+pub struct HelmMachineRow {
+    pub id: i64,
+    pub label: String,
+    pub base_url: String,
+    pub enabled: bool,
+    pub last_seen_at: Option<String>,
+    pub created_at: String,
+}
+
+pub fn insert_helm_machine(
+    conn: &Connection,
+    label: &str,
+    base_url: &str,
+) -> Result<i64, rusqlite::Error> {
+    conn.execute(
+        "INSERT INTO helm_machines (label, base_url) VALUES (?1, ?2)",
+        params![label, base_url],
+    )?;
+    Ok(conn.last_insert_rowid())
+}
+
+pub fn list_helm_machines(conn: &Connection) -> Result<Vec<HelmMachineRow>, rusqlite::Error> {
+    let mut stmt = conn.prepare(
+        "SELECT id, label, base_url, enabled, last_seen_at, created_at
+         FROM helm_machines
+         ORDER BY created_at ASC",
+    )?;
+    let rows = stmt.query_map([], |row| {
+        let enabled: i64 = row.get(3)?;
+        Ok(HelmMachineRow {
+            id: row.get(0)?,
+            label: row.get(1)?,
+            base_url: row.get(2)?,
+            enabled: enabled != 0,
+            last_seen_at: row.get(4)?,
+            created_at: row.get(5)?,
+        })
+    })?;
+    rows.collect()
+}
+
+pub fn get_helm_machine(
+    conn: &Connection,
+    id: i64,
+) -> Result<Option<HelmMachineRow>, rusqlite::Error> {
+    let mut stmt = conn.prepare(
+        "SELECT id, label, base_url, enabled, last_seen_at, created_at
+         FROM helm_machines WHERE id = ?1",
+    )?;
+    let mut rows = stmt.query_map(params![id], |row| {
+        let enabled: i64 = row.get(3)?;
+        Ok(HelmMachineRow {
+            id: row.get(0)?,
+            label: row.get(1)?,
+            base_url: row.get(2)?,
+            enabled: enabled != 0,
+            last_seen_at: row.get(4)?,
+            created_at: row.get(5)?,
+        })
+    })?;
+    rows.next().transpose()
+}
+
+pub fn update_helm_machine(
+    conn: &Connection,
+    id: i64,
+    label: &str,
+    base_url: &str,
+    enabled: bool,
+) -> Result<bool, rusqlite::Error> {
+    let affected = conn.execute(
+        "UPDATE helm_machines SET label = ?2, base_url = ?3, enabled = ?4 WHERE id = ?1",
+        params![id, label, base_url, enabled as i64],
+    )?;
+    Ok(affected > 0)
+}
+
+pub fn delete_helm_machine(conn: &Connection, id: i64) -> Result<bool, rusqlite::Error> {
+    let affected = conn.execute("DELETE FROM helm_machines WHERE id = ?1", params![id])?;
+    Ok(affected > 0)
+}
+
+pub fn touch_helm_machine_last_seen(conn: &Connection, id: i64) -> Result<bool, rusqlite::Error> {
+    let affected = conn.execute(
+        "UPDATE helm_machines SET last_seen_at = datetime('now') WHERE id = ?1",
+        params![id],
+    )?;
+    Ok(affected > 0)
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::init_test_db;

--- a/src-tauri/src/db/schema.sql
+++ b/src-tauri/src/db/schema.sql
@@ -436,3 +436,20 @@ CREATE TABLE IF NOT EXISTS pipeline_runs (
 CREATE INDEX IF NOT EXISTS idx_pipeline_runs_pipeline ON pipeline_runs(pipeline_id);
 CREATE INDEX IF NOT EXISTS idx_pipeline_runs_worktree ON pipeline_runs(worktree_id);
 CREATE INDEX IF NOT EXISTS idx_pipeline_runs_started  ON pipeline_runs(started_at);
+
+-- ============================================================
+-- Helm Machines (Phase 1 — pivot/helm-desktop)
+-- ============================================================
+-- One row per registered helm-daemon. The bearer token (if any) lives
+-- in the OS keyring, not here — see src/helm/mod.rs.
+
+CREATE TABLE IF NOT EXISTS helm_machines (
+    id              INTEGER PRIMARY KEY,
+    label           TEXT NOT NULL,
+    base_url        TEXT NOT NULL,
+    enabled         INTEGER NOT NULL DEFAULT 1,
+    last_seen_at    TEXT,
+    created_at      TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_helm_machines_enabled ON helm_machines(enabled);

--- a/src-tauri/src/helm/mod.rs
+++ b/src-tauri/src/helm/mod.rs
@@ -1,0 +1,234 @@
+//! Helm-daemon machine registry.
+//!
+//! Each row in `helm_machines` is one daemon endpoint the user has paired
+//! with workroot. The daemons are oblivious to each other — this module is
+//! the only place the multi-machine list lives, mirroring helm's
+//! `app/lib/machines.ts`.
+//!
+//! Bearer tokens are kept in the OS keyring under
+//! `service = "com.workroot.app"`, `user = "helm-token-<id>"`. They never
+//! touch the SQLite row.
+
+use crate::db::queries::{self, HelmMachineRow};
+use crate::db::AppDb;
+use keyring::Entry;
+use serde::Serialize;
+use tauri::State;
+
+const KEYRING_SERVICE: &str = "com.workroot.app";
+
+fn token_user(machine_id: i64) -> String {
+    format!("helm-token-{}", machine_id)
+}
+
+fn keyring_entry(machine_id: i64) -> Result<Entry, String> {
+    Entry::new(KEYRING_SERVICE, &token_user(machine_id))
+        .map_err(|e| format!("Keyring entry: {}", e))
+}
+
+fn read_token(machine_id: i64) -> Result<Option<String>, String> {
+    let entry = keyring_entry(machine_id)?;
+    match entry.get_password() {
+        Ok(t) => Ok(Some(t)),
+        Err(keyring::Error::NoEntry) => Ok(None),
+        Err(e) => Err(format!("Keyring read: {}", e)),
+    }
+}
+
+fn write_token(machine_id: i64, token: Option<&str>) -> Result<(), String> {
+    let entry = keyring_entry(machine_id)?;
+    match token {
+        Some(t) if !t.is_empty() => entry
+            .set_password(t)
+            .map_err(|e| format!("Keyring write: {}", e)),
+        _ => match entry.delete_credential() {
+            Ok(_) | Err(keyring::Error::NoEntry) => Ok(()),
+            Err(e) => Err(format!("Keyring clear: {}", e)),
+        },
+    }
+}
+
+/// Machine record returned to the frontend. The bearer token is included
+/// when present; React assembles `Authorization: Bearer <token>` headers
+/// directly. Tauri's IPC boundary already isolates this from the open web.
+#[derive(Debug, Serialize)]
+pub struct HelmMachine {
+    #[serde(flatten)]
+    row: HelmMachineRow,
+    api_token: Option<String>,
+}
+
+fn hydrate(row: HelmMachineRow) -> Result<HelmMachine, String> {
+    let api_token = read_token(row.id)?;
+    Ok(HelmMachine { row, api_token })
+}
+
+#[tauri::command]
+pub fn list_helm_machines(db: State<'_, AppDb>) -> Result<Vec<HelmMachine>, String> {
+    let conn = db.0.lock().map_err(|e| format!("DB lock: {}", e))?;
+    let rows =
+        queries::list_helm_machines(&conn).map_err(|e| format!("List helm machines: {}", e))?;
+    rows.into_iter().map(hydrate).collect()
+}
+
+#[tauri::command]
+pub fn add_helm_machine(
+    db: State<'_, AppDb>,
+    label: String,
+    base_url: String,
+    api_token: Option<String>,
+) -> Result<HelmMachine, String> {
+    let label = label.trim().to_string();
+    let base_url = normalize_base_url(&base_url);
+    if label.is_empty() {
+        return Err("Label is required".into());
+    }
+    if base_url.is_empty() {
+        return Err("Base URL is required".into());
+    }
+
+    let id = {
+        let conn = db.0.lock().map_err(|e| format!("DB lock: {}", e))?;
+        queries::insert_helm_machine(&conn, &label, &base_url)
+            .map_err(|e| format!("Insert helm machine: {}", e))?
+    };
+
+    if let Some(ref t) = api_token {
+        write_token(id, Some(t))?;
+    }
+
+    let conn = db.0.lock().map_err(|e| format!("DB lock: {}", e))?;
+    let row = queries::get_helm_machine(&conn, id)
+        .map_err(|e| format!("Get helm machine: {}", e))?
+        .ok_or_else(|| "Machine vanished after insert".to_string())?;
+    drop(conn);
+    hydrate(row)
+}
+
+#[tauri::command]
+pub fn update_helm_machine(
+    db: State<'_, AppDb>,
+    id: i64,
+    label: String,
+    base_url: String,
+    enabled: bool,
+    api_token: Option<String>,
+    clear_token: Option<bool>,
+) -> Result<HelmMachine, String> {
+    let label = label.trim().to_string();
+    let base_url = normalize_base_url(&base_url);
+    if label.is_empty() {
+        return Err("Label is required".into());
+    }
+    if base_url.is_empty() {
+        return Err("Base URL is required".into());
+    }
+
+    {
+        let conn = db.0.lock().map_err(|e| format!("DB lock: {}", e))?;
+        let updated = queries::update_helm_machine(&conn, id, &label, &base_url, enabled)
+            .map_err(|e| format!("Update helm machine: {}", e))?;
+        if !updated {
+            return Err(format!("No helm machine with id {}", id));
+        }
+    }
+
+    if clear_token.unwrap_or(false) {
+        write_token(id, None)?;
+    } else if let Some(t) = api_token.as_deref() {
+        write_token(id, Some(t))?;
+    }
+
+    let conn = db.0.lock().map_err(|e| format!("DB lock: {}", e))?;
+    let row = queries::get_helm_machine(&conn, id)
+        .map_err(|e| format!("Get helm machine: {}", e))?
+        .ok_or_else(|| "Machine vanished after update".to_string())?;
+    drop(conn);
+    hydrate(row)
+}
+
+#[tauri::command]
+pub fn remove_helm_machine(db: State<'_, AppDb>, id: i64) -> Result<bool, String> {
+    let removed = {
+        let conn = db.0.lock().map_err(|e| format!("DB lock: {}", e))?;
+        queries::delete_helm_machine(&conn, id)
+            .map_err(|e| format!("Delete helm machine: {}", e))?
+    };
+    if removed {
+        let _ = write_token(id, None);
+    }
+    Ok(removed)
+}
+
+#[tauri::command]
+pub fn touch_helm_machine_seen(db: State<'_, AppDb>, id: i64) -> Result<(), String> {
+    let conn = db.0.lock().map_err(|e| format!("DB lock: {}", e))?;
+    queries::touch_helm_machine_last_seen(&conn, id)
+        .map_err(|e| format!("Touch helm machine: {}", e))?;
+    Ok(())
+}
+
+fn normalize_base_url(raw: &str) -> String {
+    let trimmed = raw.trim().trim_end_matches('/').to_string();
+    trimmed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::init_test_db;
+
+    #[test]
+    fn insert_and_list() {
+        let conn = init_test_db();
+        let id = queries::insert_helm_machine(&conn, "Work MBP", "http://10.0.0.1:8421").unwrap();
+        assert!(id > 0);
+
+        let all = queries::list_helm_machines(&conn).unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].label, "Work MBP");
+        assert_eq!(all[0].base_url, "http://10.0.0.1:8421");
+        assert!(all[0].enabled);
+        assert!(all[0].last_seen_at.is_none());
+    }
+
+    #[test]
+    fn update_changes_fields() {
+        let conn = init_test_db();
+        let id = queries::insert_helm_machine(&conn, "Work", "http://10.0.0.1:8421").unwrap();
+
+        queries::update_helm_machine(&conn, id, "Work MBP", "http://10.0.0.2:8421", false).unwrap();
+
+        let m = queries::get_helm_machine(&conn, id).unwrap().unwrap();
+        assert_eq!(m.label, "Work MBP");
+        assert_eq!(m.base_url, "http://10.0.0.2:8421");
+        assert!(!m.enabled);
+    }
+
+    #[test]
+    fn delete_removes_row() {
+        let conn = init_test_db();
+        let id = queries::insert_helm_machine(&conn, "Work", "http://10.0.0.1:8421").unwrap();
+
+        let removed = queries::delete_helm_machine(&conn, id).unwrap();
+        assert!(removed);
+        assert!(queries::list_helm_machines(&conn).unwrap().is_empty());
+    }
+
+    #[test]
+    fn touch_last_seen_updates_timestamp() {
+        let conn = init_test_db();
+        let id = queries::insert_helm_machine(&conn, "Work", "http://10.0.0.1:8421").unwrap();
+
+        queries::touch_helm_machine_last_seen(&conn, id).unwrap();
+        let m = queries::get_helm_machine(&conn, id).unwrap().unwrap();
+        assert!(m.last_seen_at.is_some());
+    }
+
+    #[test]
+    fn normalize_base_url_strips_trailing_slash_and_whitespace() {
+        assert_eq!(normalize_base_url("  http://x:8421/  "), "http://x:8421");
+        assert_eq!(normalize_base_url("http://x:8421///"), "http://x:8421");
+        assert_eq!(normalize_base_url("http://x:8421"), "http://x:8421");
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@ pub mod errors;
 pub mod fileview;
 pub mod git;
 pub mod github;
+pub mod helm;
 pub mod mcp;
 pub mod memory;
 pub mod metrics;
@@ -162,6 +163,11 @@ pub fn run() {
             process::logs::search_process_logs,
             process::logs::clear_process_logs,
             process::lifecycle::cleanup_worktree_processes,
+            helm::list_helm_machines,
+            helm::add_helm_machine,
+            helm::update_helm_machine,
+            helm::remove_helm_machine,
+            helm::touch_helm_machine_seen,
             claudemd::generate_worktree_claude_md,
             claudemd::read_worktree_claude_md,
             shell::install_shell_hook,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -249,6 +249,13 @@ function AppContent({
         },
       },
       {
+        id: "settings:helm-machines",
+        label: "Helm Machines",
+        category: "Navigation",
+        icon: "\u2756",
+        action: () => openPanel("helmMachines"),
+      },
+      {
         id: "nav:close-settings",
         label: "Close Settings",
         category: "Navigation",

--- a/src/components/HelmMachinesPanel.tsx
+++ b/src/components/HelmMachinesPanel.tsx
@@ -1,0 +1,207 @@
+import { useCallback, useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { Dialog, DialogContent } from "./ui/dialog";
+import "../styles/helm-machines.css";
+
+interface HelmMachine {
+  id: number;
+  label: string;
+  base_url: string;
+  enabled: boolean;
+  last_seen_at: string | null;
+  created_at: string;
+  api_token: string | null;
+}
+
+interface HelmMachinesPanelProps {
+  onClose: () => void;
+}
+
+function formatLastSeen(iso: string | null): string {
+  if (!iso) return "never reached";
+  try {
+    const d = new Date(iso);
+    return `last seen ${d.toLocaleString()}`;
+  } catch {
+    return iso;
+  }
+}
+
+export function HelmMachinesPanel({ onClose }: HelmMachinesPanelProps) {
+  const [machines, setMachines] = useState<HelmMachine[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [newLabel, setNewLabel] = useState("");
+  const [newBaseUrl, setNewBaseUrl] = useState("");
+  const [newToken, setNewToken] = useState("");
+  const [adding, setAdding] = useState(false);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const list = await invoke<HelmMachine[]>("list_helm_machines");
+      setMachines(list);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const addMachine = useCallback(async () => {
+    if (!newLabel.trim() || !newBaseUrl.trim()) {
+      setError("Label and base URL are required.");
+      return;
+    }
+    setAdding(true);
+    setError(null);
+    try {
+      await invoke<HelmMachine>("add_helm_machine", {
+        label: newLabel,
+        baseUrl: newBaseUrl,
+        apiToken: newToken.trim() ? newToken : null,
+      });
+      setNewLabel("");
+      setNewBaseUrl("");
+      setNewToken("");
+      await refresh();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setAdding(false);
+    }
+  }, [newLabel, newBaseUrl, newToken, refresh]);
+
+  const toggleEnabled = useCallback(
+    async (m: HelmMachine) => {
+      try {
+        await invoke("update_helm_machine", {
+          id: m.id,
+          label: m.label,
+          baseUrl: m.base_url,
+          enabled: !m.enabled,
+          apiToken: null,
+          clearToken: false,
+        });
+        await refresh();
+      } catch (e) {
+        setError(String(e));
+      }
+    },
+    [refresh],
+  );
+
+  const removeMachine = useCallback(
+    async (m: HelmMachine) => {
+      try {
+        await invoke<boolean>("remove_helm_machine", { id: m.id });
+        await refresh();
+      } catch (e) {
+        setError(String(e));
+      }
+    },
+    [refresh],
+  );
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent className="helm-machines" aria-label="Helm Machines">
+        <div className="helm-machines__header">
+          <h3 className="helm-machines__title">Helm Machines</h3>
+          <p className="helm-machines__hint">
+            Each row is one helm-daemon. Disabled rows are skipped when fetching
+            agents.
+          </p>
+        </div>
+
+        {error && <p className="helm-machines__error">{error}</p>}
+
+        <div className="helm-machines__list">
+          {loading ? (
+            <p className="helm-machines__empty">Loading…</p>
+          ) : machines.length === 0 ? (
+            <p className="helm-machines__empty">
+              No machines yet. Add one below.
+            </p>
+          ) : (
+            machines.map((m) => (
+              <div
+                key={m.id}
+                className={
+                  m.enabled
+                    ? "helm-machines__row"
+                    : "helm-machines__row helm-machines__row--disabled"
+                }
+              >
+                <div className="helm-machines__row-meta">
+                  <span className="helm-machines__row-label">{m.label}</span>
+                  <span className="helm-machines__row-url">{m.base_url}</span>
+                  <span className="helm-machines__row-status">
+                    {m.api_token ? "auth: bearer • " : "auth: none • "}
+                    {formatLastSeen(m.last_seen_at)}
+                  </span>
+                </div>
+                <div className="helm-machines__row-actions">
+                  <button
+                    className="helm-machines__btn"
+                    onClick={() => void toggleEnabled(m)}
+                  >
+                    {m.enabled ? "Disable" : "Enable"}
+                  </button>
+                  <button
+                    className="helm-machines__btn helm-machines__btn--danger"
+                    onClick={() => void removeMachine(m)}
+                  >
+                    Remove
+                  </button>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+
+        <div className="helm-machines__form">
+          <input
+            type="text"
+            placeholder="Label (e.g. Work MBP)"
+            value={newLabel}
+            onChange={(e) => setNewLabel(e.target.value)}
+          />
+          <input
+            type="text"
+            placeholder="Base URL (e.g. http://10.0.0.1:8421)"
+            value={newBaseUrl}
+            onChange={(e) => setNewBaseUrl(e.target.value)}
+          />
+          <input
+            type="password"
+            placeholder="Bearer token (optional)"
+            value={newToken}
+            onChange={(e) => setNewToken(e.target.value)}
+            style={{ gridColumn: "1 / -1" }}
+          />
+          <div className="helm-machines__form-row">
+            <button
+              className="helm-machines__btn"
+              disabled={adding}
+              onClick={() => void addMachine()}
+            >
+              {adding ? "Adding…" : "Add machine"}
+            </button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/PanelHost.tsx
+++ b/src/components/PanelHost.tsx
@@ -224,6 +224,10 @@ const BrowserEvents = namedLazy(
   () => import("./BrowserEvents"),
   "BrowserEvents",
 );
+const HelmMachinesPanel = namedLazy(
+  () => import("./HelmMachinesPanel"),
+  "HelmMachinesPanel",
+);
 
 interface PanelHostProps {
   panels: ReadonlySet<PanelKey>;
@@ -898,6 +902,11 @@ export function PanelHost({
               />
             </div>
           </FocusTrapOverlay>
+        </PanelBoundary>
+      )}
+      {panels.has("helmMachines") && (
+        <PanelBoundary name="HelmMachinesPanel">
+          <HelmMachinesPanel onClose={() => closePanel("helmMachines")} />
         </PanelBoundary>
       )}
       <PanelBoundary name="QuickSwitcher">

--- a/src/hooks/usePanels.ts
+++ b/src/hooks/usePanels.ts
@@ -66,6 +66,7 @@ export type PanelKey =
   | "shellHistory"
   | "deadEnds"
   | "browserEvents"
+  | "helmMachines"
   | "checkpointManager"
   | "multiAgentPipeline"
   | "modelComparison"

--- a/src/styles/helm-machines.css
+++ b/src/styles/helm-machines.css
@@ -1,0 +1,141 @@
+.helm-machines {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px;
+  min-width: 520px;
+}
+
+.helm-machines__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.helm-machines__title {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.helm-machines__hint {
+  margin: 0;
+  font-size: 12px;
+  color: var(--color-text-secondary, #888);
+}
+
+.helm-machines__list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 280px;
+  overflow: auto;
+}
+
+.helm-machines__row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 4px 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--color-border, #2a2a2a);
+  border-radius: 6px;
+  background: var(--color-bg-secondary, #181818);
+}
+
+.helm-machines__row--disabled {
+  opacity: 0.55;
+}
+
+.helm-machines__row-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.helm-machines__row-label {
+  font-size: 13px;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.helm-machines__row-url {
+  font-size: 11px;
+  font-family: var(--font-mono, monospace);
+  color: var(--color-text-secondary, #888);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.helm-machines__row-status {
+  font-size: 11px;
+  color: var(--color-text-secondary, #888);
+}
+
+.helm-machines__row-actions {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.helm-machines__btn {
+  padding: 4px 10px;
+  font-size: 12px;
+  border: 1px solid var(--color-border, #2a2a2a);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--color-text, #e4e4e4);
+  cursor: pointer;
+}
+
+.helm-machines__btn:hover {
+  background: var(--color-bg-hover, #222);
+}
+
+.helm-machines__btn--danger {
+  color: var(--color-danger, #f87171);
+  border-color: var(--color-danger, #f87171);
+}
+
+.helm-machines__form {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  padding-top: 12px;
+  border-top: 1px solid var(--color-border, #2a2a2a);
+}
+
+.helm-machines__form input {
+  padding: 6px 8px;
+  font-size: 13px;
+  border: 1px solid var(--color-border, #2a2a2a);
+  border-radius: 4px;
+  background: var(--color-bg-secondary, #181818);
+  color: var(--color-text, #e4e4e4);
+}
+
+.helm-machines__form-row {
+  grid-column: 1 / -1;
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.helm-machines__error {
+  font-size: 12px;
+  color: var(--color-danger, #f87171);
+  margin: 0;
+}
+
+.helm-machines__empty {
+  padding: 24px;
+  text-align: center;
+  color: var(--color-text-secondary, #888);
+  font-size: 13px;
+  border: 1px dashed var(--color-border, #2a2a2a);
+  border-radius: 6px;
+}


### PR DESCRIPTION
## Summary

First slice of Phase 1 from [\`docs/PIVOT.md\`](docs/PIVOT.md): a place to register helm-daemon endpoints and store their bearer tokens. No agent fetching yet — that's PR 1.2.

## Backend

- New \`helm_machines\` table: \`id, label, base_url, enabled, last_seen_at, created_at\` plus an index on \`enabled\` for fast fan-out filtering.
- \`queries::HelmMachineRow\` and CRUD helpers in \`db/queries.rs\`.
- New \`src-tauri/src/helm/\` module with five Tauri commands:
  - \`list_helm_machines\`
  - \`add_helm_machine\`
  - \`update_helm_machine\`
  - \`remove_helm_machine\`
  - \`touch_helm_machine_seen\`
- Bearer tokens live in the **OS keyring** under \`service = "com.workroot.app"\`, \`user = "helm-token-<id>"\` — never in SQLite. Tokens come back alongside machines so React can assemble \`Authorization: Bearer …\` headers directly; Tauri's IPC is a sufficient boundary.
- 5 unit tests covering insert/list/update/delete/touch and URL normalization.

## Frontend

- New \`HelmMachinesPanel\`: list rows with enable/remove actions, plus an add-machine form (label + base URL + optional bearer token).
- Wired into \`PanelHost\`, the panel-name union in \`usePanels.ts\`, and a "Helm Machines" command-palette entry under \`Navigation\`.

## Reference

The phone app's machines store ([\`helm/app/lib/machines.ts\`](https://github.com/browser-use/helm/blob/main/app/lib/machines.ts)) is the shape we're matching; workroot persists the same data via SQLite + the OS keyring instead of zustand + AsyncStorage.

## Out of scope

- Health pinging on add (will land in PR 1.2 alongside the agents fetch)
- Machine fetching / fan-out hook
- Settings page integration — for now the panel is reachable via command palette only

## Test plan

- [x] \`cargo check\` clean
- [x] \`cargo clippy -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo test --lib\` (163 tests pass)
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm format:check\` clean
- [x] \`pnpm build\` clean
- [ ] CI green