### PR TITLE
feat: agents tab as the new home view (Phase 1.2)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,18 +44,10 @@ const SettingsTab = namedLazy(
   () => import("./components/SettingsTab"),
   "SettingsTab",
 );
-const WorkspaceGrid = namedLazy(
-  () => import("./components/WorkspaceGrid"),
-  "WorkspaceGrid",
+const AgentsTab = namedLazy(
+  () => import("./components/AgentsTab"),
+  "AgentsTab",
 );
-
-interface WorktreeInfo {
-  id: number;
-  project_id: number;
-  branch_name: string;
-  path: string;
-  status: string;
-}
 
 interface SidebarActions {
   openSearch: () => void;
@@ -972,26 +964,8 @@ function AppContent({
           <SettingsTab onClose={() => setShowSettings(false)} />
         </PanelBoundary>
       ) : !selectedWorktreePath ? (
-        <PanelBoundary name="WorkspaceGrid">
-          <WorkspaceGrid
-            projects={allProjects}
-            worktrees={allWorktrees}
-            onSelectWorktree={(wt: WorktreeInfo) => {
-              setSelectedProjectId(wt.project_id);
-              setSelectedWorktreeId(wt.id);
-              setSelectedWorktreePath(wt.path);
-              setSelectedWorktreeName(wt.branch_name);
-              setShowSettings(false);
-            }}
-            onNewWorktree={(projectId: number) => {
-              setSelectedProjectId(projectId);
-            }}
-            onOpenAgent={() => openPanel("multiAgentPipeline")}
-            onOpenDiff={() => openPanel("gitDiff")}
-            shell={terminalShell}
-            themeId={terminalThemeId}
-            snapshotMap={terminalSnapshotMapRef}
-          />
+        <PanelBoundary name="AgentsTab">
+          <AgentsTab onOpenMachines={() => openPanel("helmMachines")} />
         </PanelBoundary>
       ) : null}
       {/* TerminalPanel is rendered outside the ternary so it stays mounted

--- a/src/components/AgentsTab.tsx
+++ b/src/components/AgentsTab.tsx
@@ -1,0 +1,94 @@
+import { useAllAgents } from "../hooks/useAllAgents";
+import "../styles/agents-tab.css";
+
+interface AgentsTabProps {
+  onOpenMachines: () => void;
+}
+
+const STATE_LABELS: Record<string, string> = {
+  waiting_input: "Needs you",
+  working: "Working",
+  planning: "Planning",
+  queued: "Queued",
+  done: "Done",
+  failed: "Failed",
+};
+
+export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
+  const { agents, machines, loading } = useAllAgents();
+
+  const noMachines = machines.length === 0;
+
+  return (
+    <div className="agents-tab">
+      <div className="agents-tab__header">
+        <h2 className="agents-tab__title">Agents</h2>
+        <div className="agents-tab__machines-bar">
+          {machines.map(({ machine, error, agent_count }) => (
+            <span
+              key={machine.id}
+              className={
+                error
+                  ? "agents-tab__machine-pill agents-tab__machine-pill--err"
+                  : "agents-tab__machine-pill"
+              }
+              title={error ?? `${agent_count} agents`}
+            >
+              <span className="agents-tab__machine-pill-dot" />
+              {machine.label}
+              {!error && agent_count > 0 && ` · ${agent_count}`}
+            </span>
+          ))}
+          <button
+            className="agents-tab__empty-cta"
+            onClick={onOpenMachines}
+            style={{ marginTop: 0 }}
+          >
+            Manage machines
+          </button>
+        </div>
+      </div>
+
+      {noMachines ? (
+        <div className="agents-tab__empty">
+          <p>No helm machines registered.</p>
+          <p style={{ fontSize: 12, marginTop: 8 }}>
+            Add a daemon endpoint to start watching agents.
+          </p>
+          <button className="agents-tab__empty-cta" onClick={onOpenMachines}>
+            Add machine
+          </button>
+        </div>
+      ) : loading ? (
+        <div className="agents-tab__empty">Loading agents…</div>
+      ) : agents.length === 0 ? (
+        <div className="agents-tab__empty">
+          <p>No active agents.</p>
+          <p style={{ fontSize: 12, marginTop: 8 }}>
+            Spawn one from the helm CLI or phone app — it'll show up here.
+          </p>
+        </div>
+      ) : (
+        <div className="agents-tab__list">
+          {agents.map((a) => (
+            <div key={`${a.machine_id}:${a.id}`} className="agents-tab__row">
+              <span
+                className={`agents-tab__row-state agents-tab__row-state--${a.state}`}
+              >
+                {STATE_LABELS[a.state] ?? a.state}
+              </span>
+              <div className="agents-tab__row-meta">
+                <span className="agents-tab__row-name">{a.name}</span>
+                <span className="agents-tab__row-task">
+                  {a.last_activity ?? a.task}
+                </span>
+              </div>
+              <span className="agents-tab__row-repo">{a.repo}</span>
+              <span className="agents-tab__row-machine">{a.machine_label}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useAllAgents.ts
+++ b/src/hooks/useAllAgents.ts
@@ -1,0 +1,141 @@
+// Fan out a `/v1/agents` fetch across every enabled helm machine, merge
+// the results, and re-run on a fixed interval.
+//
+// Mirrors helm/app/lib/fanout.ts in spirit but uses native React state
+// instead of React Query — workroot doesn't pull RQ in just for this and
+// the whole "n machines × poll" surface is small enough to not need it.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import {
+  type Agent,
+  type AgentState,
+  type HelmMachine,
+  clientFor,
+} from "../lib/helm-api";
+
+export interface MergedAgent extends Agent {
+  /** Local id of the machine the agent was fetched from. */
+  machine_id: number;
+  /** User-chosen label for that machine (e.g. "Work MBP"). */
+  machine_label: string;
+}
+
+export interface MachineStatus {
+  machine: HelmMachine;
+  /** Last fetch error message, if any. Null when the most recent fetch
+   *  succeeded. */
+  error: string | null;
+  /** Number of agents this machine returned on its last successful
+   *  fetch. */
+  agent_count: number;
+}
+
+export interface AllAgentsResult {
+  agents: MergedAgent[];
+  machines: MachineStatus[];
+  /** True only on the very first load — subsequent polls keep
+   *  `loading` false so the list doesn't flicker. */
+  loading: boolean;
+  refresh: () => void;
+}
+
+const ATTENTION_RANK: Record<AgentState, number> = {
+  waiting_input: 0,
+  working: 1,
+  planning: 2,
+  queued: 3,
+  done: 4,
+  failed: 5,
+};
+
+function sortByAttention(a: MergedAgent, b: MergedAgent): number {
+  const ra = ATTENTION_RANK[a.state] ?? 99;
+  const rb = ATTENTION_RANK[b.state] ?? 99;
+  if (ra !== rb) return ra - rb;
+  return b.updated_at.localeCompare(a.updated_at);
+}
+
+const POLL_INTERVAL_MS = 5_000;
+
+export function useAllAgents(): AllAgentsResult {
+  const [agents, setAgents] = useState<MergedAgent[]>([]);
+  const [machines, setMachines] = useState<MachineStatus[]>([]);
+  const [loading, setLoading] = useState(true);
+  const cancelledRef = useRef(false);
+
+  const fetchOnce = useCallback(async () => {
+    let allMachines: HelmMachine[];
+    try {
+      allMachines = await invoke<HelmMachine[]>("list_helm_machines");
+    } catch {
+      // Tauri command itself failed — surface as empty list, no agents.
+      if (!cancelledRef.current) {
+        setMachines([]);
+        setAgents([]);
+      }
+      return;
+    }
+
+    const enabled = allMachines.filter((m) => m.enabled);
+    const results = await Promise.all(
+      enabled.map(
+        async (machine): Promise<MachineStatus & { agents: MergedAgent[] }> => {
+          try {
+            const { agents: list } = await clientFor(machine).agents();
+            // Mark as seen on first successful fetch per render.
+            void invoke("touch_helm_machine_seen", { id: machine.id }).catch(
+              () => {},
+            );
+            return {
+              machine,
+              error: null,
+              agent_count: list.length,
+              agents: list.map((a) => ({
+                ...a,
+                machine_id: machine.id,
+                machine_label: machine.label,
+              })),
+            };
+          } catch (e) {
+            return {
+              machine,
+              error: String(e),
+              agent_count: 0,
+              agents: [],
+            };
+          }
+        },
+      ),
+    );
+
+    if (cancelledRef.current) return;
+
+    const merged = results
+      .flatMap((r) => r.agents)
+      .filter((a) => !a.archived)
+      .sort(sortByAttention);
+
+    setAgents(merged);
+    setMachines(
+      results.map(({ machine, error, agent_count }) => ({
+        machine,
+        error,
+        agent_count,
+      })),
+    );
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    cancelledRef.current = false;
+    void fetchOnce();
+    const id = window.setInterval(() => void fetchOnce(), POLL_INTERVAL_MS);
+    return () => {
+      cancelledRef.current = true;
+      window.clearInterval(id);
+    };
+  }, [fetchOnce]);
+
+  return { agents, machines, loading, refresh: () => void fetchOnce() };
+}

--- a/src/lib/helm-api.ts
+++ b/src/lib/helm-api.ts
@@ -1,0 +1,201 @@
+// Daemon HTTP client. One instance per machine.
+//
+// Mirrors helm/app/lib/api.ts (the phone app's client). Workroot fetches
+// directly from React rather than proxying through Tauri commands —
+// helm's API is JSON over HTTP, no native plumbing needed.
+
+// ---- shared types (kept in step with helm/shared/api-spec/types.ts) ----
+
+export type AgentState =
+  | "queued"
+  | "planning"
+  | "working"
+  | "waiting_input"
+  | "done"
+  | "failed";
+
+export type AgentBackend = "claude" | "codex";
+
+export interface Agent {
+  id: string;
+  machine_name: string;
+  name: string;
+  repo: string;
+  task: string;
+  state: AgentState;
+  backend: AgentBackend;
+  summary: string | null;
+  archived?: boolean;
+  last_activity?: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Turn {
+  role: "user" | "assistant";
+  content: string;
+  at: string;
+}
+
+export type ThreadEvent =
+  | { kind: "user"; at: string; text: string }
+  | { kind: "assistant"; at: string; text: string }
+  | { kind: "thinking"; at: string; text: string }
+  | {
+      kind: "tool_use";
+      at: string;
+      id: string;
+      tool: string;
+      title: string;
+      input: string;
+    }
+  | {
+      kind: "tool_result";
+      at: string;
+      tool_use_id: string;
+      preview: string;
+      is_error: boolean;
+    };
+
+export interface SessionUsage {
+  input_tokens: number;
+  output_tokens: number;
+  cache_write_tokens: number;
+  cache_read_tokens: number;
+  cost_usd: number;
+}
+
+export interface AgentDetail extends Agent {
+  pending_question: string | null;
+  pr_url: string | null;
+  worktree_path: string;
+  branch: string;
+  session_id: string | null;
+  turns: Turn[];
+  thread_events?: ThreadEvent[];
+  usage?: SessionUsage;
+}
+
+export interface NewAgentRequest {
+  repo: string;
+  task: string;
+  base_branch?: string;
+  backend?: AgentBackend;
+  name?: string;
+  resume_session_id?: string;
+  use_worktree?: boolean;
+}
+
+export interface Repo {
+  name: string;
+  path: string;
+  default_branch: string;
+  preamble?: string | null;
+}
+
+export interface Health {
+  machine_name: string;
+  version: string;
+  repo_count: number;
+  uptime_seconds: number;
+}
+
+// ---- machine-shaped record exposed by Tauri (matches src-tauri/src/helm) ----
+
+export interface HelmMachine {
+  id: number;
+  label: string;
+  base_url: string;
+  enabled: boolean;
+  last_seen_at: string | null;
+  created_at: string;
+  api_token: string | null;
+}
+
+// ---- client ----
+
+const HEALTH_TIMEOUT_MS = 5_000;
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+export class DaemonClient {
+  constructor(
+    private readonly baseUrl: string,
+    private readonly token: string | null = null,
+  ) {}
+
+  private authHeader(): Record<string, string> {
+    return this.token ? { Authorization: `Bearer ${this.token}` } : {};
+  }
+
+  private async request<T>(
+    path: string,
+    init?: RequestInit,
+    timeoutMs: number = DEFAULT_TIMEOUT_MS,
+  ): Promise<T> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const res = await fetch(`${this.baseUrl}/v1${path}`, {
+        ...init,
+        signal: controller.signal,
+        headers: {
+          "Content-Type": "application/json",
+          ...this.authHeader(),
+          ...(init?.headers ?? {}),
+        },
+      });
+      if (!res.ok) {
+        throw new Error(`${res.status} ${res.statusText} on ${path}`);
+      }
+      return (await res.json()) as T;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  health(): Promise<Health> {
+    return this.request<Health>("/health", undefined, HEALTH_TIMEOUT_MS);
+  }
+
+  agents(): Promise<{ agents: Agent[] }> {
+    return this.request<{ agents: Agent[] }>("/agents");
+  }
+
+  agent(id: string): Promise<AgentDetail> {
+    return this.request<AgentDetail>(`/agents/${id}`);
+  }
+
+  repos(): Promise<{ repos: Repo[] }> {
+    return this.request<{ repos: Repo[] }>("/repos");
+  }
+
+  spawnAgent(body: NewAgentRequest): Promise<Agent> {
+    return this.request<Agent>("/agents", {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+  }
+
+  replyAgent(id: string, message: string): Promise<{ ok: boolean }> {
+    return this.request<{ ok: boolean }>(`/agents/${id}/reply`, {
+      method: "POST",
+      body: JSON.stringify({ message }),
+    });
+  }
+
+  killAgent(id: string): Promise<{ ok: boolean }> {
+    return this.request<{ ok: boolean }>(`/agents/${id}/kill`, {
+      method: "POST",
+    });
+  }
+
+  deleteAgent(id: string): Promise<{ ok: boolean }> {
+    return this.request<{ ok: boolean }>(`/agents/${id}`, {
+      method: "DELETE",
+    });
+  }
+}
+
+export function clientFor(m: HelmMachine): DaemonClient {
+  return new DaemonClient(m.base_url, m.api_token);
+}

--- a/src/styles/agents-tab.css
+++ b/src/styles/agents-tab.css
@@ -1,0 +1,148 @@
+.agents-tab {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 24px 32px;
+  height: 100%;
+  overflow: auto;
+}
+
+.agents-tab__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 16px;
+}
+
+.agents-tab__title {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 600;
+}
+
+.agents-tab__machines-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.agents-tab__machine-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  font-size: 12px;
+  border: 1px solid var(--color-border, #2a2a2a);
+  border-radius: 999px;
+  background: var(--color-bg-secondary, #181818);
+}
+
+.agents-tab__machine-pill--err {
+  border-color: var(--color-danger, #f87171);
+  color: var(--color-danger, #f87171);
+}
+
+.agents-tab__machine-pill-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--color-success, #4ade80);
+}
+
+.agents-tab__machine-pill--err .agents-tab__machine-pill-dot {
+  background: var(--color-danger, #f87171);
+}
+
+.agents-tab__list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.agents-tab__row {
+  display: grid;
+  grid-template-columns: 90px 1fr auto auto;
+  gap: 16px;
+  align-items: center;
+  padding: 12px 16px;
+  border: 1px solid var(--color-border, #2a2a2a);
+  border-radius: 6px;
+  background: var(--color-bg-secondary, #181818);
+}
+
+.agents-tab__row-state {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  font-weight: 600;
+  color: var(--color-text-secondary, #888);
+}
+
+.agents-tab__row-state--waiting_input {
+  color: var(--color-warning, #fbbf24);
+}
+.agents-tab__row-state--working {
+  color: var(--color-success, #4ade80);
+}
+.agents-tab__row-state--failed {
+  color: var(--color-danger, #f87171);
+}
+.agents-tab__row-state--done {
+  color: var(--color-text-secondary, #888);
+}
+
+.agents-tab__row-name {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.agents-tab__row-task {
+  font-size: 12px;
+  color: var(--color-text-secondary, #888);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.agents-tab__row-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.agents-tab__row-machine {
+  font-size: 11px;
+  color: var(--color-text-secondary, #888);
+}
+
+.agents-tab__row-repo {
+  font-size: 11px;
+  font-family: var(--font-mono, monospace);
+  color: var(--color-text-secondary, #888);
+}
+
+.agents-tab__empty {
+  margin-top: 32px;
+  padding: 32px;
+  text-align: center;
+  border: 1px dashed var(--color-border, #2a2a2a);
+  border-radius: 6px;
+  color: var(--color-text-secondary, #888);
+}
+
+.agents-tab__empty-cta {
+  margin-top: 12px;
+  padding: 6px 12px;
+  font-size: 12px;
+  border: 1px solid var(--color-border, #2a2a2a);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--color-text, #e4e4e4);
+  cursor: pointer;
+}
+
+.agents-tab__empty-cta:hover {
+  background: var(--color-bg-hover, #222);
+}


### PR DESCRIPTION
## Summary

Second slice of Phase 1 from [\`docs/PIVOT.md\`](docs/PIVOT.md). Fans out a \`GET /v1/agents\` across every enabled helm machine on a 5-second poll, merges and sorts the results by attention, and lands the live list on the home view.

Stacked on #443 (helm machines foundation, now merged).

## What's new

- **\`src/lib/helm-api.ts\`** — \`DaemonClient\` mirroring [\`helm/app/lib/api.ts\`](https://github.com/browser-use/helm/blob/main/app/lib/api.ts). Bearer auth, \`AbortController\` timeouts (5s for \`/health\`, 15s for everything else), full \`Agent\` / \`AgentDetail\` / \`ThreadEvent\` / \`SessionUsage\` types kept in step with helm's [shared spec](https://github.com/browser-use/helm/blob/main/shared/api-spec/types.ts).
- **\`src/hooks/useAllAgents.ts\`** — pulls machines from Tauri, filters to enabled, parallel-fetches \`/v1/agents\` per machine, merges results tagged with \`machine_id\` + \`machine_label\`, drops archived rows, sorts by \`AgentState\` attention rank (\`waiting_input\` < \`working\` < \`planning\` < \`queued\` < \`done\` < \`failed\`). Polls every 5s. Calls \`touch_helm_machine_seen\` on each successful machine fetch.
- **\`AgentsTab.tsx\`** — list view with per-row state pills, per-machine pills (green when healthy, red when the last fetch failed), and three empty states (no machines / loading / no agents).

## UX change

\`AgentsTab\` **replaces \`WorkspaceGrid\`** as the home view (when no worktree is selected and Settings is closed). Per the pivot, agents are the front door now. The sidebar + \`TerminalPanel\` flow when a worktree IS selected is untouched — clicking into a project/worktree still drops you in the terminal as before.

## Out of scope (and explicitly deferred)

- **WorkspaceGrid is left in the tree** unreferenced. Killing it vs. resurrecting it as a \`view:legacy-projects\` panel is a follow-up call — not blocking this PR.
- **Right-pane agent detail** (PR 1.3) — clicking a row does nothing yet.
- **Actions** (reply / kill / delete) — PR 1.4.

## Test plan

- [x] \`cargo check\` clean
- [x] \`cargo clippy -D warnings\` clean
- [x] \`cargo test --lib\` (163 tests pass — backend unchanged)
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm format:check\` clean
- [x] \`pnpm build\` clean
- [ ] CI green
- [ ] Manual smoke against a real helm-daemon (deferred to user — I don't have one running locally)