### PR TITLE
feat: agent detail right pane (Phase 1.3)

### DIFF
--- a/src/components/AgentDetailPane.tsx
+++ b/src/components/AgentDetailPane.tsx
@@ -1,0 +1,189 @@
+import { useAgentDetail } from "../hooks/useAgentDetail";
+import { type ThreadEvent, type Turn } from "../lib/helm-api";
+import "../styles/agent-detail.css";
+
+interface AgentDetailPaneProps {
+  machineId: number | null;
+  agentId: string | null;
+  onClose: () => void;
+}
+
+function formatCost(usd: number): string {
+  return `$${usd.toFixed(4)}`;
+}
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return n.toString();
+}
+
+function ThreadEventRow({ ev }: { ev: ThreadEvent }) {
+  switch (ev.kind) {
+    case "user":
+      return (
+        <div className="agent-detail__event agent-detail__event--user">
+          <span className="agent-detail__event-label">User</span>
+          {ev.text}
+        </div>
+      );
+    case "assistant":
+      return (
+        <div className="agent-detail__event agent-detail__event--assistant">
+          <span className="agent-detail__event-label">Assistant</span>
+          {ev.text}
+        </div>
+      );
+    case "thinking":
+      return (
+        <div className="agent-detail__event agent-detail__event--thinking">
+          {ev.text}
+        </div>
+      );
+    case "tool_use":
+      return (
+        <div className="agent-detail__event agent-detail__event--tool_use">
+          <span className="agent-detail__event-label">
+            tool: {ev.tool} — {ev.title}
+          </span>
+          {ev.input}
+        </div>
+      );
+    case "tool_result":
+      return (
+        <div
+          className={
+            ev.is_error
+              ? "agent-detail__event agent-detail__event--tool_result is-error"
+              : "agent-detail__event agent-detail__event--tool_result"
+          }
+        >
+          <span className="agent-detail__event-label">
+            result{ev.is_error ? " (error)" : ""}
+          </span>
+          {ev.preview}
+        </div>
+      );
+  }
+}
+
+function TurnRow({ turn }: { turn: Turn }) {
+  return (
+    <div
+      className={
+        turn.role === "user"
+          ? "agent-detail__event agent-detail__event--user"
+          : "agent-detail__event agent-detail__event--assistant"
+      }
+    >
+      <span className="agent-detail__event-label">{turn.role}</span>
+      {turn.content}
+    </div>
+  );
+}
+
+export function AgentDetailPane({
+  machineId,
+  agentId,
+  onClose,
+}: AgentDetailPaneProps) {
+  const { detail, machine, loading, error } = useAgentDetail(
+    machineId,
+    agentId,
+  );
+
+  if (machineId === null || agentId === null) {
+    return (
+      <aside className="agent-detail">
+        <p className="agent-detail__empty">Select an agent to inspect.</p>
+      </aside>
+    );
+  }
+
+  return (
+    <aside className="agent-detail">
+      <div className="agent-detail__header">
+        <div className="agent-detail__title-row">
+          <h3 className="agent-detail__title">{detail?.name ?? "Loading…"}</h3>
+          <button
+            className="agent-detail__close"
+            onClick={onClose}
+            aria-label="Close detail pane"
+          >
+            ×
+          </button>
+        </div>
+        {detail && (
+          <div className="agent-detail__meta">
+            <span
+              className={`agent-detail__state-pill agent-detail__state-pill--${detail.state}`}
+            >
+              {detail.state}
+            </span>
+            <span className="agent-detail__meta-item">
+              {machine?.label ?? detail.machine_name}
+            </span>
+            <span className="agent-detail__meta-item">{detail.repo}</span>
+            <span className="agent-detail__meta-item">{detail.branch}</span>
+          </div>
+        )}
+      </div>
+
+      {error && <p className="agent-detail__error">{error}</p>}
+
+      {loading && !detail ? (
+        <p className="agent-detail__loading">Loading…</p>
+      ) : detail ? (
+        <>
+          {detail.pending_question && (
+            <div className="agent-detail__pending">
+              <span className="agent-detail__pending-label">
+                Pending question
+              </span>
+              {detail.pending_question}
+            </div>
+          )}
+
+          {detail.pr_url && (
+            <a
+              className="agent-detail__pr"
+              href={detail.pr_url}
+              target="_blank"
+              rel="noreferrer"
+            >
+              {detail.pr_url}
+            </a>
+          )}
+
+          <div className="agent-detail__events">
+            {detail.thread_events && detail.thread_events.length > 0
+              ? detail.thread_events.map((ev, i) => (
+                  <ThreadEventRow key={i} ev={ev} />
+                ))
+              : detail.turns.map((t, i) => <TurnRow key={i} turn={t} />)}
+            {(!detail.thread_events || detail.thread_events.length === 0) &&
+              detail.turns.length === 0 && (
+                <p className="agent-detail__empty">
+                  No transcript yet — agent hasn't produced output.
+                </p>
+              )}
+          </div>
+
+          {detail.usage && (
+            <div className="agent-detail__usage">
+              <span>
+                in {formatTokens(detail.usage.input_tokens)} · out{" "}
+                {formatTokens(detail.usage.output_tokens)}
+              </span>
+              <span>
+                cache w {formatTokens(detail.usage.cache_write_tokens)} · r{" "}
+                {formatTokens(detail.usage.cache_read_tokens)}
+              </span>
+              <span>{formatCost(detail.usage.cost_usd)}</span>
+            </div>
+          )}
+        </>
+      ) : null}
+    </aside>
+  );
+}

--- a/src/components/AgentsTab.tsx
+++ b/src/components/AgentsTab.tsx
@@ -1,8 +1,15 @@
+import { useCallback, useEffect, useState } from "react";
 import { useAllAgents } from "../hooks/useAllAgents";
+import { AgentDetailPane } from "./AgentDetailPane";
 import "../styles/agents-tab.css";
 
 interface AgentsTabProps {
   onOpenMachines: () => void;
+}
+
+interface Selection {
+  machineId: number;
+  agentId: string;
 }
 
 const STATE_LABELS: Record<string, string> = {
@@ -16,11 +23,35 @@ const STATE_LABELS: Record<string, string> = {
 
 export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
   const { agents, machines, loading } = useAllAgents();
+  const [selected, setSelected] = useState<Selection | null>(null);
+
+  const closeDetail = useCallback(() => setSelected(null), []);
+
+  // Drop the selection if the underlying agent disappears (e.g. deleted
+  // remotely) — keeps the right pane from rendering stale data.
+  useEffect(() => {
+    if (!selected) return;
+    const stillThere = agents.some(
+      (a) => a.id === selected.agentId && a.machine_id === selected.machineId,
+    );
+    if (!stillThere) setSelected(null);
+  }, [agents, selected]);
+
+  // Esc closes the detail pane.
+  useEffect(() => {
+    if (!selected) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") closeDetail();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [selected, closeDetail]);
 
   const noMachines = machines.length === 0;
+  const twoPane = selected !== null;
 
-  return (
-    <div className="agents-tab">
+  const list = (
+    <>
       <div className="agents-tab__header">
         <h2 className="agents-tab__title">Agents</h2>
         <div className="agents-tab__machines-bar">
@@ -70,25 +101,70 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
         </div>
       ) : (
         <div className="agents-tab__list">
-          {agents.map((a) => (
-            <div key={`${a.machine_id}:${a.id}`} className="agents-tab__row">
-              <span
-                className={`agents-tab__row-state agents-tab__row-state--${a.state}`}
+          {agents.map((a) => {
+            const isSelected =
+              selected?.agentId === a.id &&
+              selected?.machineId === a.machine_id;
+            return (
+              <div
+                key={`${a.machine_id}:${a.id}`}
+                className={
+                  isSelected
+                    ? "agents-tab__row agents-tab__row--selected"
+                    : "agents-tab__row"
+                }
+                onClick={() =>
+                  setSelected({ machineId: a.machine_id, agentId: a.id })
+                }
+                role="button"
+                tabIndex={0}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    setSelected({
+                      machineId: a.machine_id,
+                      agentId: a.id,
+                    });
+                  }
+                }}
               >
-                {STATE_LABELS[a.state] ?? a.state}
-              </span>
-              <div className="agents-tab__row-meta">
-                <span className="agents-tab__row-name">{a.name}</span>
-                <span className="agents-tab__row-task">
-                  {a.last_activity ?? a.task}
+                <span
+                  className={`agents-tab__row-state agents-tab__row-state--${a.state}`}
+                >
+                  {STATE_LABELS[a.state] ?? a.state}
+                </span>
+                <div className="agents-tab__row-meta">
+                  <span className="agents-tab__row-name">{a.name}</span>
+                  <span className="agents-tab__row-task">
+                    {a.last_activity ?? a.task}
+                  </span>
+                </div>
+                <span className="agents-tab__row-repo">{a.repo}</span>
+                <span className="agents-tab__row-machine">
+                  {a.machine_label}
                 </span>
               </div>
-              <span className="agents-tab__row-repo">{a.repo}</span>
-              <span className="agents-tab__row-machine">{a.machine_label}</span>
-            </div>
-          ))}
+            );
+          })}
         </div>
       )}
+    </>
+  );
+
+  if (!twoPane) {
+    return <div className="agents-tab">{list}</div>;
+  }
+
+  return (
+    <div className="agents-tab agents-tab--two-pane">
+      <div className="agents-tab__list-pane">{list}</div>
+      <div className="agents-tab__detail-pane">
+        <AgentDetailPane
+          machineId={selected.machineId}
+          agentId={selected.agentId}
+          onClose={closeDetail}
+        />
+      </div>
     </div>
   );
 }

--- a/src/hooks/useAgentDetail.ts
+++ b/src/hooks/useAgentDetail.ts
@@ -1,0 +1,89 @@
+// Single-agent live detail fetch.
+//
+// Given a (machine_id, agent_id) pair, repeatedly fetches /v1/agents/:id
+// against the matching machine. Used by the right pane in AgentsTab to
+// keep the thread/usage view current while an agent runs.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { type AgentDetail, type HelmMachine, clientFor } from "../lib/helm-api";
+
+const POLL_INTERVAL_MS = 3_000;
+
+export interface AgentDetailResult {
+  detail: AgentDetail | null;
+  /** Machine the agent belongs to. Null when not yet resolved or if the
+   *  machine row has been removed. */
+  machine: HelmMachine | null;
+  loading: boolean;
+  error: string | null;
+  refresh: () => void;
+}
+
+export function useAgentDetail(
+  machineId: number | null,
+  agentId: string | null,
+): AgentDetailResult {
+  const [detail, setDetail] = useState<AgentDetail | null>(null);
+  const [machine, setMachine] = useState<HelmMachine | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  const cancelledRef = useRef(false);
+
+  const fetchOnce = useCallback(async () => {
+    if (machineId === null || agentId === null) {
+      setDetail(null);
+      setMachine(null);
+      setError(null);
+      return;
+    }
+    try {
+      const machines = await invoke<HelmMachine[]>("list_helm_machines");
+      const m = machines.find((x) => x.id === machineId) ?? null;
+      if (!m) {
+        if (!cancelledRef.current) {
+          setMachine(null);
+          setDetail(null);
+          setError("Machine no longer registered");
+        }
+        return;
+      }
+      if (!cancelledRef.current) setMachine(m);
+      const d = await clientFor(m).agent(agentId);
+      if (!cancelledRef.current) {
+        setDetail(d);
+        setError(null);
+      }
+    } catch (e) {
+      if (!cancelledRef.current) setError(String(e));
+    } finally {
+      if (!cancelledRef.current) setLoading(false);
+    }
+  }, [machineId, agentId]);
+
+  useEffect(() => {
+    cancelledRef.current = false;
+    if (machineId === null || agentId === null) {
+      setDetail(null);
+      setMachine(null);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    void fetchOnce();
+    const id = window.setInterval(() => void fetchOnce(), POLL_INTERVAL_MS);
+    return () => {
+      cancelledRef.current = true;
+      window.clearInterval(id);
+    };
+  }, [fetchOnce, machineId, agentId]);
+
+  return {
+    detail,
+    machine,
+    loading,
+    error,
+    refresh: () => void fetchOnce(),
+  };
+}

--- a/src/styles/agent-detail.css
+++ b/src/styles/agent-detail.css
@@ -1,0 +1,191 @@
+.agent-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 20px 24px;
+  height: 100%;
+  overflow: auto;
+  border-left: 1px solid var(--color-border, #2a2a2a);
+  background: var(--color-bg, #111);
+}
+
+.agent-detail__header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--color-border, #2a2a2a);
+}
+
+.agent-detail__title-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.agent-detail__title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.agent-detail__close {
+  background: transparent;
+  border: none;
+  color: var(--color-text-secondary, #888);
+  cursor: pointer;
+  font-size: 18px;
+}
+
+.agent-detail__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 12px;
+  font-size: 11px;
+  color: var(--color-text-secondary, #888);
+}
+
+.agent-detail__meta-item {
+  font-family: var(--font-mono, monospace);
+}
+
+.agent-detail__state-pill {
+  display: inline-block;
+  padding: 2px 8px;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  font-weight: 600;
+  border-radius: 999px;
+  background: var(--color-bg-secondary, #181818);
+  border: 1px solid var(--color-border, #2a2a2a);
+}
+
+.agent-detail__state-pill--waiting_input {
+  color: var(--color-warning, #fbbf24);
+  border-color: var(--color-warning, #fbbf24);
+}
+.agent-detail__state-pill--working {
+  color: var(--color-success, #4ade80);
+  border-color: var(--color-success, #4ade80);
+}
+.agent-detail__state-pill--failed {
+  color: var(--color-danger, #f87171);
+  border-color: var(--color-danger, #f87171);
+}
+
+.agent-detail__pending {
+  padding: 10px 12px;
+  border: 1px solid var(--color-warning, #fbbf24);
+  border-radius: 6px;
+  background: rgba(251, 191, 36, 0.08);
+  font-size: 13px;
+}
+
+.agent-detail__pending-label {
+  display: block;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--color-warning, #fbbf24);
+  margin-bottom: 4px;
+}
+
+.agent-detail__pr {
+  font-size: 12px;
+  color: var(--color-link, #60a5fa);
+  text-decoration: none;
+}
+
+.agent-detail__pr:hover {
+  text-decoration: underline;
+}
+
+.agent-detail__events {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.agent-detail__event {
+  padding: 8px 12px;
+  border-radius: 6px;
+  font-size: 13px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.agent-detail__event--user {
+  background: var(--color-bg-secondary, #181818);
+  border: 1px solid var(--color-border, #2a2a2a);
+}
+
+.agent-detail__event--assistant {
+  background: rgba(96, 165, 250, 0.06);
+  border: 1px solid rgba(96, 165, 250, 0.25);
+}
+
+.agent-detail__event--thinking {
+  font-style: italic;
+  color: var(--color-text-secondary, #888);
+  font-size: 12px;
+  background: transparent;
+  border: none;
+  padding: 4px 12px;
+}
+
+.agent-detail__event--tool_use {
+  background: var(--color-bg-secondary, #181818);
+  border: 1px dashed var(--color-border, #2a2a2a);
+  font-family: var(--font-mono, monospace);
+  font-size: 12px;
+}
+
+.agent-detail__event--tool_result {
+  background: var(--color-bg-secondary, #181818);
+  border-left: 2px solid var(--color-text-secondary, #888);
+  font-family: var(--font-mono, monospace);
+  font-size: 12px;
+  padding-left: 10px;
+  border-radius: 0;
+}
+
+.agent-detail__event--tool_result.is-error {
+  border-left-color: var(--color-danger, #f87171);
+  color: var(--color-danger, #f87171);
+}
+
+.agent-detail__event-label {
+  display: block;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--color-text-secondary, #888);
+  margin-bottom: 4px;
+}
+
+.agent-detail__usage {
+  margin-top: auto;
+  padding-top: 12px;
+  border-top: 1px solid var(--color-border, #2a2a2a);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 16px;
+  font-size: 11px;
+  color: var(--color-text-secondary, #888);
+  font-family: var(--font-mono, monospace);
+}
+
+.agent-detail__loading,
+.agent-detail__error,
+.agent-detail__empty {
+  padding: 20px;
+  text-align: center;
+  color: var(--color-text-secondary, #888);
+  font-size: 13px;
+}
+
+.agent-detail__error {
+  color: var(--color-danger, #f87171);
+}

--- a/src/styles/agents-tab.css
+++ b/src/styles/agents-tab.css
@@ -7,6 +7,39 @@
   overflow: auto;
 }
 
+.agents-tab--two-pane {
+  flex-direction: row;
+  gap: 0;
+  padding: 0;
+  overflow: hidden;
+}
+
+.agents-tab__list-pane {
+  flex: 1 1 0;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 24px 32px;
+  overflow: auto;
+}
+
+.agents-tab__detail-pane {
+  flex: 1 1 0;
+  min-width: 380px;
+  max-width: 640px;
+  overflow: hidden;
+}
+
+.agents-tab__row {
+  cursor: pointer;
+}
+
+.agents-tab__row--selected {
+  border-color: var(--color-accent, #60a5fa);
+  background: rgba(96, 165, 250, 0.08);
+}
+
 .agents-tab__header {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
## Summary

Third slice of Phase 1. Clicking a row in \`AgentsTab\` now opens the agent's detail in a right pane, polled every 3 seconds. Matches helm's \`AgentDetail\` shape: \`turns\`, \`thread_events\`, \`pending_question\`, \`pr_url\`, \`session_id\`, \`usage\`.

Stacks on #444 (now merged).

## What's new

- **\`src/hooks/useAgentDetail.ts\`** — given \`(machine_id, agent_id)\`, re-resolves the machine from the Tauri store on each tick (so removing a machine cleanly drops the pane), fetches \`GET /v1/agents/:id\` every 3s, surfaces fetch errors inline.
- **\`src/components/AgentDetailPane.tsx\`** — header with state pill + machine / repo / branch meta, pending-question banner (yellow when present), PR link, thread-events renderer that styles \`user\` / \`assistant\` / \`thinking\` / \`tool_use\` / \`tool_result\` distinctly. Falls back to the legacy \`turns[]\` for codex agents and pre-tmux Claude agents that don't emit \`thread_events\`. Usage footer with token + cost totals.
- **\`AgentsTab.tsx\`** now collapses to a list-only single column when nothing is selected, switches to a two-pane layout when a row is selected.
  - Esc closes the pane.
  - Selection drops automatically if the agent is removed remotely (poll returns no match).
  - Keyboard activation (Enter / Space) on rows for accessibility.

## Backend

Untouched.

## Out of scope

- **Reply form / kill / delete** — that's PR 1.4.
- **Live tmux preview (xterm)** — Phase 2 per PIVOT.md.

## Test plan

- [x] \`cargo check\` clean (no backend changes)
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm format:check\` clean
- [x] \`pnpm build\` clean
- [ ] CI green
- [ ] Manual smoke against a real helm-daemon (deferred)