### PR TITLE
feat: agent reply / kill / delete actions (Phase 1.4)

### DIFF
--- a/src/components/AgentDetailPane.tsx
+++ b/src/components/AgentDetailPane.tsx
@@ -1,12 +1,18 @@
+import { useState } from "react";
 import { useAgentDetail } from "../hooks/useAgentDetail";
-import { type ThreadEvent, type Turn } from "../lib/helm-api";
+import { clientFor, type ThreadEvent, type Turn } from "../lib/helm-api";
 import "../styles/agent-detail.css";
 
 interface AgentDetailPaneProps {
   machineId: number | null;
   agentId: string | null;
   onClose: () => void;
+  /** Called after a successful DELETE so the parent can drop selection
+   *  before the next poll catches up. */
+  onDeleted?: () => void;
 }
+
+const TERMINAL_STATES = new Set(["done", "failed"]);
 
 function formatCost(usd: number): string {
   return `$${usd.toFixed(4)}`;
@@ -86,11 +92,15 @@ export function AgentDetailPane({
   machineId,
   agentId,
   onClose,
+  onDeleted,
 }: AgentDetailPaneProps) {
-  const { detail, machine, loading, error } = useAgentDetail(
+  const { detail, machine, loading, error, refresh } = useAgentDetail(
     machineId,
     agentId,
   );
+  const [reply, setReply] = useState("");
+  const [busy, setBusy] = useState<"reply" | "kill" | "delete" | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
 
   if (machineId === null || agentId === null) {
     return (
@@ -99,6 +109,60 @@ export function AgentDetailPane({
       </aside>
     );
   }
+
+  const sendReply = async () => {
+    if (!machine || !detail || !reply.trim()) return;
+    setBusy("reply");
+    setActionError(null);
+    try {
+      await clientFor(machine).replyAgent(detail.id, reply);
+      setReply("");
+      refresh();
+    } catch (e) {
+      setActionError(String(e));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const kill = async () => {
+    if (!machine || !detail) return;
+    if (!window.confirm(`Kill agent "${detail.name}"?`)) return;
+    setBusy("kill");
+    setActionError(null);
+    try {
+      await clientFor(machine).killAgent(detail.id);
+      refresh();
+    } catch (e) {
+      setActionError(String(e));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const remove = async () => {
+    if (!machine || !detail) return;
+    if (
+      !window.confirm(
+        `Delete agent "${detail.name}"? This removes the worktree, logs, and DB row.`,
+      )
+    )
+      return;
+    setBusy("delete");
+    setActionError(null);
+    try {
+      await clientFor(machine).deleteAgent(detail.id);
+      onDeleted?.();
+      onClose();
+    } catch (e) {
+      setActionError(String(e));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const isTerminal = detail ? TERMINAL_STATES.has(detail.state) : false;
+  const canReply = !!detail && detail.backend === "claude" && !isTerminal;
 
   return (
     <aside className="agent-detail">
@@ -127,7 +191,33 @@ export function AgentDetailPane({
             <span className="agent-detail__meta-item">{detail.branch}</span>
           </div>
         )}
+        {detail && (
+          <div className="agent-detail__actions">
+            <button
+              className="agent-detail__action-btn"
+              onClick={() => void kill()}
+              disabled={isTerminal || busy !== null}
+              title={isTerminal ? "Agent already finished" : "Kill agent"}
+            >
+              {busy === "kill" ? "Killing…" : "Kill"}
+            </button>
+            <button
+              className="agent-detail__action-btn agent-detail__action-btn--danger"
+              onClick={() => void remove()}
+              disabled={!isTerminal || busy !== null}
+              title={
+                isTerminal
+                  ? "Delete agent"
+                  : "Kill the agent before deleting (daemon refuses delete on running agents)"
+              }
+            >
+              {busy === "delete" ? "Deleting…" : "Delete"}
+            </button>
+          </div>
+        )}
       </div>
+
+      {actionError && <p className="agent-detail__error">{actionError}</p>}
 
       {error && <p className="agent-detail__error">{error}</p>}
 
@@ -180,6 +270,39 @@ export function AgentDetailPane({
                 {formatTokens(detail.usage.cache_read_tokens)}
               </span>
               <span>{formatCost(detail.usage.cost_usd)}</span>
+            </div>
+          )}
+
+          {canReply && (
+            <div className="agent-detail__reply">
+              <textarea
+                value={reply}
+                onChange={(e) => setReply(e.target.value)}
+                onKeyDown={(e) => {
+                  if (
+                    (e.metaKey || e.ctrlKey) &&
+                    e.key === "Enter" &&
+                    reply.trim()
+                  ) {
+                    e.preventDefault();
+                    void sendReply();
+                  }
+                }}
+                placeholder="Reply to the agent…"
+                disabled={busy !== null}
+              />
+              <div className="agent-detail__reply-row">
+                <span className="agent-detail__reply-hint">
+                  ⌘/Ctrl + Enter to send
+                </span>
+                <button
+                  className="agent-detail__action-btn"
+                  onClick={() => void sendReply()}
+                  disabled={!reply.trim() || busy !== null}
+                >
+                  {busy === "reply" ? "Sending…" : "Send"}
+                </button>
+              </div>
             </div>
           )}
         </>

--- a/src/components/AgentsTab.tsx
+++ b/src/components/AgentsTab.tsx
@@ -163,6 +163,7 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
           machineId={selected.machineId}
           agentId={selected.agentId}
           onClose={closeDetail}
+          onDeleted={closeDetail}
         />
       </div>
     </div>

--- a/src/styles/agent-detail.css
+++ b/src/styles/agent-detail.css
@@ -177,6 +177,70 @@
   font-family: var(--font-mono, monospace);
 }
 
+.agent-detail__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.agent-detail__action-btn {
+  padding: 4px 10px;
+  font-size: 12px;
+  border: 1px solid var(--color-border, #2a2a2a);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--color-text, #e4e4e4);
+  cursor: pointer;
+}
+
+.agent-detail__action-btn:hover {
+  background: var(--color-bg-hover, #222);
+}
+
+.agent-detail__action-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.agent-detail__action-btn--danger {
+  color: var(--color-danger, #f87171);
+  border-color: var(--color-danger, #f87171);
+}
+
+.agent-detail__reply {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding-top: 8px;
+  border-top: 1px solid var(--color-border, #2a2a2a);
+}
+
+.agent-detail__reply textarea {
+  width: 100%;
+  min-height: 64px;
+  resize: vertical;
+  padding: 8px 10px;
+  font-size: 13px;
+  font-family: inherit;
+  border: 1px solid var(--color-border, #2a2a2a);
+  border-radius: 4px;
+  background: var(--color-bg-secondary, #181818);
+  color: var(--color-text, #e4e4e4);
+  box-sizing: border-box;
+}
+
+.agent-detail__reply-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+
+.agent-detail__reply-hint {
+  font-size: 11px;
+  color: var(--color-text-secondary, #888);
+}
+
 .agent-detail__loading,
 .agent-detail__error,
 .agent-detail__empty {


### PR DESCRIPTION
## Summary

Closes the agents-tab loop for Phase 1. Adds the three actions a helm-daemon exposes for an individual agent: reply, kill, delete. All wired into \`AgentDetailPane\`.

Stacks on #445 (now merged).

## What's new

- **Reply form** at the bottom of the pane — textarea, \`⌘/Ctrl+Enter\` to send, posts to \`POST /v1/agents/:id/reply\`. The daemon flips state to \`Working\` before send-keys returns, so a \`refresh()\` right after gives immediate visual feedback. Reply is shown only when \`backend === "claude"\` and state isn't terminal — codex agents have no reply channel, and the daemon would no-op a reply to a finished agent.
- **Kill button** in the header — \`window.confirm\` then \`POST /v1/agents/:id/kill\` (kills the tmux window for claude, SIGTERM for codex). Disabled when state is already terminal.
- **Delete button** in the header — \`window.confirm\` then \`DELETE /v1/agents/:id\`, closes the pane via \`onDeleted\` on success. **Disabled until the agent is in a terminal state** — the daemon refuses delete on running agents per [\`docs/daemon-api.md\`](https://github.com/browser-use/helm/blob/main/docs/daemon-api.md), no point letting users hit a 4xx.

\`AgentsTab\` passes \`onDeleted={closeDetail}\` so the right pane drops immediately rather than waiting for the next 5s poll to drop the row from \`useAllAgents\`.

## Phase 1 wrap

With this PR the Phase 1 minimum viable loop is complete: register a machine, see all its agents, click into one, follow the thread live, send a reply, kill or delete. Phase 2 (xterm tmux preview, diff viewer, ⌘ shortcuts, menu-bar) is next per [\`docs/PIVOT.md\`](docs/PIVOT.md).

## Test plan

- [x] \`cargo check\` clean (no backend changes)
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm format:check\` clean
- [x] \`pnpm build\` clean
- [ ] CI green
- [ ] Manual smoke against a real helm-daemon (deferred)