### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.1.28",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "workroot"
-version = "0.1.28"
+version = "0.2.0"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.1.28"
+version = "0.2.0"
 edition = "2021"
 authors = ["Saurav Panda <saurav@workroot.dev>"]
 description = "A local-first developer workspace for managing projects, terminals, and Git workflows."

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.1.28",
+  "version": "0.2.0",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary

Cuts the first post-pivot release.

## What's in 0.2.0

**Phase 0 — strip-down (#439, #440, #441):** removed the file-watcher, HTTP capture / proxy / port scanner, and DB-schema introspection subsystems. ~5,800 LOC out.

**Phase 1 — agents tab loop (#443, #444, #445, #446):**
- New \`helm_machines\` registry with bearer tokens in the OS keyring
- \`AgentsTab\` replaces \`WorkspaceGrid\` as the home view; live fan-out across enabled machines on a 5s poll
- Right-pane agent detail with thread events, pending question, PR link, session usage; refreshes every 3s
- Reply / kill / delete actions

**Plus:** README + \`docs/PIVOT.md\` reframe (#425), MorningBriefing dead-invoke cleanup (#442).

## Why 0.2.0 not 0.1.29

The home view and core positioning fundamentally changed — minor bump fits better than yet another patch.

## Release process

1. Merge this PR
2. Push tag \`v0.2.0\` → \`.github/workflows/release.yml\` builds Apple Silicon DMG + .app.tar.gz, uploads to a draft release
3. Approve the build job if the \`main\` environment requires it
4. Review and publish the draft

## Test plan

- [x] \`cargo check\` clean
- [x] All four version sites updated (package.json, src-tauri/Cargo.toml, src-tauri/Cargo.lock, src-tauri/tauri.conf.json)
- [ ] CI green
- [ ] Tag pushed and DMG built