### PR TITLE
fix: HelmMachinesPanel inputs close the dialog (v0.2.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "workroot"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Saurav Panda <saurav@workroot.dev>"]
 description = "A local-first developer workspace for managing projects, terminals, and Git workflows."

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/styles/helm-machines.css
+++ b/src/styles/helm-machines.css
@@ -1,9 +1,23 @@
 .helm-machines {
+  position: fixed;
+  top: 10%;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 9500;
+  width: 560px;
+  max-width: calc(100vw - 40px);
+  max-height: 80vh;
+  overflow: auto;
   display: flex;
   flex-direction: column;
   gap: 16px;
-  padding: 16px;
-  min-width: 520px;
+  padding: 20px;
+  background-color: var(--bg-surface, #181818);
+  border: 1px solid var(--border, #2a2a2a);
+  border-radius: 8px;
+  box-shadow:
+    0 24px 64px rgba(0, 0, 0, 0.6),
+    0 0 0 1px rgba(255, 255, 255, 0.04);
 }
 
 .helm-machines__header {


### PR DESCRIPTION
## Bug

In v0.2.0, opening the Helm Machines panel and clicking on the **Base URL** or **Bearer token** inputs causes the dialog to close. Only the Label input accepts text. Reported in smoke testing.

## Root cause

\`src/components/ui/dialog.tsx\` deliberately does **not** position its content — it expects each consuming panel to set its own \`position: fixed\` etc. (compare any other Dialog panel like \`src/styles/command-bookmarks.css\`):

> \`\`\`
> /**
>  * DialogContent — renders via portal with an overlay behind it.
>  * Does NOT impose its own positioning so each panel's existing CSS
>  * (position: fixed; top: X%; left: 50%; transform: translateX(-50%))
>  * continues to work unchanged.
>  */
> \`\`\`

\`.helm-machines\` (added in #443) didn't follow that pattern — no \`position\`, no \`z-index\`. The panel rendered in the document flow at \`(0, 0)\` underneath the Radix overlay (\`z-index: 9400\`). The Label input happened to sit inside the visible panel rect; the Base URL and Token inputs overflowed into territory that was actually the overlay → \`onPointerDownOutside\` → dialog closes.

## Fix

Add the same fixed-position dialog pattern other panels already use: centered horizontally, 10% from top, \`z-index: 9500\`, surface background, drop shadow. Width capped at 560px with \`max-width: calc(100vw - 40px)\` so it stays usable on narrow windows.

## Version

Bumps to 0.2.1 so we can cut a hotfix release without re-tagging v0.2.0.

## Test plan

- [x] \`cargo check\` clean
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm format:check\` clean
- [x] \`pnpm build\` clean
- [ ] CI green
- [ ] DMG built; user can type into all three input fields without the panel closing