### PR TITLE
feat: auto-register local helm-daemon on app start (Phase 1.5a)

### DIFF
--- a/src-tauri/src/helm/mod.rs
+++ b/src-tauri/src/helm/mod.rs
@@ -12,7 +12,10 @@
 use crate::db::queries::{self, HelmMachineRow};
 use crate::db::AppDb;
 use keyring::Entry;
+use regex::Regex;
 use serde::Serialize;
+use std::path::PathBuf;
+use std::time::Duration;
 use tauri::State;
 
 const KEYRING_SERVICE: &str = "com.workroot.app";
@@ -169,8 +172,80 @@ pub fn touch_helm_machine_seen(db: State<'_, AppDb>, id: i64) -> Result<(), Stri
 }
 
 fn normalize_base_url(raw: &str) -> String {
-    let trimmed = raw.trim().trim_end_matches('/').to_string();
-    trimmed
+    raw.trim().trim_end_matches('/').to_string()
+}
+
+const HELM_DEFAULT_PORT: u16 = 8421;
+const LOCAL_PROBE_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// Find ~/.config/helm/config.toml, extract `port = N` if present.
+/// Returns None if the file isn't there (helm probably isn't installed).
+async fn read_local_helm_port() -> Option<u16> {
+    let home = std::env::var_os("HOME")?;
+    let path = PathBuf::from(home).join(".config/helm/config.toml");
+    let content = tokio::fs::read_to_string(&path).await.ok()?;
+    // Match `port = 1234` at line start; ignore comments / inline values.
+    let re = Regex::new(r"(?m)^\s*port\s*=\s*(\d+)").ok()?;
+    re.captures(&content)
+        .and_then(|c| c.get(1))
+        .and_then(|m| m.as_str().parse::<u16>().ok())
+}
+
+/// On app boot, look for a local helm-daemon and register it as a
+/// machine row if it isn't already there. Silent on failure — no
+/// dialogs, no panics; if helm isn't installed or isn't running we
+/// just don't add anything.
+pub async fn try_register_local_daemon(db: AppDb) {
+    let port = read_local_helm_port().await.unwrap_or(HELM_DEFAULT_PORT);
+    let base_url = format!("http://localhost:{}", port);
+
+    // Bail early if a row with this base_url already exists. Doing
+    // this before the network probe keeps us idempotent across app
+    // restarts even when the daemon is up.
+    let already = {
+        let Ok(conn) = db.0.lock() else {
+            return;
+        };
+        match queries::list_helm_machines(&conn) {
+            Ok(rows) => rows.iter().any(|r| r.base_url == base_url),
+            Err(_) => return,
+        }
+    };
+    if already {
+        return;
+    }
+
+    let Ok(client) = reqwest::Client::builder()
+        .timeout(LOCAL_PROBE_TIMEOUT)
+        .build()
+    else {
+        return;
+    };
+
+    let url = format!("{}/v1/health", base_url);
+    let Ok(resp) = client.get(&url).send().await else {
+        return;
+    };
+    if !resp.status().is_success() {
+        return;
+    }
+    let Ok(health): Result<serde_json::Value, _> = resp.json().await else {
+        return;
+    };
+    let label = health
+        .get("machine_name")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| "Local helm".to_string());
+
+    let Ok(conn) = db.0.lock() else {
+        return;
+    };
+    let _ = queries::insert_helm_machine(&conn, &label, &base_url);
+    eprintln!(
+        "[helm] auto-registered local daemon at {} as \"{}\"",
+        base_url, label
+    );
 }
 
 #[cfg(test)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -350,6 +350,7 @@ pub fn run() {
         .setup(|app| {
             let app_handle = app.handle().clone();
             let db = init_db(&app_handle)?;
+            let db_for_helm_probe = AppDb(std::sync::Arc::clone(&db.0));
             app.manage(db);
             app.manage(ProcessRegistry::new());
             app.manage(HttpClient::new());
@@ -359,6 +360,13 @@ pub fn run() {
             // Start CLAUDE.md watcher loop
             let watcher_handle = app.handle().clone();
             claudemd::watcher::start_watcher_loop(watcher_handle);
+
+            // Auto-register a local helm-daemon if one is running. Silent
+            // on failure — if helm isn't installed or the daemon isn't up
+            // we just don't add anything.
+            tauri::async_runtime::spawn(async move {
+                helm::try_register_local_daemon(db_for_helm_probe).await;
+            });
 
             // Start the MCP server on port 4444
             let mcp_handle = app.handle().clone();


### PR DESCRIPTION
## Summary

On launch, workroot now probes for a helm-daemon on localhost and registers it as a machine row automatically — closes the "I just installed Workroot, why don't I see my agents" gap surfaced during smoke-testing.

## How it works

1. \`src-tauri/src/helm/try_register_local_daemon\` is spawned from \`setup()\` as a background task (so the 3s probe doesn't block the splash screen).
2. Reads \`~/.config/helm/config.toml\` if present and extracts \`port = N\` with a regex; falls back to the default 8421 when the config is absent or doesn't set a port.
3. \`GET http://localhost:<port>/v1/health\` with a 3s timeout via the existing \`reqwest\` dep.
4. If it 200s and returns a JSON body, uses \`machine_name\` from the response as the row label (falls back to \`"Local helm"\`).
5. Inserts a new \`helm_machines\` row.

## Idempotence

The probe bails *before* the network call if a row with the same base URL already exists. So:

- App boot → daemon up → row added.
- App restart while daemon still up → no-op (row already there).
- User removes the row, restarts the app → row gets re-added on the next launch. That's the trade-off; the alternative ("never auto-add to a machine the user removed") would need a "snoozed" flag and feels like over-engineering for v1.

## Failure modes — all silent

- No \`HOME\` env var → fall through to default port.
- Config file absent / unreadable → default port.
- Connection refused → no row added.
- Non-2xx response → no row added.
- JSON shape unexpected → row still added with fallback label.

A single line goes to stderr on success: \`[helm] auto-registered local daemon at http://localhost:8421 as "home-mac"\`.

## Out of scope (PR 1.5b will handle)

- Tailscale peer discovery for non-local machines.

## Test plan

- [x] \`cargo check\` clean
- [x] \`cargo clippy -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo test --lib helm\` (5/5 pass)
- [ ] CI green
- [ ] Manual: launch with helm-daemon running locally → row auto-appears; relaunch → no duplicates