### PR TITLE
feat: discover helm-daemons on the tailnet (Phase 1.5b)

### DIFF
--- a/src-tauri/src/helm/mod.rs
+++ b/src-tauri/src/helm/mod.rs
@@ -15,6 +15,7 @@ use keyring::Entry;
 use regex::Regex;
 use serde::Serialize;
 use std::path::PathBuf;
+use std::process::Command;
 use std::time::Duration;
 use tauri::State;
 
@@ -169,6 +170,157 @@ pub fn touch_helm_machine_seen(db: State<'_, AppDb>, id: i64) -> Result<(), Stri
     queries::touch_helm_machine_last_seen(&conn, id)
         .map_err(|e| format!("Touch helm machine: {}", e))?;
     Ok(())
+}
+
+/// One peer that responded to /v1/health. Sent to the frontend so the
+/// user can pick which to add.
+#[derive(Debug, Serialize)]
+pub struct DiscoveredHelm {
+    /// Display name (typically the tailnet HostName).
+    pub hostname: String,
+    /// Full base URL we'd register, e.g. http://peer.tailxxx.ts.net:8421.
+    pub base_url: String,
+    /// machine_name from the daemon's /v1/health response.
+    pub machine_name: String,
+    /// Daemon version string.
+    pub version: String,
+    /// True if a row with this base_url is already in helm_machines.
+    pub already_registered: bool,
+}
+
+const TAILSCALE_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Run `tailscale status --json` against whatever `tailscale` is on
+/// PATH. Falls back to launching it through the user's login shell so
+/// GUI apps on macOS pick up Homebrew installs (matches the pattern
+/// in github/auth.rs::run_in_login_shell).
+fn run_tailscale_status_json() -> Option<String> {
+    if let Ok(out) = Command::new("tailscale")
+        .args(["status", "--json"])
+        .output()
+    {
+        if out.status.success() {
+            return Some(String::from_utf8_lossy(&out.stdout).into_owned());
+        }
+    }
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
+    let out = Command::new(&shell)
+        .args(["-l", "-c", "tailscale status --json"])
+        .output()
+        .ok()?;
+    if out.status.success() {
+        Some(String::from_utf8_lossy(&out.stdout).into_owned())
+    } else {
+        None
+    }
+}
+
+#[tauri::command]
+pub async fn discover_helm_via_tailscale(
+    db: State<'_, AppDb>,
+) -> Result<Vec<DiscoveredHelm>, String> {
+    let raw = run_tailscale_status_json().ok_or_else(|| {
+        "Tailscale CLI not found. If you use the Mac App Store version, click the Tailscale menu-bar icon and choose \"Install CLI\". Otherwise install with `brew install tailscale`."
+            .to_string()
+    })?;
+    let parsed: serde_json::Value = serde_json::from_str(&raw)
+        .map_err(|e| format!("Couldn't parse `tailscale status --json` output: {}", e))?;
+
+    let peers = parsed
+        .get("Peer")
+        .and_then(|v| v.as_object())
+        .ok_or_else(|| "Tailscale status JSON missing the `Peer` field".to_string())?;
+
+    // Build (display_name, base_url) candidates for each online peer.
+    // Prefer the FQDN from DNSName (always resolves on a tailnet);
+    // fall back to HostName for setups without MagicDNS.
+    let mut candidates: Vec<(String, String)> = Vec::new();
+    for peer in peers.values() {
+        if !peer
+            .get("Online")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+        {
+            continue;
+        }
+        let host = peer
+            .get("HostName")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let dns = peer
+            .get("DNSName")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .trim_end_matches('.')
+            .to_string();
+        let target = if !dns.is_empty() {
+            dns.clone()
+        } else if !host.is_empty() {
+            host.clone()
+        } else {
+            continue;
+        };
+        let display = if !host.is_empty() {
+            host
+        } else {
+            target.clone()
+        };
+        candidates.push((display, format!("http://{}:{}", target, HELM_DEFAULT_PORT)));
+    }
+
+    // Snapshot the existing rows once for dedup checks; release the
+    // lock before kicking off async probes.
+    let existing: Vec<String> = {
+        let conn = db.0.lock().map_err(|e| format!("DB lock: {}", e))?;
+        queries::list_helm_machines(&conn)
+            .map_err(|e| format!("List helm machines: {}", e))?
+            .into_iter()
+            .map(|r| r.base_url)
+            .collect()
+    };
+
+    let client = reqwest::Client::builder()
+        .timeout(TAILSCALE_PROBE_TIMEOUT)
+        .build()
+        .map_err(|e| format!("HTTP client: {}", e))?;
+
+    let mut set = tokio::task::JoinSet::new();
+    for (host, url) in candidates {
+        let client = client.clone();
+        let registered = existing.iter().any(|e| e == &url);
+        set.spawn(async move {
+            let resp = client.get(format!("{}/v1/health", url)).send().await.ok()?;
+            if !resp.status().is_success() {
+                return None;
+            }
+            let health: serde_json::Value = resp.json().await.ok()?;
+            Some(DiscoveredHelm {
+                hostname: host,
+                base_url: url,
+                machine_name: health
+                    .get("machine_name")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+                version: health
+                    .get("version")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+                already_registered: registered,
+            })
+        });
+    }
+
+    let mut results: Vec<DiscoveredHelm> = Vec::new();
+    while let Some(joined) = set.join_next().await {
+        if let Ok(Some(d)) = joined {
+            results.push(d);
+        }
+    }
+    results.sort_by(|a, b| a.hostname.cmp(&b.hostname));
+    Ok(results)
 }
 
 fn normalize_base_url(raw: &str) -> String {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -168,6 +168,7 @@ pub fn run() {
             helm::update_helm_machine,
             helm::remove_helm_machine,
             helm::touch_helm_machine_seen,
+            helm::discover_helm_via_tailscale,
             claudemd::generate_worktree_claude_md,
             claudemd::read_worktree_claude_md,
             shell::install_shell_hook,

--- a/src/components/HelmMachinesPanel.tsx
+++ b/src/components/HelmMachinesPanel.tsx
@@ -13,6 +13,14 @@ interface HelmMachine {
   api_token: string | null;
 }
 
+interface DiscoveredHelm {
+  hostname: string;
+  base_url: string;
+  machine_name: string;
+  version: string;
+  already_registered: boolean;
+}
+
 interface HelmMachinesPanelProps {
   onClose: () => void;
 }
@@ -36,6 +44,10 @@ export function HelmMachinesPanel({ onClose }: HelmMachinesPanelProps) {
   const [newBaseUrl, setNewBaseUrl] = useState("");
   const [newToken, setNewToken] = useState("");
   const [adding, setAdding] = useState(false);
+
+  const [discovered, setDiscovered] = useState<DiscoveredHelm[] | null>(null);
+  const [discovering, setDiscovering] = useState(false);
+  const [discoverError, setDiscoverError] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
     setLoading(true);
@@ -109,6 +121,49 @@ export function HelmMachinesPanel({ onClose }: HelmMachinesPanelProps) {
     [refresh],
   );
 
+  const discover = useCallback(async () => {
+    setDiscovering(true);
+    setDiscoverError(null);
+    try {
+      const list = await invoke<DiscoveredHelm[]>(
+        "discover_helm_via_tailscale",
+      );
+      setDiscovered(list);
+    } catch (e) {
+      setDiscoverError(String(e));
+      setDiscovered([]);
+    } finally {
+      setDiscovering(false);
+    }
+  }, []);
+
+  const addDiscovered = useCallback(
+    async (d: DiscoveredHelm) => {
+      try {
+        await invoke<HelmMachine>("add_helm_machine", {
+          label: d.machine_name || d.hostname,
+          baseUrl: d.base_url,
+          apiToken: null,
+        });
+        // Mark this discovery as registered so the list updates
+        // without a full re-discover.
+        setDiscovered((prev) =>
+          prev
+            ? prev.map((x) =>
+                x.base_url === d.base_url
+                  ? { ...x, already_registered: true }
+                  : x,
+              )
+            : prev,
+        );
+        await refresh();
+      } catch (e) {
+        setError(String(e));
+      }
+    },
+    [refresh],
+  );
+
   return (
     <Dialog
       open
@@ -132,7 +187,7 @@ export function HelmMachinesPanel({ onClose }: HelmMachinesPanelProps) {
             <p className="helm-machines__empty">Loading…</p>
           ) : machines.length === 0 ? (
             <p className="helm-machines__empty">
-              No machines yet. Add one below.
+              No machines yet. Add one below or discover via Tailscale.
             </p>
           ) : (
             machines.map((m) => (
@@ -169,6 +224,61 @@ export function HelmMachinesPanel({ onClose }: HelmMachinesPanelProps) {
               </div>
             ))
           )}
+        </div>
+
+        <div className="helm-machines__discover">
+          <div className="helm-machines__discover-header">
+            <span className="helm-machines__discover-title">
+              Discover via Tailscale
+            </span>
+            <button
+              className="helm-machines__btn"
+              onClick={() => void discover()}
+              disabled={discovering}
+            >
+              {discovering ? "Probing…" : "Discover"}
+            </button>
+          </div>
+          {discoverError && (
+            <p className="helm-machines__error">{discoverError}</p>
+          )}
+          {discovered !== null &&
+            !discoverError &&
+            (discovered.length === 0 ? (
+              <p className="helm-machines__empty">
+                No daemons answered on the tailnet.
+              </p>
+            ) : (
+              <div className="helm-machines__discover-list">
+                {discovered.map((d) => (
+                  <div key={d.base_url} className="helm-machines__discover-row">
+                    <div className="helm-machines__row-meta">
+                      <span className="helm-machines__row-label">
+                        {d.hostname}
+                      </span>
+                      <span className="helm-machines__row-url">
+                        {d.base_url}
+                      </span>
+                      <span className="helm-machines__row-status">
+                        {d.machine_name || "?"} {d.version && `· v${d.version}`}
+                      </span>
+                    </div>
+                    {d.already_registered ? (
+                      <span className="helm-machines__discover-added">
+                        Added
+                      </span>
+                    ) : (
+                      <button
+                        className="helm-machines__btn"
+                        onClick={() => void addDiscovered(d)}
+                      >
+                        Add
+                      </button>
+                    )}
+                  </div>
+                ))}
+              </div>
+            ))}
         </div>
 
         <div className="helm-machines__form">

--- a/src/styles/helm-machines.css
+++ b/src/styles/helm-machines.css
@@ -115,6 +115,52 @@
   border-color: var(--color-danger, #f87171);
 }
 
+.helm-machines__discover {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-top: 12px;
+  border-top: 1px solid var(--color-border, #2a2a2a);
+}
+
+.helm-machines__discover-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.helm-machines__discover-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-text, #e4e4e4);
+}
+
+.helm-machines__discover-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  max-height: 220px;
+  overflow: auto;
+}
+
+.helm-machines__discover-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 8px 12px;
+  padding: 8px 10px;
+  border: 1px dashed var(--color-border, #2a2a2a);
+  border-radius: 6px;
+  align-items: center;
+}
+
+.helm-machines__discover-added {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--color-text-secondary, #888);
+}
+
 .helm-machines__form {
   display: grid;
   grid-template-columns: 1fr 1fr;


### PR DESCRIPTION
## Summary

Adds an opt-in **Discover via Tailscale** button to the Helm Machines panel that finds and lists every other machine on the user's tailnet currently running helm-daemon.

Stacks on #449 (local auto-detect). Together they close the smoke-test feedback that asked "shouldn't workroot just find my machines automatically."

## Backend (\`src-tauri/src/helm/mod.rs\`)

- New \`discover_helm_via_tailscale\` Tauri command shells out to \`tailscale status --json\`. Tries the direct PATH first, falls back through the user's login shell so Homebrew installs resolve in GUI contexts (same trick \`github/auth.rs::run_in_login_shell\` uses).
- For every \`Online\` peer, builds candidate URL \`http://<DNSName>:8421\` — FQDN preferred so resolution works even without MagicDNS short-names; \`HostName\` fallback when \`DNSName\` is missing.
- Parallel-probes \`/v1/health\` on each candidate via \`reqwest\` with a 2s timeout, using \`tokio::task::JoinSet\` (no new deps).
- Returns rows with \`hostname\`, \`base_url\`, \`machine_name\`, \`version\`, and an \`already_registered\` flag computed against the existing \`helm_machines\` table.
- Friendly error when the CLI is missing, including instructions for the Mac App Store version (which needs the menubar "Install CLI" toggle).

## Frontend (\`HelmMachinesPanel.tsx\`)

- New "Discover via Tailscale" section between the existing list and the manual-add form. Probe button, inline error, result list with per-row **Add** / **Added** badge.
- Optimistic update on Add: flips the discovered row's \`already_registered\` to true immediately so the user gets feedback without re-probing.

## Why opt-in

Probing every tailnet peer's :8421 port automatically felt invasive — your tailnet contains machines that aren't yours. The flow is now:

1. **First run, local helm:** PR #449 auto-adds it. Zero clicks.
2. **Add cross-machine:** open Helm Machines → click "Discover" → pick the ones to add.

## Out of scope

- Per-machine bearer tokens at discovery time. Today the daemon doesn't enforce auth (per \`docs/daemon-api.md\`); when the Tailscale-User-Login check lands upstream we'll add a token field next to each discovered row.
- Auto-rediscovery on a timer.

## Test plan

- [x] \`cargo check\` clean
- [x] \`cargo clippy -D warnings\` clean
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm format:check\` clean
- [x] \`pnpm build\` clean
- [ ] CI green
- [ ] Manual: tailnet with multiple helm-daemons → Discover lists each, Add works, Already-Added badge shows for existing rows
- [ ] Manual: no tailscale CLI → friendly error message