### PR TITLE
chore: bump version to 0.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "workroot"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 authors = ["Saurav Panda <saurav@workroot.dev>"]
 description = "A local-first developer workspace for managing projects, terminals, and Git workflows."

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary

Cuts the second post-pivot release.

## What's in 0.2.2

- **#449 — Local helm-daemon auto-register.** On app start, workroot probes \`localhost:<port>\` for a helm-daemon and adds it to the machines registry if one is running. Reads \`~/.config/helm/config.toml\` for the port when present; falls back to 8421.
- **#450 — Tailscale peer discovery.** New "Discover via Tailscale" button in Helm Machines parallel-probes every online tailnet peer's \`:8421/v1/health\`; user one-click adds the responders.
- **#448 — Hotfix from 0.2.1.** Helm Machines panel now positions itself as a proper overlay so all three input fields stay clickable.

## Release process

1. Merge this PR
2. Push tag \`v0.2.2\` → \`.github/workflows/release.yml\` builds the Apple Silicon DMG
3. Approve build job if \`environment: main\` requires it
4. Auto-published — no draft step

## Test plan

- [x] \`cargo check\` clean
- [x] All four version sites updated
- [ ] CI green
- [ ] Tag pushed, DMG built