### PR TITLE
fix: route helm daemon HTTP through Rust to bypass CSP (v0.2.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "workroot"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 authors = ["Saurav Panda <saurav@workroot.dev>"]
 description = "A local-first developer workspace for managing projects, terminals, and Git workflows."
@@ -9,7 +9,7 @@ description = "A local-first developer workspace for managing projects, terminal
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = ["tray-icon"] }
+tauri = { version = "2", features = ["tray-icon", "devtools"] }
 tauri-plugin-shell = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src-tauri/src/helm/mod.rs
+++ b/src-tauri/src/helm/mod.rs
@@ -172,6 +172,85 @@ pub fn touch_helm_machine_seen(db: State<'_, AppDb>, id: i64) -> Result<(), Stri
     Ok(())
 }
 
+const PROXY_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Proxy a JSON request to a registered helm-daemon.
+///
+/// Workroot's WebView is locked to `default-src 'self'` so direct
+/// `fetch()` to a daemon URL is blocked by CSP. Instead, the React side
+/// hands the request to this Tauri command and we make it from Rust,
+/// where neither CSP nor CORS apply.
+///
+/// `body` is sent verbatim as the request body when present (callers
+/// pass a JSON-encoded string). The response body is parsed as JSON
+/// when the daemon returns 2xx and a JSON content type; otherwise the
+/// raw text is wrapped in `{"text": "..."}` so the React side can still
+/// surface it.
+#[tauri::command]
+pub async fn helm_proxy_request(
+    db: State<'_, AppDb>,
+    machine_id: i64,
+    method: String,
+    path: String,
+    body: Option<String>,
+) -> Result<serde_json::Value, String> {
+    if !path.starts_with('/') {
+        return Err(format!("Path must start with '/': {}", path));
+    }
+
+    let row = {
+        let conn = db.0.lock().map_err(|e| format!("DB lock: {}", e))?;
+        queries::get_helm_machine(&conn, machine_id)
+            .map_err(|e| format!("Get helm machine: {}", e))?
+            .ok_or_else(|| format!("No helm machine with id {}", machine_id))?
+    };
+    let token = read_token(machine_id)?;
+
+    let url = format!("{}{}", row.base_url, path);
+    let client = reqwest::Client::builder()
+        .timeout(PROXY_TIMEOUT)
+        .build()
+        .map_err(|e| format!("HTTP client: {}", e))?;
+
+    let mut req = match method.to_uppercase().as_str() {
+        "GET" => client.get(&url),
+        "POST" => client.post(&url),
+        "DELETE" => client.delete(&url),
+        "PUT" => client.put(&url),
+        other => return Err(format!("Unsupported method: {}", other)),
+    };
+    if let Some(t) = token {
+        req = req.bearer_auth(t);
+    }
+    if let Some(b) = body {
+        req = req.header("Content-Type", "application/json").body(b);
+    }
+
+    let resp = req
+        .send()
+        .await
+        .map_err(|e| format!("Daemon request failed: {}", e))?;
+    let status = resp.status();
+    let raw = resp
+        .text()
+        .await
+        .map_err(|e| format!("Read daemon response body: {}", e))?;
+
+    if !status.is_success() {
+        return Err(format!(
+            "Daemon returned {}: {}",
+            status,
+            raw.chars().take(400).collect::<String>()
+        ));
+    }
+
+    if raw.is_empty() {
+        return Ok(serde_json::Value::Null);
+    }
+    serde_json::from_str::<serde_json::Value>(&raw)
+        .or_else(|_| Ok(serde_json::json!({ "text": raw })))
+}
+
 /// One peer that responded to /v1/health. Sent to the frontend so the
 /// user can pick which to add.
 #[derive(Debug, Serialize)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -169,6 +169,7 @@ pub fn run() {
             helm::remove_helm_machine,
             helm::touch_helm_machine_seen,
             helm::discover_helm_via_tailscale,
+            helm::helm_proxy_request,
             claudemd::generate_worktree_claude_md,
             claudemd::read_worktree_claude_md,
             shell::install_shell_hook,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/lib/helm-api.ts
+++ b/src/lib/helm-api.ts
@@ -1,8 +1,10 @@
 // Daemon HTTP client. One instance per machine.
 //
-// Mirrors helm/app/lib/api.ts (the phone app's client). Workroot fetches
-// directly from React rather than proxying through Tauri commands —
-// helm's API is JSON over HTTP, no native plumbing needed.
+// Shape mirrors helm/app/lib/api.ts (the phone app's client). Calls go
+// through the `helm_proxy_request` Tauri command rather than `fetch()`
+// directly — workroot's WebView CSP locks `connect-src` to 'self', and
+// the daemon doesn't send CORS headers either, so a browser-side fetch
+// would be doubly blocked. Routing through Rust sidesteps both.
 
 // ---- shared types (kept in step with helm/shared/api-spec/types.ts) ----
 
@@ -114,88 +116,59 @@ export interface HelmMachine {
 
 // ---- client ----
 
-const HEALTH_TIMEOUT_MS = 5_000;
-const DEFAULT_TIMEOUT_MS = 15_000;
+import { invoke } from "@tauri-apps/api/core";
 
 export class DaemonClient {
-  constructor(
-    private readonly baseUrl: string,
-    private readonly token: string | null = null,
-  ) {}
-
-  private authHeader(): Record<string, string> {
-    return this.token ? { Authorization: `Bearer ${this.token}` } : {};
-  }
+  constructor(private readonly machineId: number) {}
 
   private async request<T>(
+    method: "GET" | "POST" | "DELETE" | "PUT",
     path: string,
-    init?: RequestInit,
-    timeoutMs: number = DEFAULT_TIMEOUT_MS,
+    body?: unknown,
   ): Promise<T> {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
-    try {
-      const res = await fetch(`${this.baseUrl}/v1${path}`, {
-        ...init,
-        signal: controller.signal,
-        headers: {
-          "Content-Type": "application/json",
-          ...this.authHeader(),
-          ...(init?.headers ?? {}),
-        },
-      });
-      if (!res.ok) {
-        throw new Error(`${res.status} ${res.statusText} on ${path}`);
-      }
-      return (await res.json()) as T;
-    } finally {
-      clearTimeout(timer);
-    }
+    return (await invoke<T>("helm_proxy_request", {
+      machineId: this.machineId,
+      method,
+      path: `/v1${path}`,
+      body: body === undefined ? null : JSON.stringify(body),
+    })) as T;
   }
 
   health(): Promise<Health> {
-    return this.request<Health>("/health", undefined, HEALTH_TIMEOUT_MS);
+    return this.request<Health>("GET", "/health");
   }
 
   agents(): Promise<{ agents: Agent[] }> {
-    return this.request<{ agents: Agent[] }>("/agents");
+    return this.request<{ agents: Agent[] }>("GET", "/agents");
   }
 
   agent(id: string): Promise<AgentDetail> {
-    return this.request<AgentDetail>(`/agents/${id}`);
+    return this.request<AgentDetail>("GET", `/agents/${id}`);
   }
 
   repos(): Promise<{ repos: Repo[] }> {
-    return this.request<{ repos: Repo[] }>("/repos");
+    return this.request<{ repos: Repo[] }>("GET", "/repos");
   }
 
   spawnAgent(body: NewAgentRequest): Promise<Agent> {
-    return this.request<Agent>("/agents", {
-      method: "POST",
-      body: JSON.stringify(body),
-    });
+    return this.request<Agent>("POST", "/agents", body);
   }
 
   replyAgent(id: string, message: string): Promise<{ ok: boolean }> {
-    return this.request<{ ok: boolean }>(`/agents/${id}/reply`, {
-      method: "POST",
-      body: JSON.stringify({ message }),
+    return this.request<{ ok: boolean }>("POST", `/agents/${id}/reply`, {
+      message,
     });
   }
 
   killAgent(id: string): Promise<{ ok: boolean }> {
-    return this.request<{ ok: boolean }>(`/agents/${id}/kill`, {
-      method: "POST",
-    });
+    return this.request<{ ok: boolean }>("POST", `/agents/${id}/kill`);
   }
 
   deleteAgent(id: string): Promise<{ ok: boolean }> {
-    return this.request<{ ok: boolean }>(`/agents/${id}`, {
-      method: "DELETE",
-    });
+    return this.request<{ ok: boolean }>("DELETE", `/agents/${id}`);
   }
 }
 
 export function clientFor(m: HelmMachine): DaemonClient {
-  return new DaemonClient(m.base_url, m.api_token);
+  return new DaemonClient(m.id);
 }


### PR DESCRIPTION
## Bug

Smoke testing v0.2.2 against two real Tailscale-connected helm-daemons: machines were registered (Discover worked), pills appeared in the agents view but **both red**, "No active agents" empty state.

## Root cause

\`tauri.conf.json:15\` ships:

\`\`\`
"csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'"
\`\`\`

\`connect-src\` falls back to \`default-src 'self'\` — so the WebView blocks every \`fetch()\` to non-Tauri origins. \`/v1/health\` worked during Tailscale Discover because that probe ran from Rust; the React-side \`fetch()\` for \`/v1/agents\` got blocked. helm-daemon also doesn't send CORS headers (built for React Native + CLI, neither of which goes through a browser), so even relaxing CSP wouldn't have been enough.

## Fix

**Route every daemon HTTP call through Rust.** New \`helm_proxy_request(machine_id, method, path, body)\` Tauri command runs the request via \`reqwest\` server-side, where neither CSP nor CORS apply.

- Token comes from the keyring on every call (token rotations pick up immediately).
- Non-2xx responses become a string error including a 400-char preview of the body so the UI surfaces the real failure mode.
- Non-JSON 2xx responses are wrapped as \`{ text: "..." }\` so the React side stays JSON-typed.

\`DaemonClient\` becomes a thin wrapper around \`invoke()\` — no \`fetch()\`, no \`AbortController\`, no Authorization assembly in JS. \`clientFor(m)\` now only stores the machine id; Rust re-reads the row + token on each call.

## Bonus: DevTools in release

Enabled the \`tauri/devtools\` Cargo feature so packaged builds let you open the inspector with **⌘ + ⌥ + I**. Will save us a v0.x.y cycle next time something fails silently.

## Version

Bumps to 0.2.3 so it ships as a hotfix release.

## Test plan

- [x] \`cargo check\` clean
- [x] \`cargo clippy -D warnings\` clean
- [x] \`cargo test --lib\` (163 pass, no behavior change)
- [x] \`pnpm typecheck\` / \`lint\` / \`format:check\` / \`build\` clean
- [ ] CI green
- [ ] After install: pills go green, agents list populates from both Tailscale machines