### PR TITLE
Detail pane: per-tool renderers + sticky-bottom auto-scroll (v0.2.4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "workroot"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 authors = ["Saurav Panda <saurav@workroot.dev>"]
 description = "A local-first developer workspace for managing projects, terminals, and Git workflows."

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/components/AgentDetailPane.tsx
+++ b/src/components/AgentDetailPane.tsx
@@ -1,4 +1,11 @@
-import { useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useAgentDetail } from "../hooks/useAgentDetail";
 import { clientFor, type ThreadEvent, type Turn } from "../lib/helm-api";
 import "../styles/agent-detail.css";
@@ -14,6 +21,33 @@ interface AgentDetailPaneProps {
 
 const TERMINAL_STATES = new Set(["done", "failed"]);
 
+// How many lines to keep visible from a long stdout/result before truncating.
+// We show the first half + last half, joined by an ellipsis row.
+const RESULT_PREVIEW_LINES = 14;
+
+// Distance from the bottom (px) within which we still consider the user
+// "at the bottom." Slack uses ~24; matches visual intuition.
+const STICKY_THRESHOLD_PX = 24;
+
+type ToolUseEv = Extract<ThreadEvent, { kind: "tool_use" }>;
+type ToolResultEv = Extract<ThreadEvent, { kind: "tool_result" }>;
+
+type RenderItem =
+  | {
+      type: "message";
+      key: string;
+      role: "user" | "assistant" | "thinking";
+      text: string;
+      at: string;
+    }
+  | {
+      type: "tool";
+      key: string;
+      toolUse: ToolUseEv;
+      toolResult: ToolResultEv | null;
+    }
+  | { type: "turn"; key: string; turn: Turn };
+
 function formatCost(usd: number): string {
   return `$${usd.toFixed(4)}`;
 }
@@ -24,69 +58,284 @@ function formatTokens(n: number): string {
   return n.toString();
 }
 
-function ThreadEventRow({ ev }: { ev: ThreadEvent }) {
-  switch (ev.kind) {
-    case "user":
-      return (
-        <div className="agent-detail__event agent-detail__event--user">
-          <span className="agent-detail__event-label">User</span>
-          {ev.text}
-        </div>
-      );
-    case "assistant":
-      return (
-        <div className="agent-detail__event agent-detail__event--assistant">
-          <span className="agent-detail__event-label">Assistant</span>
-          {ev.text}
-        </div>
-      );
-    case "thinking":
-      return (
-        <div className="agent-detail__event agent-detail__event--thinking">
-          {ev.text}
-        </div>
-      );
-    case "tool_use":
-      return (
-        <div className="agent-detail__event agent-detail__event--tool_use">
-          <span className="agent-detail__event-label">
-            tool: {ev.tool} — {ev.title}
-          </span>
-          {ev.input}
-        </div>
-      );
-    case "tool_result":
-      return (
-        <div
-          className={
-            ev.is_error
-              ? "agent-detail__event agent-detail__event--tool_result is-error"
-              : "agent-detail__event agent-detail__event--tool_result"
-          }
-        >
-          <span className="agent-detail__event-label">
-            result{ev.is_error ? " (error)" : ""}
-          </span>
-          {ev.preview}
-        </div>
-      );
+function safeJsonParse(s: string): unknown {
+  if (!s) return null;
+  try {
+    return JSON.parse(s);
+  } catch {
+    return null;
   }
 }
 
-function TurnRow({ turn }: { turn: Turn }) {
+function asRecord(v: unknown): Record<string, unknown> | null {
+  return v && typeof v === "object" && !Array.isArray(v)
+    ? (v as Record<string, unknown>)
+    : null;
+}
+
+function asString(v: unknown): string {
+  return typeof v === "string" ? v : "";
+}
+
+function prettyJson(s: string): string {
+  const parsed = safeJsonParse(s);
+  if (parsed === null) return s;
+  try {
+    return JSON.stringify(parsed, null, 2);
+  } catch {
+    return s;
+  }
+}
+
+function buildItems(detail: {
+  thread_events?: ThreadEvent[];
+  turns: Turn[];
+}): RenderItem[] {
+  const events = detail.thread_events ?? [];
+  if (events.length === 0) {
+    return detail.turns.map((t, i) => ({
+      type: "turn",
+      key: `turn:${i}:${t.at}`,
+      turn: t,
+    }));
+  }
+
+  // Index results by their tool_use_id so the renderer can pair them.
+  const resultById = new Map<string, ToolResultEv>();
+  for (const e of events) {
+    if (e.kind === "tool_result") resultById.set(e.tool_use_id, e);
+  }
+
+  const items: RenderItem[] = [];
+  for (const e of events) {
+    if (e.kind === "tool_result") continue; // emitted alongside its tool_use
+    if (e.kind === "tool_use") {
+      items.push({
+        type: "tool",
+        key: `tool:${e.id}`,
+        toolUse: e,
+        toolResult: resultById.get(e.id) ?? null,
+      });
+    } else {
+      items.push({
+        type: "message",
+        key: `${e.kind}:${e.at}`,
+        role: e.kind,
+        text: e.text,
+        at: e.at,
+      });
+    }
+  }
+  return items;
+}
+
+// One-line summary for a tool call, derived from the tool name + parsed args.
+// The point is intent over arguments — the args live behind the chevron.
+function toolSummary(t: ToolUseEv): { kind: string; summary: string } {
+  const args = asRecord(safeJsonParse(t.input)) ?? {};
+  const name = t.tool;
+  const lower = name.toLowerCase();
+
+  if (lower === "bash" || lower.includes("shell")) {
+    const cmd = asString(args.command);
+    return { kind: "bash", summary: cmd ? `$ ${cmd}` : "$" };
+  }
+  if (lower === "read") {
+    const fp = asString(args.file_path) || asString(args.path);
+    const offset = typeof args.offset === "number" ? args.offset : null;
+    const limit = typeof args.limit === "number" ? args.limit : null;
+    const range =
+      offset != null && limit != null
+        ? ` (lines ${offset}–${offset + limit})`
+        : "";
+    return { kind: "read", summary: `${fp}${range}` };
+  }
+  if (lower === "write") {
+    const fp = asString(args.file_path) || asString(args.path);
+    return { kind: "write", summary: fp };
+  }
+  if (lower === "edit") {
+    const fp = asString(args.file_path) || asString(args.path);
+    return { kind: "edit", summary: fp };
+  }
+  if (lower === "grep") {
+    const pat = asString(args.pattern);
+    const path = asString(args.path);
+    return {
+      kind: "grep",
+      summary: path ? `"${pat}" in ${path}` : `"${pat}"`,
+    };
+  }
+  if (lower === "glob") {
+    const pat = asString(args.pattern);
+    return { kind: "glob", summary: pat };
+  }
+  if (lower === "webfetch" || lower === "web_fetch") {
+    return { kind: "web", summary: asString(args.url) };
+  }
+  if (lower === "websearch" || lower === "web_search") {
+    return { kind: "web", summary: asString(args.query) };
+  }
+  if (lower.startsWith("mcp__") || lower.includes(":")) {
+    return { kind: "mcp", summary: t.title || lower };
+  }
+  return { kind: "generic", summary: t.title || name };
+}
+
+// Trim a long result body for the collapsed view: keep the first half and
+// last half, drop the middle behind a "… N lines hidden" marker. Returns
+// the trimmed text and how many lines were hidden.
+function trimResult(
+  text: string,
+  maxLines: number,
+): { display: string; hiddenCount: number } {
+  const lines = text.split("\n");
+  if (lines.length <= maxLines) {
+    return { display: text, hiddenCount: 0 };
+  }
+  const half = Math.floor(maxLines / 2);
+  const head = lines.slice(0, half);
+  const tail = lines.slice(lines.length - half);
+  const hidden = lines.length - head.length - tail.length;
+  const display = [...head, `… ${hidden} lines hidden …`, ...tail].join("\n");
+  return { display, hiddenCount: hidden };
+}
+
+// ----- subcomponents -----
+
+function MessageItem({
+  role,
+  text,
+  expanded,
+  onToggle,
+}: {
+  role: "user" | "assistant" | "thinking";
+  text: string;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  if (role === "thinking") {
+    const wordCount = text.trim().split(/\s+/).filter(Boolean).length;
+    return (
+      <div className="agent-detail__msg agent-detail__msg--thinking">
+        <button
+          type="button"
+          className="agent-detail__msg-toggle"
+          onClick={onToggle}
+          aria-expanded={expanded}
+        >
+          <span className="agent-detail__chevron">{expanded ? "▾" : "▸"}</span>
+          thinking ({wordCount} words)
+        </button>
+        {expanded && <div className="agent-detail__msg-body">{text}</div>}
+      </div>
+    );
+  }
+  return (
+    <div
+      className={
+        role === "user"
+          ? "agent-detail__msg agent-detail__msg--user"
+          : "agent-detail__msg agent-detail__msg--assistant"
+      }
+    >
+      <span className="agent-detail__msg-label">
+        {role === "user" ? "You" : "Assistant"}
+      </span>
+      <div className="agent-detail__msg-body">{text}</div>
+    </div>
+  );
+}
+
+function ToolItem({
+  toolUse,
+  toolResult,
+  expanded,
+  onToggle,
+}: {
+  toolUse: ToolUseEv;
+  toolResult: ToolResultEv | null;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  const { kind, summary } = useMemo(() => toolSummary(toolUse), [toolUse]);
+  const hasError = toolResult?.is_error === true;
+  const trimmed = useMemo(
+    () =>
+      toolResult
+        ? trimResult(toolResult.preview, RESULT_PREVIEW_LINES)
+        : { display: "", hiddenCount: 0 },
+    [toolResult],
+  );
+
+  const wrapClass = [
+    "agent-detail__tool",
+    `agent-detail__tool--${kind}`,
+    hasError ? "is-error" : "",
+    !toolResult ? "is-pending" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div className={wrapClass}>
+      <button
+        type="button"
+        className="agent-detail__tool-head"
+        onClick={onToggle}
+        aria-expanded={expanded}
+      >
+        <span className="agent-detail__chevron">{expanded ? "▾" : "▸"}</span>
+        <span className="agent-detail__tool-name">{toolUse.tool}</span>
+        <span className="agent-detail__tool-summary">{summary}</span>
+        {!toolResult && (
+          <span className="agent-detail__tool-pending">running…</span>
+        )}
+        {hasError && <span className="agent-detail__tool-err-tag">error</span>}
+      </button>
+
+      {expanded && (
+        <div className="agent-detail__tool-args">
+          <pre>{prettyJson(toolUse.input)}</pre>
+        </div>
+      )}
+
+      {toolResult && (
+        <div className="agent-detail__tool-result">
+          <pre>{expanded ? toolResult.preview : trimmed.display}</pre>
+          {!expanded && trimmed.hiddenCount > 0 && (
+            <button
+              type="button"
+              className="agent-detail__tool-show-all"
+              onClick={onToggle}
+            >
+              show all ({trimmed.hiddenCount} more lines)
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TurnItem({ turn }: { turn: Turn }) {
   return (
     <div
       className={
         turn.role === "user"
-          ? "agent-detail__event agent-detail__event--user"
-          : "agent-detail__event agent-detail__event--assistant"
+          ? "agent-detail__msg agent-detail__msg--user"
+          : "agent-detail__msg agent-detail__msg--assistant"
       }
     >
-      <span className="agent-detail__event-label">{turn.role}</span>
-      {turn.content}
+      <span className="agent-detail__msg-label">
+        {turn.role === "user" ? "You" : "Assistant"}
+      </span>
+      <div className="agent-detail__msg-body">{turn.content}</div>
     </div>
   );
 }
+
+// ----- main component -----
 
 export function AgentDetailPane({
   machineId,
@@ -101,6 +350,110 @@ export function AgentDetailPane({
   const [reply, setReply] = useState("");
   const [busy, setBusy] = useState<"reply" | "kill" | "delete" | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
+
+  // Per-item expansion state. Keyed by the stable RenderItem.key so a 3 s
+  // poll re-render doesn't wipe what the user has open.
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
+  const toggleExpanded = useCallback((key: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
+
+  const items = useMemo<RenderItem[]>(
+    () => (detail ? buildItems(detail) : []),
+    [detail],
+  );
+
+  // ---- auto-scroll plumbing ----
+  // The events container scrolls; the rest of the pane is fixed. We follow
+  // the Slack/iMessage pattern: only auto-scroll when the user is already
+  // at the bottom; otherwise count "unseen" items and surface a pill.
+  const eventsRef = useRef<HTMLDivElement>(null);
+  const userAtBottomRef = useRef(true);
+  // Fingerprint = item.key + (for tool pairs) whether the result has arrived,
+  // so a tool that finishes is treated as a *new* signal even though its key
+  // didn't change.
+  const seenFingerprintsRef = useRef<Set<string>>(new Set());
+  const [unseen, setUnseen] = useState(0);
+
+  const fingerprint = useCallback((it: RenderItem): string => {
+    if (it.type === "tool") {
+      return `${it.key}|${it.toolResult ? "res" : "pend"}`;
+    }
+    return it.key;
+  }, []);
+
+  const markAllSeen = useCallback(() => {
+    const set = seenFingerprintsRef.current;
+    for (const it of items) set.add(fingerprint(it));
+    setUnseen(0);
+  }, [items, fingerprint]);
+
+  const scrollToBottom = useCallback(() => {
+    const el = eventsRef.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+    userAtBottomRef.current = true;
+    markAllSeen();
+  }, [markAllSeen]);
+
+  const onEventsScroll = useCallback(() => {
+    const el = eventsRef.current;
+    if (!el) return;
+    const atBottom =
+      el.scrollHeight - el.scrollTop - el.clientHeight < STICKY_THRESHOLD_PX;
+    userAtBottomRef.current = atBottom;
+    if (atBottom && unseen !== 0) markAllSeen();
+  }, [unseen, markAllSeen]);
+
+  // Reset everything when the user picks a different agent.
+  useEffect(() => {
+    seenFingerprintsRef.current = new Set();
+    userAtBottomRef.current = true;
+    setUnseen(0);
+    setExpanded(new Set());
+  }, [machineId, agentId]);
+
+  // After every render that changes items: scroll if at bottom, else count
+  // the new ones into `unseen`. Runs in useLayoutEffect so we measure the
+  // post-DOM scrollHeight before paint.
+  useLayoutEffect(() => {
+    if (items.length === 0) return;
+    const el = eventsRef.current;
+    if (!el) return;
+
+    const seen = seenFingerprintsRef.current;
+    const isFirstPaint = seen.size === 0;
+
+    if (isFirstPaint) {
+      // Initial render of a freshly selected agent — jump to bottom and
+      // mark everything seen.
+      el.scrollTop = el.scrollHeight;
+      for (const it of items) seen.add(fingerprint(it));
+      userAtBottomRef.current = true;
+      return;
+    }
+
+    if (userAtBottomRef.current) {
+      el.scrollTop = el.scrollHeight;
+      for (const it of items) seen.add(fingerprint(it));
+      if (unseen !== 0) setUnseen(0);
+      return;
+    }
+
+    let added = 0;
+    for (const it of items) {
+      if (!seen.has(fingerprint(it))) added += 1;
+    }
+    if (added !== unseen) setUnseen(added);
+    // Don't add to `seen` here — these are the ones the pill is counting.
+    // They'll get marked seen when the user scrolls back to bottom or
+    // clicks the pill.
+  }, [items, fingerprint, unseen]);
 
   if (machineId === null || agentId === null) {
     return (
@@ -163,6 +516,7 @@ export function AgentDetailPane({
 
   const isTerminal = detail ? TERMINAL_STATES.has(detail.state) : false;
   const canReply = !!detail && detail.backend === "claude" && !isTerminal;
+  const hasTranscript = items.length > 0;
 
   return (
     <aside className="agent-detail">
@@ -218,95 +572,125 @@ export function AgentDetailPane({
       </div>
 
       {actionError && <p className="agent-detail__error">{actionError}</p>}
-
       {error && <p className="agent-detail__error">{error}</p>}
 
-      {loading && !detail ? (
-        <p className="agent-detail__loading">Loading…</p>
-      ) : detail ? (
-        <>
-          {detail.pending_question && (
-            <div className="agent-detail__pending">
-              <span className="agent-detail__pending-label">
-                Pending question
-              </span>
-              {detail.pending_question}
-            </div>
-          )}
+      {detail?.pending_question && (
+        <div className="agent-detail__pending">
+          <span className="agent-detail__pending-label">Pending question</span>
+          {detail.pending_question}
+        </div>
+      )}
 
-          {detail.pr_url && (
-            <a
-              className="agent-detail__pr"
-              href={detail.pr_url}
-              target="_blank"
-              rel="noreferrer"
+      {detail?.pr_url && (
+        <a
+          className="agent-detail__pr"
+          href={detail.pr_url}
+          target="_blank"
+          rel="noreferrer"
+        >
+          {detail.pr_url}
+        </a>
+      )}
+
+      <div className="agent-detail__events-wrap">
+        <div
+          className="agent-detail__events"
+          ref={eventsRef}
+          onScroll={onEventsScroll}
+        >
+          {loading && !detail ? (
+            <p className="agent-detail__loading">Loading…</p>
+          ) : !hasTranscript && detail ? (
+            <p className="agent-detail__empty">
+              No transcript yet — agent hasn't produced output.
+            </p>
+          ) : (
+            items.map((it) => {
+              if (it.type === "turn") {
+                return <TurnItem key={it.key} turn={it.turn} />;
+              }
+              if (it.type === "message") {
+                return (
+                  <MessageItem
+                    key={it.key}
+                    role={it.role}
+                    text={it.text}
+                    expanded={expanded.has(it.key)}
+                    onToggle={() => toggleExpanded(it.key)}
+                  />
+                );
+              }
+              return (
+                <ToolItem
+                  key={it.key}
+                  toolUse={it.toolUse}
+                  toolResult={it.toolResult}
+                  expanded={expanded.has(it.key)}
+                  onToggle={() => toggleExpanded(it.key)}
+                />
+              );
+            })
+          )}
+        </div>
+
+        {unseen > 0 && (
+          <button
+            type="button"
+            className="agent-detail__new-pill"
+            onClick={scrollToBottom}
+            aria-label={`Scroll to ${unseen} new events`}
+          >
+            ↓ {unseen} new
+          </button>
+        )}
+      </div>
+
+      {detail?.usage && (
+        <div className="agent-detail__usage">
+          <span>
+            in {formatTokens(detail.usage.input_tokens)} · out{" "}
+            {formatTokens(detail.usage.output_tokens)}
+          </span>
+          <span>
+            cache w {formatTokens(detail.usage.cache_write_tokens)} · r{" "}
+            {formatTokens(detail.usage.cache_read_tokens)}
+          </span>
+          <span>{formatCost(detail.usage.cost_usd)}</span>
+        </div>
+      )}
+
+      {canReply && (
+        <div className="agent-detail__reply">
+          <textarea
+            value={reply}
+            onChange={(e) => setReply(e.target.value)}
+            onKeyDown={(e) => {
+              if (
+                (e.metaKey || e.ctrlKey) &&
+                e.key === "Enter" &&
+                reply.trim()
+              ) {
+                e.preventDefault();
+                void sendReply();
+              }
+            }}
+            placeholder="Reply to the agent…"
+            disabled={busy !== null}
+          />
+          <div className="agent-detail__reply-row">
+            <span className="agent-detail__reply-hint">
+              ⌘/Ctrl + Enter to send
+            </span>
+            <button
+              className="agent-detail__action-btn"
+              onClick={() => void sendReply()}
+              disabled={!reply.trim() || busy !== null}
             >
-              {detail.pr_url}
-            </a>
-          )}
-
-          <div className="agent-detail__events">
-            {detail.thread_events && detail.thread_events.length > 0
-              ? detail.thread_events.map((ev, i) => (
-                  <ThreadEventRow key={i} ev={ev} />
-                ))
-              : detail.turns.map((t, i) => <TurnRow key={i} turn={t} />)}
-            {(!detail.thread_events || detail.thread_events.length === 0) &&
-              detail.turns.length === 0 && (
-                <p className="agent-detail__empty">
-                  No transcript yet — agent hasn't produced output.
-                </p>
-              )}
+              {busy === "reply" ? "Sending…" : "Send"}
+            </button>
           </div>
-
-          {detail.usage && (
-            <div className="agent-detail__usage">
-              <span>
-                in {formatTokens(detail.usage.input_tokens)} · out{" "}
-                {formatTokens(detail.usage.output_tokens)}
-              </span>
-              <span>
-                cache w {formatTokens(detail.usage.cache_write_tokens)} · r{" "}
-                {formatTokens(detail.usage.cache_read_tokens)}
-              </span>
-              <span>{formatCost(detail.usage.cost_usd)}</span>
-            </div>
-          )}
-
-          {canReply && (
-            <div className="agent-detail__reply">
-              <textarea
-                value={reply}
-                onChange={(e) => setReply(e.target.value)}
-                onKeyDown={(e) => {
-                  if (
-                    (e.metaKey || e.ctrlKey) &&
-                    e.key === "Enter" &&
-                    reply.trim()
-                  ) {
-                    e.preventDefault();
-                    void sendReply();
-                  }
-                }}
-                placeholder="Reply to the agent…"
-                disabled={busy !== null}
-              />
-              <div className="agent-detail__reply-row">
-                <span className="agent-detail__reply-hint">
-                  ⌘/Ctrl + Enter to send
-                </span>
-                <button
-                  className="agent-detail__action-btn"
-                  onClick={() => void sendReply()}
-                  disabled={!reply.trim() || busy !== null}
-                >
-                  {busy === "reply" ? "Sending…" : "Send"}
-                </button>
-              </div>
-            </div>
-          )}
-        </>
-      ) : null}
+        </div>
+      )}
     </aside>
   );
 }

--- a/src/styles/agent-detail.css
+++ b/src/styles/agent-detail.css
@@ -1,10 +1,13 @@
+/* The aside is a flex column with hidden overflow; only the events list
+ * scrolls. That's what makes sticky-bottom auto-scroll work — header,
+ * usage row, and reply box stay parked while transcript flows below. */
 .agent-detail {
   display: flex;
   flex-direction: column;
   gap: 12px;
   padding: 20px 24px;
   height: 100%;
-  overflow: auto;
+  overflow: hidden;
   border-left: 1px solid var(--color-border, #2a2a2a);
   background: var(--color-bg, #111);
 }
@@ -15,6 +18,7 @@
   gap: 6px;
   padding-bottom: 12px;
   border-bottom: 1px solid var(--color-border, #2a2a2a);
+  flex: 0 0 auto;
 }
 
 .agent-detail__title-row {
@@ -81,6 +85,7 @@
   border-radius: 6px;
   background: rgba(251, 191, 36, 0.08);
   font-size: 13px;
+  flex: 0 0 auto;
 }
 
 .agent-detail__pending-label {
@@ -96,77 +101,219 @@
   font-size: 12px;
   color: var(--color-link, #60a5fa);
   text-decoration: none;
+  flex: 0 0 auto;
 }
 
 .agent-detail__pr:hover {
   text-decoration: underline;
 }
 
+/* The events wrapper claims the remaining vertical space; the inner
+ * .agent-detail__events is the actual scroll container so the floating
+ * "↓ N new" pill can sit in the wrapper without being scrolled away. */
+.agent-detail__events-wrap {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+}
+
 .agent-detail__events {
+  flex: 1 1 auto;
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
+  padding-right: 4px;
 }
 
-.agent-detail__event {
-  padding: 8px 12px;
-  border-radius: 6px;
+.agent-detail__new-pill {
+  position: absolute;
+  bottom: 8px;
+  right: 12px;
+  padding: 4px 10px;
+  font-size: 11px;
+  font-weight: 600;
+  border: 1px solid var(--color-accent, #60a5fa);
+  border-radius: 999px;
+  background: var(--color-bg, #111);
+  color: var(--color-accent, #60a5fa);
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+
+.agent-detail__new-pill:hover {
+  background: rgba(96, 165, 250, 0.12);
+}
+
+/* ---- messages (user / assistant / thinking) ---- */
+
+.agent-detail__msg {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 6px 8px 6px 10px;
   font-size: 13px;
-  white-space: pre-wrap;
-  word-break: break-word;
+  border-left: 2px solid transparent;
 }
 
-.agent-detail__event--user {
-  background: var(--color-bg-secondary, #181818);
-  border: 1px solid var(--color-border, #2a2a2a);
-}
-
-.agent-detail__event--assistant {
-  background: rgba(96, 165, 250, 0.06);
-  border: 1px solid rgba(96, 165, 250, 0.25);
-}
-
-.agent-detail__event--thinking {
-  font-style: italic;
-  color: var(--color-text-secondary, #888);
-  font-size: 12px;
-  background: transparent;
-  border: none;
-  padding: 4px 12px;
-}
-
-.agent-detail__event--tool_use {
-  background: var(--color-bg-secondary, #181818);
-  border: 1px dashed var(--color-border, #2a2a2a);
-  font-family: var(--font-mono, monospace);
-  font-size: 12px;
-}
-
-.agent-detail__event--tool_result {
-  background: var(--color-bg-secondary, #181818);
-  border-left: 2px solid var(--color-text-secondary, #888);
-  font-family: var(--font-mono, monospace);
-  font-size: 12px;
-  padding-left: 10px;
-  border-radius: 0;
-}
-
-.agent-detail__event--tool_result.is-error {
-  border-left-color: var(--color-danger, #f87171);
-  color: var(--color-danger, #f87171);
-}
-
-.agent-detail__event-label {
-  display: block;
+.agent-detail__msg-label {
   font-size: 10px;
   text-transform: uppercase;
   letter-spacing: 0.5px;
   color: var(--color-text-secondary, #888);
-  margin-bottom: 4px;
 }
 
+.agent-detail__msg-body {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.agent-detail__msg--user {
+  border-left-color: var(--color-text-secondary, #888);
+}
+
+.agent-detail__msg--assistant {
+  border-left-color: var(--color-link, #60a5fa);
+}
+
+.agent-detail__msg--thinking {
+  border-left-color: transparent;
+  color: var(--color-text-secondary, #888);
+  font-style: italic;
+  font-size: 12px;
+  padding-left: 12px;
+}
+
+.agent-detail__msg-toggle {
+  background: transparent;
+  border: none;
+  padding: 0;
+  color: var(--color-text-secondary, #888);
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.agent-detail__chevron {
+  display: inline-block;
+  width: 12px;
+  color: var(--color-text-secondary, #888);
+  font-size: 10px;
+}
+
+/* ---- tool call + result, paired in a single block ---- */
+
+.agent-detail__tool {
+  display: flex;
+  flex-direction: column;
+  border-left: 2px solid var(--color-text-secondary, #555);
+  padding-left: 8px;
+  font-size: 12px;
+}
+
+.agent-detail__tool.is-error {
+  border-left-color: var(--color-danger, #f87171);
+}
+
+.agent-detail__tool.is-pending {
+  border-left-color: var(--color-success, #4ade80);
+}
+
+.agent-detail__tool-head {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  background: transparent;
+  border: none;
+  padding: 2px 0;
+  cursor: pointer;
+  text-align: left;
+  color: var(--color-text, #e4e4e4);
+  font: inherit;
+  width: 100%;
+  min-width: 0;
+}
+
+.agent-detail__tool-name {
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  text-transform: lowercase;
+  color: var(--color-text-secondary, #888);
+  flex: 0 0 auto;
+}
+
+.agent-detail__tool-summary {
+  font-family: var(--font-mono, monospace);
+  font-size: 12px;
+  color: var(--color-text, #e4e4e4);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.agent-detail__tool-pending {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--color-success, #4ade80);
+  flex: 0 0 auto;
+}
+
+.agent-detail__tool-err-tag {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--color-danger, #f87171);
+  flex: 0 0 auto;
+}
+
+.agent-detail__tool-args,
+.agent-detail__tool-result {
+  margin: 4px 0 4px 16px;
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+}
+
+.agent-detail__tool-args pre,
+.agent-detail__tool-result pre {
+  margin: 0;
+  padding: 6px 8px;
+  background: var(--color-bg-secondary, #181818);
+  border-radius: 4px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--color-text-secondary, #aaa);
+  max-height: 480px;
+  overflow: auto;
+}
+
+.agent-detail__tool.is-error .agent-detail__tool-result pre {
+  color: var(--color-danger, #f87171);
+}
+
+.agent-detail__tool-show-all {
+  margin-top: 4px;
+  background: transparent;
+  border: none;
+  padding: 0;
+  font-size: 11px;
+  color: var(--color-link, #60a5fa);
+  cursor: pointer;
+}
+
+.agent-detail__tool-show-all:hover {
+  text-decoration: underline;
+}
+
+/* ---- footer (usage + reply) ---- */
+
 .agent-detail__usage {
-  margin-top: auto;
   padding-top: 12px;
   border-top: 1px solid var(--color-border, #2a2a2a);
   display: flex;
@@ -175,6 +322,7 @@
   font-size: 11px;
   color: var(--color-text-secondary, #888);
   font-family: var(--font-mono, monospace);
+  flex: 0 0 auto;
 }
 
 .agent-detail__actions {
@@ -213,6 +361,7 @@
   gap: 6px;
   padding-top: 8px;
   border-top: 1px solid var(--color-border, #2a2a2a);
+  flex: 0 0 auto;
 }
 
 .agent-detail__reply textarea {
@@ -252,4 +401,5 @@
 
 .agent-detail__error {
   color: var(--color-danger, #f87171);
+  flex: 0 0 auto;
 }


### PR DESCRIPTION
Closes #453, #454.

The detail pane now reads more like a collapsible call log than a wall of raw JSON, and it auto-scrolls intelligently as new events stream in.

## What changed

### Per-tool renderers (#453)
- `tool_use` and `tool_result` render as **one paired block**, not two separate boxes.
- Per-tool intent header from parsed args:
  - `Bash` → `$ <command>`
  - `Read` → `path/to/file.ts (lines 1-200)`
  - `Edit` / `Write` → `path/to/file.ts`
  - `Grep` → `"pattern" in src/`
  - `WebFetch` / `WebSearch` → URL or query
  - MCP / generic → tool name + title
- Result body trims to head/tail with `show all (N more lines)` expand; full args + full result live behind one chevron.
- `thinking` collapses to `▸ thinking (N words)` instead of inline italic walls.
- Expansion state keyed by **stable RenderItem id** (`tool_use.id` for pairs, `at` for messages) so the 3 s detail poll no longer wipes what the user has open.

### Sticky-bottom auto-scroll (#454)
- Events list is now its own scroll container; header, usage, and reply box stay parked.
- Auto-scrolls only when the user **was** already at the bottom — never yanks them away from history.
- Floating `↓ N new` pill when scrolled up; click jumps to bottom and clears.
- Scroll to bottom on agent switch (common case: "I clicked it to see what it just did").
- Tool-pair fingerprint treats a result completion as new even though the item key is stable, so a finishing tool surfaces in the pill.

### Version
- Bumped to **v0.2.4** so this ships in the next release DMG.

## Test plan
- [ ] `pnpm typecheck` — clean
- [ ] `pnpm lint` — clean
- [ ] `pnpm format:check` — clean
- [ ] `pnpm build` — builds
- [ ] CI green (Backend Checks, Frontend Checks, Build × 3)
- [ ] Smoke: open a long-running agent, watch new tool calls flow in without scrolling, scroll up to read history without being yanked back, see `↓ N new` pill, click it.
- [ ] Smoke: expand a Bash tool, let the 3 s poll fire — the expansion stays open.
- [ ] Smoke: switch between agents — detail pane jumps to bottom on each switch.