### PR TITLE
Dense agents table + offline banner + reply on terminal agents (v0.2.5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.2.4",
+  "version": "0.2.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "workroot"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 authors = ["Saurav Panda <saurav@workroot.dev>"]
 description = "A local-first developer workspace for managing projects, terminals, and Git workflows."

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/components/AgentDetailPane.tsx
+++ b/src/components/AgentDetailPane.tsx
@@ -515,7 +515,10 @@ export function AgentDetailPane({
   };
 
   const isTerminal = detail ? TERMINAL_STATES.has(detail.state) : false;
-  const canReply = !!detail && detail.backend === "claude" && !isTerminal;
+  // Replying to a terminal Claude agent resumes it (the daemon supports
+  // this — same behavior the helm phone app uses). Codex backends are
+  // still gated since their session-resume story differs.
+  const canReply = !!detail && detail.backend === "claude";
   const hasTranscript = items.length > 0;
 
   return (
@@ -674,7 +677,9 @@ export function AgentDetailPane({
                 void sendReply();
               }
             }}
-            placeholder="Reply to the agent…"
+            placeholder={
+              isTerminal ? "Reply to resume the agent…" : "Reply to the agent…"
+            }
             disabled={busy !== null}
           />
           <div className="agent-detail__reply-row">

--- a/src/components/AgentsTab.tsx
+++ b/src/components/AgentsTab.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useState } from "react";
-import { useAllAgents } from "../hooks/useAllAgents";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { useAllAgents, type MachineStatus } from "../hooks/useAllAgents";
 import { AgentDetailPane } from "./AgentDetailPane";
 import "../styles/agents-tab.css";
 
@@ -21,14 +22,85 @@ const STATE_LABELS: Record<string, string> = {
   failed: "Failed",
 };
 
+// "Office Mac" → "Office", "personal-mac" → "personal", etc. The "-mac"
+// suffix is the same on every machine and is wasted column width.
+function shortMachineLabel(label: string): string {
+  return label
+    .replace(/[\s_-]?mac$/i, "")
+    .replace(/[\s_-]?macbook$/i, "")
+    .trim();
+}
+
+// Compact "time ago" — 1m / 2h / 3d / "now". Driven by the 5 s poll tick;
+// resolution coarser than 1 m doesn't matter for an agent log.
+function ageSince(iso: string, now: number): string {
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return "—";
+  const secs = Math.max(0, Math.floor((now - t) / 1000));
+  if (secs < 30) return "now";
+  if (secs < 60 * 60) return `${Math.floor(secs / 60)}m`;
+  if (secs < 60 * 60 * 24) return `${Math.floor(secs / 3600)}h`;
+  return `${Math.floor(secs / 86400)}d`;
+}
+
+function OfflineBanner({
+  status,
+  onOpenMachines,
+  onRetry,
+}: {
+  status: MachineStatus;
+  onOpenMachines: () => void;
+  onRetry: () => void;
+}) {
+  const lastSeen = status.machine.last_seen_at
+    ? ageSince(status.machine.last_seen_at, Date.now())
+    : null;
+  return (
+    <div className="agents-tab__banner" role="alert">
+      <span className="agents-tab__banner-dot" />
+      <span className="agents-tab__banner-msg">
+        <strong>{status.machine.label}</strong> unreachable
+        {lastSeen ? ` — last seen ${lastSeen} ago` : ""}
+      </span>
+      <span className="agents-tab__banner-err" title={status.error ?? ""}>
+        {status.error ?? "no response"}
+      </span>
+      <div className="agents-tab__banner-actions">
+        <button
+          type="button"
+          className="agents-tab__banner-btn"
+          onClick={onRetry}
+        >
+          Retry
+        </button>
+        <button
+          type="button"
+          className="agents-tab__banner-btn"
+          onClick={onOpenMachines}
+        >
+          Open machines
+        </button>
+      </div>
+    </div>
+  );
+}
+
 export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
-  const { agents, machines, loading } = useAllAgents();
+  const { agents, machines, loading, refresh } = useAllAgents();
   const [selected, setSelected] = useState<Selection | null>(null);
+  const [now, setNow] = useState<number>(() => Date.now());
+
+  // Re-tick the "age" column every 30 s so rows update between polls
+  // without a full re-fetch.
+  useEffect(() => {
+    const id = window.setInterval(() => setNow(Date.now()), 30_000);
+    return () => window.clearInterval(id);
+  }, []);
 
   const closeDetail = useCallback(() => setSelected(null), []);
 
-  // Drop the selection if the underlying agent disappears (e.g. deleted
-  // remotely) — keeps the right pane from rendering stale data.
+  // Drop selection if the underlying agent disappears (deleted remotely,
+  // or its machine went offline).
   useEffect(() => {
     if (!selected) return;
     const stillThere = agents.some(
@@ -47,8 +119,23 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
     return () => window.removeEventListener("keydown", onKey);
   }, [selected, closeDetail]);
 
+  const offlineMachines = useMemo(
+    () => machines.filter((m) => m.error !== null),
+    [machines],
+  );
+
   const noMachines = machines.length === 0;
   const twoPane = selected !== null;
+
+  const onRetryMachine = useCallback(
+    (machineId: number) => {
+      // No per-machine retry endpoint — kick a full refresh. The fan-out
+      // re-tries every enabled machine.
+      void invoke("touch_helm_machine_seen", { id: machineId }).catch(() => {});
+      refresh();
+    },
+    [refresh],
+  );
 
   const list = (
     <>
@@ -80,6 +167,15 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
         </div>
       </div>
 
+      {offlineMachines.map((m) => (
+        <OfflineBanner
+          key={m.machine.id}
+          status={m}
+          onOpenMachines={onOpenMachines}
+          onRetry={() => onRetryMachine(m.machine.id)}
+        />
+      ))}
+
       {noMachines ? (
         <div className="agents-tab__empty">
           <p>No helm machines registered.</p>
@@ -100,52 +196,77 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
           </p>
         </div>
       ) : (
-        <div className="agents-tab__list">
-          {agents.map((a) => {
-            const isSelected =
-              selected?.agentId === a.id &&
-              selected?.machineId === a.machine_id;
-            return (
-              <div
-                key={`${a.machine_id}:${a.id}`}
-                className={
-                  isSelected
-                    ? "agents-tab__row agents-tab__row--selected"
-                    : "agents-tab__row"
-                }
-                onClick={() =>
-                  setSelected({ machineId: a.machine_id, agentId: a.id })
-                }
-                role="button"
-                tabIndex={0}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    setSelected({
-                      machineId: a.machine_id,
-                      agentId: a.id,
-                    });
+        <div className="agents-tab__table" role="table" aria-label="Agents">
+          <div className="agents-tab__thead" role="row">
+            <span role="columnheader">State</span>
+            <span role="columnheader">Name</span>
+            <span role="columnheader">Activity</span>
+            <span role="columnheader">Repo</span>
+            <span role="columnheader">Backend</span>
+            <span role="columnheader">Machine</span>
+            <span role="columnheader" className="agents-tab__col-age">
+              Age
+            </span>
+          </div>
+          <div className="agents-tab__tbody">
+            {agents.map((a) => {
+              const isSelected =
+                selected?.agentId === a.id &&
+                selected?.machineId === a.machine_id;
+              const stateLabel = STATE_LABELS[a.state] ?? a.state;
+              const activity = a.last_activity ?? a.task;
+              const machineShort = shortMachineLabel(a.machine_label);
+              return (
+                <div
+                  key={`${a.machine_id}:${a.id}`}
+                  className={
+                    isSelected
+                      ? "agents-tab__row agents-tab__row--selected"
+                      : "agents-tab__row"
                   }
-                }}
-              >
-                <span
-                  className={`agents-tab__row-state agents-tab__row-state--${a.state}`}
+                  onClick={() =>
+                    setSelected({ machineId: a.machine_id, agentId: a.id })
+                  }
+                  role="row"
+                  tabIndex={0}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      setSelected({
+                        machineId: a.machine_id,
+                        agentId: a.id,
+                      });
+                    }
+                  }}
                 >
-                  {STATE_LABELS[a.state] ?? a.state}
-                </span>
-                <div className="agents-tab__row-meta">
-                  <span className="agents-tab__row-name">{a.name}</span>
-                  <span className="agents-tab__row-task">
-                    {a.last_activity ?? a.task}
+                  <span
+                    className={`agents-tab__state-pill agents-tab__state-pill--${a.state}`}
+                  >
+                    {stateLabel}
+                  </span>
+                  <span className="agents-tab__cell-name" title={a.name}>
+                    {a.name}
+                  </span>
+                  <span className="agents-tab__cell-activity" title={activity}>
+                    {activity}
+                  </span>
+                  <span className="agents-tab__cell-repo" title={a.repo}>
+                    {a.repo}
+                  </span>
+                  <span className="agents-tab__cell-backend">{a.backend}</span>
+                  <span
+                    className="agents-tab__cell-machine"
+                    title={a.machine_label}
+                  >
+                    {machineShort}
+                  </span>
+                  <span className="agents-tab__cell-age">
+                    {ageSince(a.updated_at, now)}
                   </span>
                 </div>
-                <span className="agents-tab__row-repo">{a.repo}</span>
-                <span className="agents-tab__row-machine">
-                  {a.machine_label}
-                </span>
-              </div>
-            );
-          })}
+              );
+            })}
+          </div>
         </div>
       )}
     </>

--- a/src/styles/agents-tab.css
+++ b/src/styles/agents-tab.css
@@ -1,8 +1,8 @@
 .agents-tab {
   display: flex;
   flex-direction: column;
-  gap: 16px;
-  padding: 24px 32px;
+  gap: 12px;
+  padding: 20px 28px;
   height: 100%;
   overflow: auto;
 }
@@ -19,8 +19,8 @@
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 16px;
-  padding: 24px 32px;
+  gap: 12px;
+  padding: 20px 28px;
   overflow: auto;
 }
 
@@ -31,20 +31,12 @@
   overflow: hidden;
 }
 
-.agents-tab__row {
-  cursor: pointer;
-}
-
-.agents-tab__row--selected {
-  border-color: var(--color-accent, #60a5fa);
-  background: rgba(96, 165, 250, 0.08);
-}
-
 .agents-tab__header {
   display: flex;
   justify-content: space-between;
   align-items: baseline;
   gap: 16px;
+  flex-wrap: wrap;
 }
 
 .agents-tab__title {
@@ -87,74 +79,214 @@
   background: var(--color-danger, #f87171);
 }
 
-.agents-tab__list {
+/* ---- offline machine banner ---- */
+
+.agents-tab__banner {
   display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.agents-tab__row {
-  display: grid;
-  grid-template-columns: 90px 1fr auto auto;
-  gap: 16px;
   align-items: center;
-  padding: 12px 16px;
-  border: 1px solid var(--color-border, #2a2a2a);
+  gap: 10px;
+  padding: 8px 12px;
+  border: 1px solid var(--color-warning, #fbbf24);
   border-radius: 6px;
-  background: var(--color-bg-secondary, #181818);
-}
-
-.agents-tab__row-state {
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  font-weight: 600;
-  color: var(--color-text-secondary, #888);
-}
-
-.agents-tab__row-state--waiting_input {
-  color: var(--color-warning, #fbbf24);
-}
-.agents-tab__row-state--working {
-  color: var(--color-success, #4ade80);
-}
-.agents-tab__row-state--failed {
-  color: var(--color-danger, #f87171);
-}
-.agents-tab__row-state--done {
-  color: var(--color-text-secondary, #888);
-}
-
-.agents-tab__row-name {
-  font-size: 14px;
-  font-weight: 600;
-}
-
-.agents-tab__row-task {
+  background: rgba(251, 191, 36, 0.08);
   font-size: 12px;
+  color: var(--color-text, #e4e4e4);
+}
+
+.agents-tab__banner-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--color-warning, #fbbf24);
+  flex: 0 0 auto;
+}
+
+.agents-tab__banner-msg {
+  flex: 0 0 auto;
+}
+
+.agents-tab__banner-err {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
   color: var(--color-text-secondary, #888);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.agents-tab__row-meta {
+.agents-tab__banner-actions {
+  display: flex;
+  gap: 6px;
+  flex: 0 0 auto;
+}
+
+.agents-tab__banner-btn {
+  padding: 3px 10px;
+  font-size: 11px;
+  border: 1px solid var(--color-border, #2a2a2a);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--color-text, #e4e4e4);
+  cursor: pointer;
+}
+
+.agents-tab__banner-btn:hover {
+  background: var(--color-bg-hover, #222);
+}
+
+/* ---- dense agents table ---- */
+
+.agents-tab__table {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  border-top: 1px solid var(--color-border, #2a2a2a);
+  border-bottom: 1px solid var(--color-border, #2a2a2a);
+}
+
+/* Same template on header + rows so columns align. */
+.agents-tab__thead,
+.agents-tab__row {
+  display: grid;
+  grid-template-columns:
+    90px /* state pill */
+    minmax(140px, 1.4fr) /* name */
+    minmax(180px, 2.6fr) /* activity */
+    minmax(120px, 1fr) /* repo */
+    62px /* backend */
+    96px /* machine */
+    52px; /* age */
+  gap: 14px;
+  align-items: center;
+  padding: 6px 8px;
+  font-size: 13px;
+}
+
+.agents-tab__thead {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--color-text-secondary, #888);
+  border-bottom: 1px solid var(--color-border, #2a2a2a);
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.agents-tab__tbody {
+  display: flex;
+  flex-direction: column;
+}
+
+.agents-tab__row {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  border-left: 2px solid transparent;
+  cursor: pointer;
+  min-height: 30px;
+}
+
+.agents-tab__row:hover {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.agents-tab__row--selected {
+  border-left-color: var(--color-accent, #60a5fa);
+  background: rgba(96, 165, 250, 0.08);
+}
+
+.agents-tab__row--selected:hover {
+  background: rgba(96, 165, 250, 0.1);
+}
+
+/* state pill — mirrors detail-pane treatment */
+.agents-tab__state-pill {
+  display: inline-block;
+  padding: 1px 8px;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  font-weight: 600;
+  border-radius: 999px;
+  background: var(--color-bg-secondary, #181818);
+  border: 1px solid var(--color-border, #2a2a2a);
+  color: var(--color-text-secondary, #888);
+  text-align: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.agents-tab__state-pill--waiting_input {
+  color: var(--color-warning, #fbbf24);
+  border-color: var(--color-warning, #fbbf24);
+}
+.agents-tab__state-pill--working {
+  color: var(--color-success, #4ade80);
+  border-color: var(--color-success, #4ade80);
+}
+.agents-tab__state-pill--failed {
+  color: var(--color-danger, #f87171);
+  border-color: var(--color-danger, #f87171);
+}
+.agents-tab__state-pill--planning,
+.agents-tab__state-pill--queued {
+  color: var(--color-text-secondary, #aaa);
+}
+
+/* row cells — every column gets ellipsis overflow so the grid stays tight */
+.agents-tab__row > span,
+.agents-tab__thead > span {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   min-width: 0;
 }
 
-.agents-tab__row-machine {
-  font-size: 11px;
+.agents-tab__cell-name {
+  font-weight: 500;
+  color: var(--color-text, #e4e4e4);
+}
+
+.agents-tab__row
+  .agents-tab__state-pill--waiting_input
+  ~ .agents-tab__cell-name,
+.agents-tab__row .agents-tab__state-pill--failed ~ .agents-tab__cell-name {
+  font-weight: 600;
+}
+
+.agents-tab__cell-activity {
   color: var(--color-text-secondary, #888);
 }
 
-.agents-tab__row-repo {
-  font-size: 11px;
+.agents-tab__cell-repo {
   font-family: var(--font-mono, monospace);
+  font-size: 12px;
   color: var(--color-text-secondary, #888);
+  direction: rtl; /* truncate from the left so the repo basename stays visible */
+  text-align: left;
 }
+
+.agents-tab__cell-backend {
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  color: var(--color-text-secondary, #888);
+  text-transform: lowercase;
+}
+
+.agents-tab__cell-machine {
+  font-size: 12px;
+  color: var(--color-text-secondary, #aaa);
+}
+
+.agents-tab__cell-age,
+.agents-tab__col-age {
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  color: var(--color-text-secondary, #888);
+  text-align: right;
+}
+
+/* ---- empty / loading ---- */
 
 .agents-tab__empty {
   margin-top: 32px;


### PR DESCRIPTION
Closes #455 and #457. Plus a bug fix you flagged today.

## Bug fix: reply on terminal agents

You reported the detail pane has no way to type/send a message. The reply textarea was hidden when state ∈ `{done, failed}` so once an agent finished, you couldn't continue the conversation. The helm daemon supports replying to a terminal Claude agent (it resumes the session — same path the phone app uses). Drop the `!isTerminal` gate; switch the placeholder to *"Reply to resume the agent…"* when terminal so the behavior is obvious. Codex backend is still gated since its session-resume story differs.

## #455 — dense table

Cards → flat table. Columns: **State** · **Name** · **Activity** · **Repo** · **Backend** · **Machine** · **Age**. Single-pixel row separators, no per-row borders. Selected row = 2 px left accent + faint background. `~30 px` row height (was ~64 px), so roughly 2× the rows visible.

Machine labels strip the `-mac` suffix (same on every machine, just eats column width).

**Deferred from the original spec:** branch / cost / tokens / attention-badge columns. Those fields don't live on the list-level `Agent` payload today — only on `AgentDetail`. Showing them would require either N+1 detail fetches per row (no) or extending the daemon `/v1/agents` payload with a `usage_summary` (probably next). Called out so we don't lose track.

## #457 — offline banner

Per-machine amber banner above the table when a machine fails to respond, with `last seen N ago`, the underlying error message truncated, and `Retry` / `Open machines` buttons. Stacks if more than one is offline. Header pills stay as the canonical detail.

**Row-dimming for offline-machine agents was on the spec but isn't needed today:** `useAllAgents` drops agents from machines that erred, so there are no rows to dim. Doing it properly would need a "last known good" cache in the hook — separate change if/when we want it.

## Test plan
- [ ] Local checks: `pnpm typecheck` ✅, `pnpm lint` ✅, `pnpm format:check` ✅, `pnpm build` ✅
- [ ] CI green
- [ ] Smoke: open a done agent, see the reply box, type → Send (or ⌘↵). Daemon should accept and the agent should resume.
- [ ] Smoke: kill the helm-daemon on one machine, see the banner appear; restart it, click Retry, banner clears.
- [ ] Smoke: with 20+ agents loaded, count visible rows — should fit ~25 at 1440×900 vs ~6 before.