### PR TITLE
Fix agents table overflow + add working indicator (v0.2.6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.2.5",
+  "version": "0.2.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "workroot"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 authors = ["Saurav Panda <saurav@workroot.dev>"]
 description = "A local-first developer workspace for managing projects, terminals, and Git workflows."

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/components/AgentDetailPane.tsx
+++ b/src/components/AgentDetailPane.tsx
@@ -20,6 +20,15 @@ interface AgentDetailPaneProps {
 }
 
 const TERMINAL_STATES = new Set(["done", "failed"]);
+// States where the agent is actively doing something — used to surface a
+// "thinking" / typing-bubble at the bottom of the events list.
+const ACTIVE_STATES = new Set(["working", "planning", "queued"]);
+
+const ACTIVE_STATE_LABEL: Record<string, string> = {
+  working: "Agent is working",
+  planning: "Agent is planning",
+  queued: "Agent is queued",
+};
 
 // How many lines to keep visible from a long stdout/result before truncating.
 // We show the first half + last half, joined by an ellipsis row.
@@ -633,6 +642,22 @@ export function AgentDetailPane({
                 />
               );
             })
+          )}
+          {detail && ACTIVE_STATES.has(detail.state) && (
+            <div
+              className="agent-detail__working"
+              aria-live="polite"
+              aria-label={ACTIVE_STATE_LABEL[detail.state] ?? "Agent is busy"}
+            >
+              <span className="agent-detail__working-dots">
+                <span />
+                <span />
+                <span />
+              </span>
+              <span className="agent-detail__working-label">
+                {ACTIVE_STATE_LABEL[detail.state] ?? "working"}
+              </span>
+            </div>
           )}
         </div>
 

--- a/src/components/AgentsTab.tsx
+++ b/src/components/AgentsTab.tsx
@@ -43,6 +43,15 @@ function ageSince(iso: string, now: number): string {
   return `${Math.floor(secs / 86400)}d`;
 }
 
+// "now" → "just now"; everything else → "last seen 3m ago"
+function lastSeenPhrase(iso: string | null): string {
+  if (!iso) return "";
+  const ago = ageSince(iso, Date.now());
+  if (ago === "now") return " — last seen just now";
+  if (ago === "—") return "";
+  return ` — last seen ${ago} ago`;
+}
+
 function OfflineBanner({
   status,
   onOpenMachines,
@@ -52,18 +61,13 @@ function OfflineBanner({
   onOpenMachines: () => void;
   onRetry: () => void;
 }) {
-  const lastSeen = status.machine.last_seen_at
-    ? ageSince(status.machine.last_seen_at, Date.now())
-    : null;
+  const errTitle = status.error ?? "no response";
   return (
     <div className="agents-tab__banner" role="alert">
       <span className="agents-tab__banner-dot" />
-      <span className="agents-tab__banner-msg">
+      <span className="agents-tab__banner-msg" title={errTitle}>
         <strong>{status.machine.label}</strong> unreachable
-        {lastSeen ? ` — last seen ${lastSeen} ago` : ""}
-      </span>
-      <span className="agents-tab__banner-err" title={status.error ?? ""}>
-        {status.error ?? "no response"}
+        {lastSeenPhrase(status.machine.last_seen_at)}
       </span>
       <div className="agents-tab__banner-actions">
         <button
@@ -202,7 +206,6 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
             <span role="columnheader">Name</span>
             <span role="columnheader">Activity</span>
             <span role="columnheader">Repo</span>
-            <span role="columnheader">Backend</span>
             <span role="columnheader">Machine</span>
             <span role="columnheader" className="agents-tab__col-age">
               Age
@@ -253,7 +256,6 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
                   <span className="agents-tab__cell-repo" title={a.repo}>
                     {a.repo}
                   </span>
-                  <span className="agents-tab__cell-backend">{a.backend}</span>
                   <span
                     className="agents-tab__cell-machine"
                     title={a.machine_label}

--- a/src/styles/agent-detail.css
+++ b/src/styles/agent-detail.css
@@ -146,6 +146,62 @@
   background: rgba(96, 165, 250, 0.12);
 }
 
+/* ---- "agent is working" typing bubble at the bottom of the events ---- */
+
+.agent-detail__working {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin: 4px 0 6px 8px;
+  padding: 6px 12px;
+  border-radius: 14px;
+  background: rgba(74, 222, 128, 0.08);
+  border: 1px solid rgba(74, 222, 128, 0.3);
+  font-size: 12px;
+  color: var(--color-success, #4ade80);
+  align-self: flex-start;
+}
+
+.agent-detail__working-dots {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+}
+
+.agent-detail__working-dots span {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--color-success, #4ade80);
+  display: inline-block;
+  animation: agent-detail-typing 1.2s ease-in-out infinite;
+}
+
+.agent-detail__working-dots span:nth-child(2) {
+  animation-delay: 0.18s;
+}
+
+.agent-detail__working-dots span:nth-child(3) {
+  animation-delay: 0.36s;
+}
+
+@keyframes agent-detail-typing {
+  0%,
+  60%,
+  100% {
+    opacity: 0.25;
+    transform: translateY(0);
+  }
+  30% {
+    opacity: 1;
+    transform: translateY(-2px);
+  }
+}
+
+.agent-detail__working-label {
+  font-weight: 500;
+}
+
 /* ---- messages (user / assistant / thinking) ---- */
 
 .agent-detail__msg {

--- a/src/styles/agents-tab.css
+++ b/src/styles/agents-tab.css
@@ -91,6 +91,7 @@
   background: rgba(251, 191, 36, 0.08);
   font-size: 12px;
   color: var(--color-text, #e4e4e4);
+  min-width: 0;
 }
 
 .agents-tab__banner-dot {
@@ -102,15 +103,8 @@
 }
 
 .agents-tab__banner-msg {
-  flex: 0 0 auto;
-}
-
-.agents-tab__banner-err {
   flex: 1 1 auto;
   min-width: 0;
-  font-family: var(--font-mono, monospace);
-  font-size: 11px;
-  color: var(--color-text-secondary, #888);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -145,22 +139,26 @@
   border-bottom: 1px solid var(--color-border, #2a2a2a);
 }
 
-/* Same template on header + rows so columns align. */
+/* Same template on header + rows so columns align. Tuned to fit the
+ * narrower list pane when the detail pane is open (window width minus
+ * the right pane's 380–640 px). Backend column is dropped — it shows
+ * the same value ("claude") for almost every row and isn't worth the
+ * width; the detail pane still surfaces it. */
 .agents-tab__thead,
 .agents-tab__row {
   display: grid;
   grid-template-columns:
-    90px /* state pill */
-    minmax(140px, 1.4fr) /* name */
-    minmax(180px, 2.6fr) /* activity */
-    minmax(120px, 1fr) /* repo */
-    62px /* backend */
-    96px /* machine */
-    52px; /* age */
-  gap: 14px;
+    72px /* state pill */
+    minmax(120px, 1.4fr) /* name */
+    minmax(140px, 2.4fr) /* activity */
+    minmax(96px, 1fr) /* repo */
+    72px /* machine */
+    44px; /* age */
+  gap: 12px;
   align-items: center;
   padding: 6px 8px;
   font-size: 13px;
+  min-width: 0;
 }
 
 .agents-tab__thead {
@@ -262,15 +260,6 @@
   font-family: var(--font-mono, monospace);
   font-size: 12px;
   color: var(--color-text-secondary, #888);
-  direction: rtl; /* truncate from the left so the repo basename stays visible */
-  text-align: left;
-}
-
-.agents-tab__cell-backend {
-  font-family: var(--font-mono, monospace);
-  font-size: 11px;
-  color: var(--color-text-secondary, #888);
-  text-transform: lowercase;
 }
 
 .agents-tab__cell-machine {


### PR DESCRIPTION
Hotfix for v0.2.5 — the table looked broken in the screenshot you shared.

## Bug fixes

**Table overflow.** Backend / Machine / Age columns were clipped off the right edge when the detail pane was open. Sum of grid min-widths was ~840 px but the list pane only gets `window − up to 640 px`. Fixes:

- Drop the **Backend** column entirely. It says `claude` for almost every row and isn't worth the width; the detail header still surfaces it.
- Tighten remaining columns: state `90→72`, name `140→120`, activity `180→140`, repo `120→96`, machine `96→72`, age `52→44`, gap `14→12`.
- New min-width total: ~580 px. Fits the narrow list pane comfortably.

**Repo column garbled.** The `direction: rtl` truncation trick from v0.2.5 produced unreadable strings like `…t-sauravp` (mirroring mid-word). Switched to standard left-to-right ellipsis — `browser-use-rust-saur…` reads cleanly.

**Banner.** Two issues:
- "last seen **now ago**" — fixed to "last seen **just now**" when the age resolves to "now".
- Inline truncated error showed as `Da…` (useless). Removed the inline render; full error stays in the `title` attribute on hover.

## New: working indicator

You also flagged: *"when agent is working, I dont see the working thing loading kind of bubble"*.

Added a chat-style typing bubble at the bottom of the events list when state is **working / planning / queued** — three pulsing green dots with a label ("Agent is working" / "planning" / "queued"). Sits as a flex-start bubble below the last event, and the sticky-bottom scroll behavior naturally keeps it in view as new events arrive.

## Test plan
- [ ] Local checks: `pnpm typecheck` ✅, `pnpm lint` ✅, `pnpm format:check` ✅, `pnpm build` ✅
- [ ] CI green
- [ ] Smoke: open detail pane on any agent — Machine + Age columns now visible to the right of Repo
- [ ] Smoke: open a `working` agent — see the green pulsing bubble at the bottom of the events list
- [ ] Smoke: kill helm-daemon on a machine, hover the banner — full error text shows in tooltip; banner reads "last seen just now"