### PR TITLE
Splits + chat bubbles + file attach + better proxy errors (v0.3.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.2.6",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "workroot"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.2.6"
+version = "0.3.0"
 edition = "2021"
 authors = ["Saurav Panda <saurav@workroot.dev>"]
 description = "A local-first developer workspace for managing projects, terminals, and Git workflows."

--- a/src-tauri/src/helm/mod.rs
+++ b/src-tauri/src/helm/mod.rs
@@ -172,7 +172,7 @@ pub fn touch_helm_machine_seen(db: State<'_, AppDb>, id: i64) -> Result<(), Stri
     Ok(())
 }
 
-const PROXY_TIMEOUT: Duration = Duration::from_secs(15);
+const PROXY_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Proxy a JSON request to a registered helm-daemon.
 ///
@@ -226,10 +226,29 @@ pub async fn helm_proxy_request(
         req = req.header("Content-Type", "application/json").body(b);
     }
 
-    let resp = req
-        .send()
-        .await
-        .map_err(|e| format!("Daemon request failed: {}", e))?;
+    let resp = req.send().await.map_err(|e| {
+        // Default reqwest Display hides the underlying cause. Surface the
+        // error kind and chain so the React side can show something
+        // diagnosable instead of "error sending request for url …".
+        let kind = if e.is_timeout() {
+            "timeout"
+        } else if e.is_connect() {
+            "connect"
+        } else if e.is_request() {
+            "request"
+        } else if e.is_body() {
+            "body"
+        } else {
+            "other"
+        };
+        let mut msg = format!("Daemon {} failed [{}]: {}", method, kind, e);
+        let mut src = std::error::Error::source(&e);
+        while let Some(s) = src {
+            msg.push_str(&format!(" → {}", s));
+            src = s.source();
+        }
+        msg
+    })?;
     let status = resp.status();
     let raw = resp
         .text()

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/components/AgentDetailPane.tsx
+++ b/src/components/AgentDetailPane.tsx
@@ -6,6 +6,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { useAgentDetail } from "../hooks/useAgentDetail";
 import { clientFor, type ThreadEvent, type Turn } from "../lib/helm-api";
 import "../styles/agent-detail.css";
@@ -248,9 +249,6 @@ function MessageItem({
           : "agent-detail__msg agent-detail__msg--assistant"
       }
     >
-      <span className="agent-detail__msg-label">
-        {role === "user" ? "You" : "Assistant"}
-      </span>
       <div className="agent-detail__msg-body">{text}</div>
     </div>
   );
@@ -336,9 +334,6 @@ function TurnItem({ turn }: { turn: Turn }) {
           : "agent-detail__msg agent-detail__msg--assistant"
       }
     >
-      <span className="agent-detail__msg-label">
-        {turn.role === "user" ? "You" : "Assistant"}
-      </span>
       <div className="agent-detail__msg-body">{turn.content}</div>
     </div>
   );
@@ -471,6 +466,26 @@ export function AgentDetailPane({
       </aside>
     );
   }
+
+  // Open the system file picker and append "[attached: <abs path>]" to
+  // the reply text. The daemon's /reply endpoint accepts only a string
+  // body, so we can't actually upload bytes — but inserting the absolute
+  // path is enough for the agent to use its Read tool on the file
+  // (works for code, text, JSON, images Claude can see, etc).
+  const attachFiles = async () => {
+    let picked: string | string[] | null = null;
+    try {
+      picked = await openDialog({ multiple: true });
+    } catch (e) {
+      setActionError(`Attach failed: ${e}`);
+      return;
+    }
+    if (!picked) return;
+    const paths = Array.isArray(picked) ? picked : [picked];
+    if (paths.length === 0) return;
+    const lines = paths.map((p) => `[attached: ${p}]`).join("\n");
+    setReply((prev) => (prev.trim() ? `${prev}\n${lines}\n` : `${lines}\n`));
+  };
 
   const sendReply = async () => {
     if (!machine || !detail || !reply.trim()) return;
@@ -711,13 +726,24 @@ export function AgentDetailPane({
             <span className="agent-detail__reply-hint">
               ⌘/Ctrl + Enter to send
             </span>
-            <button
-              className="agent-detail__action-btn"
-              onClick={() => void sendReply()}
-              disabled={!reply.trim() || busy !== null}
-            >
-              {busy === "reply" ? "Sending…" : "Send"}
-            </button>
+            <div className="agent-detail__reply-actions">
+              <button
+                type="button"
+                className="agent-detail__action-btn agent-detail__attach-btn"
+                onClick={() => void attachFiles()}
+                disabled={busy !== null}
+                title="Attach a file — its absolute path is appended so the agent can Read it"
+              >
+                Attach
+              </button>
+              <button
+                className="agent-detail__action-btn"
+                onClick={() => void sendReply()}
+                disabled={!reply.trim() || busy !== null}
+              >
+                {busy === "reply" ? "Sending…" : "Send"}
+              </button>
+            </div>
           </div>
         </div>
       )}

--- a/src/components/AgentsTab.tsx
+++ b/src/components/AgentsTab.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { useAllAgents, type MachineStatus } from "../hooks/useAllAgents";
 import { AgentDetailPane } from "./AgentDetailPane";
@@ -8,10 +8,16 @@ interface AgentsTabProps {
   onOpenMachines: () => void;
 }
 
-interface Selection {
+interface Pane {
+  paneId: number;
   machineId: number;
   agentId: string;
 }
+
+// Cap on simultaneously open agent panes. 4 fits a 2×2 grid; beyond
+// that each pane gets too narrow to be useful and the per-pane 3 s
+// poll starts adding up.
+const MAX_PANES = 4;
 
 const STATE_LABELS: Record<string, string> = {
   waiting_input: "Needs you",
@@ -22,7 +28,7 @@ const STATE_LABELS: Record<string, string> = {
   failed: "Failed",
 };
 
-// "Office Mac" → "Office", "personal-mac" → "personal", etc. The "-mac"
+// "Office Mac" → "Office", "personal-mac" → "personal". The "-mac"
 // suffix is the same on every machine and is wasted column width.
 function shortMachineLabel(label: string): string {
   return label
@@ -31,7 +37,7 @@ function shortMachineLabel(label: string): string {
     .trim();
 }
 
-// Compact "time ago" — 1m / 2h / 3d / "now". Driven by the 5 s poll tick;
+// Compact "time ago" — 1m / 2h / 3d / "now". Driven by a 30 s tick;
 // resolution coarser than 1 m doesn't matter for an agent log.
 function ageSince(iso: string, now: number): string {
   const t = Date.parse(iso);
@@ -43,7 +49,6 @@ function ageSince(iso: string, now: number): string {
   return `${Math.floor(secs / 86400)}d`;
 }
 
-// "now" → "just now"; everything else → "last seen 3m ago"
 function lastSeenPhrase(iso: string | null): string {
   if (!iso) return "";
   const ago = ageSince(iso, Date.now());
@@ -91,37 +96,86 @@ function OfflineBanner({
 
 export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
   const { agents, machines, loading, refresh } = useAllAgents();
-  const [selected, setSelected] = useState<Selection | null>(null);
+  const [panes, setPanes] = useState<Pane[]>([]);
+  const [focusedPaneId, setFocusedPaneId] = useState<number | null>(null);
   const [now, setNow] = useState<number>(() => Date.now());
+  const paneIdRef = useRef(1);
 
-  // Re-tick the "age" column every 30 s so rows update between polls
-  // without a full re-fetch.
+  // Re-tick the "age" column every 30 s.
   useEffect(() => {
     const id = window.setInterval(() => setNow(Date.now()), 30_000);
     return () => window.clearInterval(id);
   }, []);
 
-  const closeDetail = useCallback(() => setSelected(null), []);
+  // Open an agent in a pane. If it's already open, just focus that pane.
+  // If we're at MAX_PANES, evict the oldest.
+  const openAgent = useCallback((machineId: number, agentId: string) => {
+    setPanes((prev) => {
+      const existing = prev.find(
+        (p) => p.machineId === machineId && p.agentId === agentId,
+      );
+      if (existing) {
+        setFocusedPaneId(existing.paneId);
+        return prev;
+      }
+      const newPane: Pane = {
+        paneId: paneIdRef.current++,
+        machineId,
+        agentId,
+      };
+      const next =
+        prev.length >= MAX_PANES
+          ? [...prev.slice(1), newPane]
+          : [...prev, newPane];
+      setFocusedPaneId(newPane.paneId);
+      return next;
+    });
+  }, []);
 
-  // Drop selection if the underlying agent disappears (deleted remotely,
-  // or its machine went offline).
+  const closePane = useCallback((paneId: number) => {
+    setPanes((prev) => {
+      const next = prev.filter((p) => p.paneId !== paneId);
+      // If we just closed the focused pane, focus the new last one
+      // (or null if empty).
+      setFocusedPaneId((prevFocus) => {
+        if (prevFocus !== paneId) return prevFocus;
+        return next.length > 0 ? next[next.length - 1].paneId : null;
+      });
+      return next;
+    });
+  }, []);
+
+  // Drop any pane whose underlying agent has disappeared (deleted
+  // remotely, or its machine went offline).
   useEffect(() => {
-    if (!selected) return;
-    const stillThere = agents.some(
-      (a) => a.id === selected.agentId && a.machine_id === selected.machineId,
+    setPanes((prev) =>
+      prev.filter((p) =>
+        agents.some((a) => a.id === p.agentId && a.machine_id === p.machineId),
+      ),
     );
-    if (!stillThere) setSelected(null);
-  }, [agents, selected]);
+  }, [agents]);
 
-  // Esc closes the detail pane.
+  // Esc closes the focused pane.
   useEffect(() => {
-    if (!selected) return;
+    if (panes.length === 0) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") closeDetail();
+      if (e.key !== "Escape") return;
+      const target = e.target as HTMLElement | null;
+      // Don't intercept Esc inside text inputs (clears the input).
+      if (
+        target &&
+        (target.tagName === "TEXTAREA" || target.tagName === "INPUT")
+      ) {
+        return;
+      }
+      const id =
+        focusedPaneId ??
+        (panes.length > 0 ? panes[panes.length - 1].paneId : null);
+      if (id !== null) closePane(id);
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [selected, closeDetail]);
+  }, [panes, focusedPaneId, closePane]);
 
   const offlineMachines = useMemo(
     () => machines.filter((m) => m.error !== null),
@@ -129,17 +183,23 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
   );
 
   const noMachines = machines.length === 0;
-  const twoPane = selected !== null;
+  const splitView = panes.length > 0;
 
   const onRetryMachine = useCallback(
     (machineId: number) => {
-      // No per-machine retry endpoint — kick a full refresh. The fan-out
-      // re-tries every enabled machine.
       void invoke("touch_helm_machine_seen", { id: machineId }).catch(() => {});
       refresh();
     },
     [refresh],
   );
+
+  // Build a Set of "open" machineId:agentId so list rows can show whether
+  // they're already in a pane.
+  const openSet = useMemo(() => {
+    const s = new Set<string>();
+    for (const p of panes) s.add(`${p.machineId}:${p.agentId}`);
+    return s;
+  }, [panes]);
 
   const list = (
     <>
@@ -213,9 +273,7 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
           </div>
           <div className="agents-tab__tbody">
             {agents.map((a) => {
-              const isSelected =
-                selected?.agentId === a.id &&
-                selected?.machineId === a.machine_id;
+              const isOpen = openSet.has(`${a.machine_id}:${a.id}`);
               const stateLabel = STATE_LABELS[a.state] ?? a.state;
               const activity = a.last_activity ?? a.task;
               const machineShort = shortMachineLabel(a.machine_label);
@@ -223,22 +281,17 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
                 <div
                   key={`${a.machine_id}:${a.id}`}
                   className={
-                    isSelected
+                    isOpen
                       ? "agents-tab__row agents-tab__row--selected"
                       : "agents-tab__row"
                   }
-                  onClick={() =>
-                    setSelected({ machineId: a.machine_id, agentId: a.id })
-                  }
+                  onClick={() => openAgent(a.machine_id, a.id)}
                   role="row"
                   tabIndex={0}
                   onKeyDown={(e) => {
                     if (e.key === "Enter" || e.key === " ") {
                       e.preventDefault();
-                      setSelected({
-                        machineId: a.machine_id,
-                        agentId: a.id,
-                      });
+                      openAgent(a.machine_id, a.id);
                     }
                   }}
                 >
@@ -271,23 +324,46 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
           </div>
         </div>
       )}
+
+      {splitView && (
+        <div className="agents-tab__hint">
+          {panes.length} of {MAX_PANES} panes open · click a row to open another
+          · Esc closes the focused pane
+        </div>
+      )}
     </>
   );
 
-  if (!twoPane) {
+  if (!splitView) {
     return <div className="agents-tab">{list}</div>;
   }
 
   return (
-    <div className="agents-tab agents-tab--two-pane">
+    <div className="agents-tab agents-tab--splits">
       <div className="agents-tab__list-pane">{list}</div>
-      <div className="agents-tab__detail-pane">
-        <AgentDetailPane
-          machineId={selected.machineId}
-          agentId={selected.agentId}
-          onClose={closeDetail}
-          onDeleted={closeDetail}
-        />
+      <div className={`agents-tab__panes agents-tab__panes--n${panes.length}`}>
+        {panes.map((p) => {
+          const focused = focusedPaneId === p.paneId;
+          return (
+            <div
+              key={p.paneId}
+              className={
+                focused
+                  ? "agents-tab__pane agents-tab__pane--focused"
+                  : "agents-tab__pane"
+              }
+              onClick={() => setFocusedPaneId(p.paneId)}
+              onFocus={() => setFocusedPaneId(p.paneId)}
+            >
+              <AgentDetailPane
+                machineId={p.machineId}
+                agentId={p.agentId}
+                onClose={() => closePane(p.paneId)}
+                onDeleted={() => closePane(p.paneId)}
+              />
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/styles/agent-detail.css
+++ b/src/styles/agent-detail.css
@@ -5,10 +5,9 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
-  padding: 20px 24px;
+  padding: 16px 20px;
   height: 100%;
   overflow: hidden;
-  border-left: 1px solid var(--color-border, #2a2a2a);
   background: var(--color-bg, #111);
 }
 

--- a/src/styles/agent-detail.css
+++ b/src/styles/agent-detail.css
@@ -203,20 +203,18 @@
 
 /* ---- messages (user / assistant / thinking) ---- */
 
+/* Chat-bubble alignment — user right, assistant left, like iMessage.
+ * Alignment + color carry the role; the "You / Assistant" labels were
+ * dropped from JSX so the bubble itself reads as the speaker. */
 .agent-detail__msg {
   display: flex;
   flex-direction: column;
   gap: 4px;
-  padding: 6px 8px 6px 10px;
+  padding: 8px 12px;
   font-size: 13px;
-  border-left: 2px solid transparent;
-}
-
-.agent-detail__msg-label {
-  font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  color: var(--color-text-secondary, #888);
+  max-width: min(78%, 640px);
+  border-radius: 14px;
+  word-break: break-word;
 }
 
 .agent-detail__msg-body {
@@ -225,19 +223,31 @@
 }
 
 .agent-detail__msg--user {
-  border-left-color: var(--color-text-secondary, #888);
+  align-self: flex-end;
+  background: rgba(96, 165, 250, 0.18);
+  border: 1px solid rgba(96, 165, 250, 0.35);
+  color: var(--color-text, #e4e4e4);
+  border-bottom-right-radius: 4px; /* iMessage-style "tail corner" */
 }
 
 .agent-detail__msg--assistant {
-  border-left-color: var(--color-link, #60a5fa);
+  align-self: flex-start;
+  background: var(--color-bg-secondary, #181818);
+  border: 1px solid var(--color-border, #2a2a2a);
+  color: var(--color-text, #e4e4e4);
+  border-bottom-left-radius: 4px;
 }
 
 .agent-detail__msg--thinking {
-  border-left-color: transparent;
+  align-self: flex-start;
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  padding: 4px 0 4px 8px;
   color: var(--color-text-secondary, #888);
   font-style: italic;
   font-size: 12px;
-  padding-left: 12px;
+  max-width: 100%;
 }
 
 .agent-detail__msg-toggle {
@@ -443,6 +453,16 @@
 .agent-detail__reply-hint {
   font-size: 11px;
   color: var(--color-text-secondary, #888);
+}
+
+.agent-detail__reply-actions {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.agent-detail__attach-btn {
+  font-size: 12px;
 }
 
 .agent-detail__loading,

--- a/src/styles/agents-tab.css
+++ b/src/styles/agents-tab.css
@@ -7,7 +7,7 @@
   overflow: auto;
 }
 
-.agents-tab--two-pane {
+.agents-tab--splits {
   flex-direction: row;
   gap: 0;
   padding: 0;
@@ -15,20 +15,68 @@
 }
 
 .agents-tab__list-pane {
-  flex: 1 1 0;
+  flex: 0 0 clamp(280px, 28%, 420px);
   min-width: 0;
   display: flex;
   flex-direction: column;
   gap: 12px;
-  padding: 20px 28px;
+  padding: 16px 20px;
   overflow: auto;
+  border-right: 1px solid var(--color-border, #2a2a2a);
 }
 
-.agents-tab__detail-pane {
-  flex: 1 1 0;
-  min-width: 380px;
-  max-width: 640px;
+/* ---- splits container (the right side, holds 1–4 detail panes) ---- */
+
+.agents-tab__panes {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+  display: grid;
+  gap: 1px;
+  background: var(--color-border, #2a2a2a);
   overflow: hidden;
+}
+
+.agents-tab__panes--n1 {
+  grid-template-columns: 1fr;
+}
+.agents-tab__panes--n2 {
+  grid-template-columns: 1fr 1fr;
+}
+.agents-tab__panes--n3 {
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr 1fr;
+}
+.agents-tab__panes--n3 .agents-tab__pane:nth-child(3) {
+  grid-column: 1 / -1; /* third pane spans the full bottom row */
+}
+.agents-tab__panes--n4 {
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr 1fr;
+}
+
+.agents-tab__pane {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  background: var(--color-bg, #111);
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+}
+
+.agents-tab__pane--focused {
+  outline-color: var(--color-accent, #60a5fa);
+}
+
+.agents-tab__hint {
+  margin-top: 12px;
+  font-size: 11px;
+  color: var(--color-text-secondary, #888);
+  padding: 6px 8px;
+  border-top: 1px solid var(--color-border, #2a2a2a);
 }
 
 .agents-tab__header {


### PR DESCRIPTION
Bundles four user-facing improvements as **v0.3.0**.

## 1. Multi-pane splits *(was the original PR scope — closes the "chat is 25 % of screen" complaint)*

Click rows to open up to 4 panes side-by-side: 1 / 2 / 2+1 / 2×2 grid. List pane shrinks to `clamp(280-420 px)` so a single open chat fills the rest of the window (~2100 px wide on a 27"). Each pane is independent — own poll, scroll, expansion, reply. Esc closes the focused pane; × per pane works too. Click an already-open agent → just focuses its pane. 5th open evicts the oldest.

## 2. Chat-bubble layout *(user ask)*

User messages right-aligned, assistant messages left-aligned, iMessage-style. Bubbles cap at `min(78 %, 640 px)` so they don't span the whole pane. "You / Assistant" labels dropped — alignment + color carry the speaker.

## 3. File attach button *(user ask)*

New **Attach** button next to Send. Opens the system file picker (multi-select); appends `[attached: <abs path>]` lines to the reply text. The agent uses its Read tool on the path.

**Why path-only, not bytes:** the daemon `/v1/agents/:id/reply` endpoint only accepts a string body. Real image embed needs a daemon API change — out of scope here. Works fine today for code, JSON, text, and images Claude can read off disk.

## 4. Proxy error reporting *(user-reported bug)*

You hit `Daemon request failed: error sending request for url (http://...)` trying to reply. The reqwest source chain was hidden by the format string. Now:
- Errors include the reqwest **error kind** (`timeout` / `connect` / `request` / `body` / `other`) and walk the full source chain. So instead of `error sending request for url (...)` you'll see `Daemon POST failed [connect]: ... → tcp connect error → Connection refused (os error 61)` and can actually diagnose it.
- **PROXY_TIMEOUT bumped 15 s → 30 s.** Reply endpoints can take a beat for the daemon to ack on slow tailnet links; was misreporting these as connect failures.

## Deferred (planning agent recommendations for v0.3.1)

A separate planning pass identified higher-leverage UX changes that would be a bigger refactor — filing as follow-ups, not bundled here:

- Collapsed pane header (single 24 px row) — reclaims ~80 px vertical per pane
- Auto-grow single-line reply box (drop the explicit Send button; `⌘↵` is the gesture)
- Cmd+Enter zoom (tmux-style — focused pane → 100 % width, list collapses to a top bar; Esc unzooms)
- Keyboard layer (Cmd+1-4 focus, Cmd+W close, Cmd+L list toggle, Cmd+P palette includes agents)
- Terminal-fy data surfaces (mono everywhere event-side, drop more border-radius, no emoji in UI)
- Status-bar hotkey hint that rotates by focus context

## Test plan
- [ ] Local: `pnpm typecheck` ✅, `pnpm lint` ✅, `pnpm format:check` ✅, `pnpm build` ✅, `cargo build --release` ✅
- [ ] CI green
- [ ] Smoke: open 4 different agents in panes, watch all 4 update independently
- [ ] Smoke: type a message → bubbles right; agent replies → bubbles left, no labels
- [ ] Smoke: click Attach, pick a file, the path appears in the textarea; send and the agent reads it
- [ ] Smoke: kill the daemon process and try to reply → error message names what failed (connect / timeout etc), not the opaque "Daemon request failed"