### PR TITLE
Collapsed single-line pane header (v0.3.1, closes #462)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "workroot"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["Saurav Panda <saurav@workroot.dev>"]
 description = "A local-first developer workspace for managing projects, terminals, and Git workflows."

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/components/AgentDetailPane.tsx
+++ b/src/components/AgentDetailPane.tsx
@@ -6,7 +6,9 @@ import {
   useRef,
   useState,
 } from "react";
+import * as Popover from "@radix-ui/react-popover";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
+import { open as openShell } from "@tauri-apps/plugin-shell";
 import { useAgentDetail } from "../hooks/useAgentDetail";
 import { clientFor, type ThreadEvent, type Turn } from "../lib/helm-api";
 import "../styles/agent-detail.css";
@@ -517,6 +519,22 @@ export function AgentDetailPane({
     }
   };
 
+  const copyText = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch (e) {
+      setActionError(`Copy failed: ${e}`);
+    }
+  };
+
+  const openPath = async (path: string) => {
+    try {
+      await openShell(path);
+    } catch (e) {
+      setActionError(`Open failed: ${e}`);
+    }
+  };
+
   const remove = async () => {
     if (!machine || !detail) return;
     if (
@@ -547,56 +565,131 @@ export function AgentDetailPane({
 
   return (
     <aside className="agent-detail">
-      <div className="agent-detail__header">
-        <div className="agent-detail__title-row">
-          <h3 className="agent-detail__title">{detail?.name ?? "Loading…"}</h3>
-          <button
-            className="agent-detail__close"
-            onClick={onClose}
-            aria-label="Close detail pane"
-          >
-            ×
-          </button>
-        </div>
+      <header className="agent-detail__header">
         {detail && (
-          <div className="agent-detail__meta">
+          <span
+            className={`agent-detail__state-pill agent-detail__state-pill--${detail.state}`}
+            title={detail.state}
+          >
+            {detail.state}
+          </span>
+        )}
+        <span className="agent-detail__name" title={detail?.name ?? undefined}>
+          {detail?.name ?? "Loading…"}
+        </span>
+        {detail && (
+          <>
+            <span className="agent-detail__sep">·</span>
             <span
-              className={`agent-detail__state-pill agent-detail__state-pill--${detail.state}`}
+              className="agent-detail__crumb"
+              title={`${detail.repo}:${detail.branch}`}
             >
-              {detail.state}
+              {detail.repo}:{detail.branch}
             </span>
-            <span className="agent-detail__meta-item">
+            <span className="agent-detail__sep">@</span>
+            <span
+              className="agent-detail__crumb"
+              title={machine?.label ?? detail.machine_name}
+            >
               {machine?.label ?? detail.machine_name}
             </span>
-            <span className="agent-detail__meta-item">{detail.repo}</span>
-            <span className="agent-detail__meta-item">{detail.branch}</span>
-          </div>
+          </>
         )}
+        <span className="agent-detail__spacer" />
         {detail && (
-          <div className="agent-detail__actions">
-            <button
-              className="agent-detail__action-btn"
-              onClick={() => void kill()}
-              disabled={isTerminal || busy !== null}
-              title={isTerminal ? "Agent already finished" : "Kill agent"}
-            >
-              {busy === "kill" ? "Killing…" : "Kill"}
-            </button>
-            <button
-              className="agent-detail__action-btn agent-detail__action-btn--danger"
-              onClick={() => void remove()}
-              disabled={!isTerminal || busy !== null}
-              title={
-                isTerminal
-                  ? "Delete agent"
-                  : "Kill the agent before deleting (daemon refuses delete on running agents)"
-              }
-            >
-              {busy === "delete" ? "Deleting…" : "Delete"}
-            </button>
-          </div>
+          <Popover.Root>
+            <Popover.Trigger asChild>
+              <button
+                className="agent-detail__icon-btn"
+                aria-label="More actions"
+                title="More actions"
+              >
+                ⋯
+              </button>
+            </Popover.Trigger>
+            <Popover.Portal>
+              <Popover.Content
+                className="agent-detail__menu"
+                sideOffset={4}
+                align="end"
+              >
+                <button
+                  type="button"
+                  className="agent-detail__menu-item"
+                  onClick={() => void kill()}
+                  disabled={isTerminal || busy !== null}
+                >
+                  {busy === "kill" ? "Killing…" : "Kill"}
+                </button>
+                <button
+                  type="button"
+                  className="agent-detail__menu-item agent-detail__menu-item--danger"
+                  onClick={() => void remove()}
+                  disabled={!isTerminal || busy !== null}
+                  title={
+                    isTerminal
+                      ? "Delete agent"
+                      : "Kill the agent before deleting"
+                  }
+                >
+                  {busy === "delete" ? "Deleting…" : "Delete"}
+                </button>
+                <div className="agent-detail__menu-sep" />
+                <button
+                  type="button"
+                  className="agent-detail__menu-item"
+                  onClick={() => void copyText(detail.id)}
+                >
+                  Copy agent ID
+                </button>
+                {detail.worktree_path && (
+                  <>
+                    <button
+                      type="button"
+                      className="agent-detail__menu-item"
+                      onClick={() => void copyText(detail.worktree_path)}
+                    >
+                      Copy worktree path
+                    </button>
+                    <button
+                      type="button"
+                      className="agent-detail__menu-item"
+                      onClick={() => void openPath(detail.worktree_path)}
+                    >
+                      Open worktree in Finder
+                    </button>
+                  </>
+                )}
+                {detail.pr_url && (
+                  <button
+                    type="button"
+                    className="agent-detail__menu-item"
+                    onClick={() => void openPath(detail.pr_url!)}
+                  >
+                    Open PR
+                  </button>
+                )}
+                <div className="agent-detail__menu-sep" />
+                <button
+                  type="button"
+                  className="agent-detail__menu-item"
+                  onClick={() => refresh()}
+                >
+                  Refresh
+                </button>
+              </Popover.Content>
+            </Popover.Portal>
+          </Popover.Root>
         )}
-      </div>
+        <button
+          className="agent-detail__icon-btn"
+          onClick={onClose}
+          aria-label="Close pane"
+          title="Close pane"
+        >
+          ×
+        </button>
+      </header>
 
       {actionError && <p className="agent-detail__error">{actionError}</p>}
       {error && <p className="agent-detail__error">{error}</p>}

--- a/src/styles/agent-detail.css
+++ b/src/styles/agent-detail.css
@@ -11,46 +11,112 @@
   background: var(--color-bg, #111);
 }
 
+/* Single-row pane header: state pill · name · repo:branch @ machine · ⋯ · ×.
+ * Reclaims vertical space for the transcript at 4 panes open. Action
+ * buttons (Kill/Delete/Copy/Open) live in the ⋯ popover. */
 .agent-detail__header {
   display: flex;
-  flex-direction: column;
-  gap: 6px;
-  padding-bottom: 12px;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 6px 6px 6px;
   border-bottom: 1px solid var(--color-border, #2a2a2a);
+  font-size: 12px;
+  flex: 0 0 auto;
+  min-height: 28px;
+  min-width: 0;
+}
+
+.agent-detail__name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text, #e4e4e4);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 0 1 auto;
+  min-width: 0;
+}
+
+.agent-detail__sep {
+  color: var(--color-text-secondary, #555);
   flex: 0 0 auto;
 }
 
-.agent-detail__title-row {
-  display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-  gap: 12px;
-}
-
-.agent-detail__title {
-  margin: 0;
-  font-size: 16px;
-  font-weight: 600;
-}
-
-.agent-detail__close {
-  background: transparent;
-  border: none;
-  color: var(--color-text-secondary, #888);
-  cursor: pointer;
-  font-size: 18px;
-}
-
-.agent-detail__meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px 12px;
+.agent-detail__crumb {
+  font-family: var(--font-mono, monospace);
   font-size: 11px;
   color: var(--color-text-secondary, #888);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 0 1 auto;
+  min-width: 0;
 }
 
-.agent-detail__meta-item {
-  font-family: var(--font-mono, monospace);
+.agent-detail__spacer {
+  flex: 1 1 auto;
+}
+
+.agent-detail__icon-btn {
+  background: transparent;
+  border: none;
+  color: var(--color-text-secondary, #aaa);
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  padding: 4px 8px;
+  border-radius: 4px;
+  flex: 0 0 auto;
+}
+
+.agent-detail__icon-btn:hover {
+  background: var(--color-bg-hover, #222);
+  color: var(--color-text, #e4e4e4);
+}
+
+/* ---- ⋯ popover menu ---- */
+
+.agent-detail__menu {
+  display: flex;
+  flex-direction: column;
+  min-width: 200px;
+  padding: 4px;
+  background: var(--color-bg-secondary, #181818);
+  border: 1px solid var(--color-border, #2a2a2a);
+  border-radius: 6px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+}
+
+.agent-detail__menu-item {
+  text-align: left;
+  background: transparent;
+  border: none;
+  color: var(--color-text, #e4e4e4);
+  padding: 6px 10px;
+  font-size: 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  font: inherit;
+}
+
+.agent-detail__menu-item:hover:not(:disabled) {
+  background: var(--color-bg-hover, #222);
+}
+
+.agent-detail__menu-item:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.agent-detail__menu-item--danger {
+  color: var(--color-danger, #f87171);
+}
+
+.agent-detail__menu-sep {
+  height: 1px;
+  background: var(--color-border, #2a2a2a);
+  margin: 4px 0;
 }
 
 .agent-detail__state-pill {


### PR DESCRIPTION
First of the 8 v0.3.1 UX issues. Closes #462.

## What

Collapses the multi-row `AgentDetailPane` header to one ~28 px row:

```
[state] name · repo:branch @ machine                              ⋯  ×
```

Reclaims ~80 px of vertical space per pane — biggest win is at 4 panes open.

## Header anatomy
- **State pill** — same colored treatment as before, kept load-bearing for attention scanning
- **Name** — bold, primary
- **`·` separator** then **`repo:branch`** in mono-dim
- **`@` separator** then **machine label** in mono-dim
- All cells truncate with ellipsis as needed; everything fits on one line down to ~280 px wide

## ⋯ popover (replaces explicit Kill/Delete buttons)
Anchored to the header right side via Radix Popover (matches `ProfileSelector` pattern):

- **Kill** — disabled when terminal
- **Delete** — disabled when not terminal, colored red
- *(separator)*
- **Copy agent ID** — `navigator.clipboard.writeText`
- **Copy worktree path**
- **Open worktree in Finder** — `@tauri-apps/plugin-shell.open(path)`
- **Open PR** — when `pr_url` exists
- *(separator)*
- **Refresh** — re-runs `useAgentDetail` fetch

Destructive items (Kill, Delete) keep their existing `confirm()` prompts.

## Trade-off

Kill / Delete go from 1 click to 2 (open menu → click). Acceptable: they're destructive + infrequent, and at 4 panes open the cramped 1-click buttons were a misclick risk anyway.

## Test plan
- [ ] Local: `pnpm typecheck` ✅, `pnpm lint` ✅, `pnpm format:check` ✅, `pnpm build` ✅, `cargo update -p workroot` ✅
- [ ] CI green
- [ ] Smoke: header is one row, ~28 px tall
- [ ] Smoke: ⋯ menu opens, all items present, Kill/Delete enable/disable correctly based on state
- [ ] Smoke: "Open worktree in Finder" actually opens Finder at the worktree path
- [ ] Smoke: at 4 panes open, more transcript fits per pane than before