### PR TITLE
Auto-grow single-line reply box (closes #463)

### DIFF
--- a/src/components/AgentDetailPane.tsx
+++ b/src/components/AgentDetailPane.tsx
@@ -357,6 +357,21 @@ export function AgentDetailPane({
   const [busy, setBusy] = useState<"reply" | "kill" | "delete" | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
 
+  // Auto-grow the reply textarea: starts at one line, grows to fit
+  // content up to a 160 px ceiling, then scrolls inside. Avoids the
+  // ~80 px reply box dominating each pane at the 4-pane grid.
+  const replyRef = useRef<HTMLTextAreaElement>(null);
+  const autoGrowReply = useCallback(() => {
+    const el = replyRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${Math.min(160, el.scrollHeight)}px`;
+  }, []);
+
+  useEffect(() => {
+    autoGrowReply();
+  }, [reply, autoGrowReply]);
+
   // Per-item expansion state. Keyed by the stable RenderItem.key so a 3 s
   // poll re-render doesn't wipe what the user has open.
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
@@ -798,7 +813,9 @@ export function AgentDetailPane({
       {canReply && (
         <div className="agent-detail__reply">
           <textarea
+            ref={replyRef}
             value={reply}
+            rows={1}
             onChange={(e) => setReply(e.target.value)}
             onKeyDown={(e) => {
               if (
@@ -811,33 +828,24 @@ export function AgentDetailPane({
               }
             }}
             placeholder={
-              isTerminal ? "Reply to resume the agent…" : "Reply to the agent…"
+              busy === "reply"
+                ? "Sending…"
+                : isTerminal
+                  ? "Reply to resume the agent…  (⌘↵)"
+                  : "Reply to the agent…  (⌘↵)"
             }
             disabled={busy !== null}
           />
-          <div className="agent-detail__reply-row">
-            <span className="agent-detail__reply-hint">
-              ⌘/Ctrl + Enter to send
-            </span>
-            <div className="agent-detail__reply-actions">
-              <button
-                type="button"
-                className="agent-detail__action-btn agent-detail__attach-btn"
-                onClick={() => void attachFiles()}
-                disabled={busy !== null}
-                title="Attach a file — its absolute path is appended so the agent can Read it"
-              >
-                Attach
-              </button>
-              <button
-                className="agent-detail__action-btn"
-                onClick={() => void sendReply()}
-                disabled={!reply.trim() || busy !== null}
-              >
-                {busy === "reply" ? "Sending…" : "Send"}
-              </button>
-            </div>
-          </div>
+          <button
+            type="button"
+            className="agent-detail__attach-icon"
+            onClick={() => void attachFiles()}
+            disabled={busy !== null}
+            aria-label="Attach a file"
+            title="Attach a file — its absolute path is appended so the agent can Read it"
+          >
+            +
+          </button>
         </div>
       )}
     </aside>

--- a/src/styles/agent-detail.css
+++ b/src/styles/agent-detail.css
@@ -486,10 +486,12 @@
   border-color: var(--color-danger, #f87171);
 }
 
+/* Single-line auto-growing reply. The textarea starts at one line,
+ * grows to fit content up to 160 px (set inline by autoGrowReply),
+ * then scrolls inside. The "+" attach button sits inline in the
+ * bottom-right corner — no separate Send button (⌘+Enter sends). */
 .agent-detail__reply {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
+  position: relative;
   padding-top: 8px;
   border-top: 1px solid var(--color-border, #2a2a2a);
   flex: 0 0 auto;
@@ -497,38 +499,55 @@
 
 .agent-detail__reply textarea {
   width: 100%;
-  min-height: 64px;
-  resize: vertical;
-  padding: 8px 10px;
+  min-height: 28px;
+  max-height: 160px;
+  resize: none;
+  padding: 6px 36px 6px 10px; /* right padding leaves room for the + */
   font-size: 13px;
   font-family: inherit;
+  line-height: 1.4;
   border: 1px solid var(--color-border, #2a2a2a);
   border-radius: 4px;
   background: var(--color-bg-secondary, #181818);
   color: var(--color-text, #e4e4e4);
   box-sizing: border-box;
+  overflow-y: auto;
+  display: block;
 }
 
-.agent-detail__reply-row {
-  display: flex;
-  justify-content: space-between;
+.agent-detail__reply textarea:focus {
+  outline: none;
+  border-color: var(--color-accent, #60a5fa);
+}
+
+.agent-detail__attach-icon {
+  position: absolute;
+  right: 6px;
+  bottom: 6px;
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
   align-items: center;
-  gap: 8px;
+  justify-content: center;
+  background: transparent;
+  border: 1px solid var(--color-border, #2a2a2a);
+  border-radius: 4px;
+  color: var(--color-text-secondary, #aaa);
+  cursor: pointer;
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 1;
+  padding: 0;
 }
 
-.agent-detail__reply-hint {
-  font-size: 11px;
-  color: var(--color-text-secondary, #888);
+.agent-detail__attach-icon:hover:not(:disabled) {
+  background: var(--color-bg-hover, #222);
+  color: var(--color-text, #e4e4e4);
 }
 
-.agent-detail__reply-actions {
-  display: flex;
-  gap: 6px;
-  align-items: center;
-}
-
-.agent-detail__attach-btn {
-  font-size: 12px;
+.agent-detail__attach-icon:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
 .agent-detail__loading,


### PR DESCRIPTION
Second of the v0.3.1 batch. Closes #463.

## What

Replaces the 80 px multi-row reply block with a single-line, auto-growing textarea. Drops the visible Send button — `⌘+Enter` is the gesture, the placeholder teaches it.

## Reply textarea

- `rows={1}`, `min-height: 28 px`, `max-height: 160 px`
- Auto-grows on content via a `useEffect` that sets `height` from `scrollHeight` (capped at 160)
- Placeholder includes the keyboard hint:
  - `"Reply to the agent…  (⌘↵)"`
  - `"Reply to resume the agent…  (⌘↵)"` when terminal
  - `"Sending…"` when busy
- Right padding leaves a 30 px gutter for the inline `+` button
- Focused border highlights in accent

## Attach as inline icon

- Dropped the separate "Attach" button + reply-row + reply-hint + reply-actions
- `+` 24 × 24 button anchored absolute in the bottom-right corner of the textarea wrapper
- Same behavior: opens the system file picker (multi-select) and appends `[attached: <abs path>]` lines

## No version bump in this PR

Bundling with #462 (collapsed header, already merged) into the next v0.3.1 tag once a couple more land.

## Test plan
- [ ] Local: typecheck ✅, lint ✅, format ✅, build ✅
- [ ] CI green
- [ ] Smoke: empty reply box is one line tall
- [ ] Smoke: type a long message, the box grows up to ~160 px then scrolls inside
- [ ] Smoke: ⌘+Enter sends; `+` opens picker; selected paths append to text