### PR TITLE
Draggable splits + Ghostty palette (v0.4.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.3.1",
+  "version": "0.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "workroot"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 authors = ["Saurav Panda <saurav@workroot.dev>"]
 description = "A local-first developer workspace for managing projects, terminals, and Git workflows."

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/components/AgentDetailPane.tsx
+++ b/src/components/AgentDetailPane.tsx
@@ -619,7 +619,7 @@ export function AgentDetailPane({
                 aria-label="More actions"
                 title="More actions"
               >
-                ⋯
+                [&hellip;]
               </button>
             </Popover.Trigger>
             <Popover.Portal>
@@ -702,7 +702,7 @@ export function AgentDetailPane({
           aria-label="Close pane"
           title="Close pane"
         >
-          ×
+          [x]
         </button>
       </header>
 

--- a/src/components/AgentsTab.tsx
+++ b/src/components/AgentsTab.tsx
@@ -57,6 +57,56 @@ function lastSeenPhrase(iso: string | null): string {
   return ` — last seen ${ago} ago`;
 }
 
+// Draggable splitter between two panes. `direction: 'vertical'` means
+// the bar runs vertically — it sits between left/right panes and resizes
+// their widths (cursor: col-resize). `'horizontal'` is the opposite: a
+// horizontal bar between top/bottom panes (cursor: row-resize).
+//
+// `ratio` is the size fraction of the *first* sibling (0..1). The drag
+// computes a new ratio from the parent's current size and forwards it
+// to the parent via onChange.
+function Divider({
+  direction,
+  ratio,
+  onChange,
+}: {
+  direction: "vertical" | "horizontal";
+  ratio: number;
+  onChange: (next: number) => void;
+}) {
+  const onPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.currentTarget.setPointerCapture(e.pointerId);
+    const parent = e.currentTarget.parentElement;
+    if (!parent) return;
+    const total =
+      direction === "vertical" ? parent.offsetWidth : parent.offsetHeight;
+    if (total <= 0) return;
+    const startPos = direction === "vertical" ? e.clientX : e.clientY;
+    const startRatio = ratio;
+    const onMove = (ev: PointerEvent) => {
+      const cur = direction === "vertical" ? ev.clientX : ev.clientY;
+      const delta = cur - startPos;
+      const next = Math.max(0.15, Math.min(0.85, startRatio + delta / total));
+      onChange(next);
+    };
+    const onUp = () => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+    };
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+  };
+  return (
+    <div
+      className={`agents-tab__divider agents-tab__divider--${direction}`}
+      onPointerDown={onPointerDown}
+      role="separator"
+      aria-orientation={direction === "vertical" ? "vertical" : "horizontal"}
+    />
+  );
+}
+
 function OfflineBanner({
   status,
   onOpenMachines,
@@ -98,6 +148,21 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
   const { agents, machines, loading, refresh } = useAllAgents();
   const [panes, setPanes] = useState<Pane[]>([]);
   const [focusedPaneId, setFocusedPaneId] = useState<number | null>(null);
+  // Split ratios (0..1) — first sibling fraction. The fixed-grid model
+  // is gone; layouts are now flex with draggable dividers between any
+  // two adjacent panes. We track three ratios because n=4 has two
+  // horizontal cuts (top row, bottom row) plus one vertical cut.
+  const [ratios, setRatios] = useState({
+    twoCol: 0.5, // n=2: single vertical divider
+    vertical: 0.5, // n=3, n=4: top/bottom horizontal divider
+    topRow: 0.5, // n=3, n=4: vertical divider in top row
+    botRow: 0.5, // n=4: vertical divider in bottom row
+  });
+  const setRatio = useCallback(
+    (key: keyof typeof ratios, value: number) =>
+      setRatios((prev) => ({ ...prev, [key]: value })),
+    [],
+  );
   const [now, setNow] = useState<number>(() => Date.now());
   const paneIdRef = useRef(1);
 
@@ -327,8 +392,8 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
 
       {splitView && (
         <div className="agents-tab__hint">
-          {panes.length} of {MAX_PANES} panes open · click a row to open another
-          · Esc closes the focused pane
+          {panes.length} of {MAX_PANES} · click row to open · drag dividers to
+          resize · Esc closes focused
         </div>
       )}
     </>
@@ -338,32 +403,120 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
     return <div className="agents-tab">{list}</div>;
   }
 
+  // Render a leaf pane (the AgentDetailPane wrapped in the focus/click
+  // chrome). Pulled out so the n=1..4 layout code below stays readable.
+  const leaf = (p: Pane, basis?: number) => {
+    const focused = focusedPaneId === p.paneId;
+    return (
+      <div
+        key={p.paneId}
+        className={
+          focused
+            ? "agents-tab__pane agents-tab__pane--focused"
+            : "agents-tab__pane"
+        }
+        style={
+          basis !== undefined ? { flexBasis: `${basis * 100}%` } : undefined
+        }
+        onClick={() => setFocusedPaneId(p.paneId)}
+        onFocus={() => setFocusedPaneId(p.paneId)}
+      >
+        <AgentDetailPane
+          machineId={p.machineId}
+          agentId={p.agentId}
+          onClose={() => closePane(p.paneId)}
+          onDeleted={() => closePane(p.paneId)}
+        />
+      </div>
+    );
+  };
+
+  let panesNode: React.ReactNode;
+  if (panes.length === 1) {
+    panesNode = leaf(panes[0]);
+  } else if (panes.length === 2) {
+    panesNode = (
+      <>
+        {leaf(panes[0], ratios.twoCol)}
+        <Divider
+          direction="vertical"
+          ratio={ratios.twoCol}
+          onChange={(n) => setRatio("twoCol", n)}
+        />
+        {leaf(panes[1], 1 - ratios.twoCol)}
+      </>
+    );
+  } else if (panes.length === 3) {
+    // Top row: panes[0] | panes[1]; bottom row spans: panes[2].
+    panesNode = (
+      <>
+        <div
+          className="agents-tab__split-row"
+          style={{ flexBasis: `${ratios.vertical * 100}%` }}
+        >
+          {leaf(panes[0], ratios.topRow)}
+          <Divider
+            direction="vertical"
+            ratio={ratios.topRow}
+            onChange={(n) => setRatio("topRow", n)}
+          />
+          {leaf(panes[1], 1 - ratios.topRow)}
+        </div>
+        <Divider
+          direction="horizontal"
+          ratio={ratios.vertical}
+          onChange={(n) => setRatio("vertical", n)}
+        />
+        <div
+          className="agents-tab__split-row"
+          style={{ flexBasis: `${(1 - ratios.vertical) * 100}%` }}
+        >
+          {leaf(panes[2], 1)}
+        </div>
+      </>
+    );
+  } else {
+    // 4 panes: 2×2.
+    panesNode = (
+      <>
+        <div
+          className="agents-tab__split-row"
+          style={{ flexBasis: `${ratios.vertical * 100}%` }}
+        >
+          {leaf(panes[0], ratios.topRow)}
+          <Divider
+            direction="vertical"
+            ratio={ratios.topRow}
+            onChange={(n) => setRatio("topRow", n)}
+          />
+          {leaf(panes[1], 1 - ratios.topRow)}
+        </div>
+        <Divider
+          direction="horizontal"
+          ratio={ratios.vertical}
+          onChange={(n) => setRatio("vertical", n)}
+        />
+        <div
+          className="agents-tab__split-row"
+          style={{ flexBasis: `${(1 - ratios.vertical) * 100}%` }}
+        >
+          {leaf(panes[2], ratios.botRow)}
+          <Divider
+            direction="vertical"
+            ratio={ratios.botRow}
+            onChange={(n) => setRatio("botRow", n)}
+          />
+          {leaf(panes[3], 1 - ratios.botRow)}
+        </div>
+      </>
+    );
+  }
+
   return (
     <div className="agents-tab agents-tab--splits">
       <div className="agents-tab__list-pane">{list}</div>
       <div className={`agents-tab__panes agents-tab__panes--n${panes.length}`}>
-        {panes.map((p) => {
-          const focused = focusedPaneId === p.paneId;
-          return (
-            <div
-              key={p.paneId}
-              className={
-                focused
-                  ? "agents-tab__pane agents-tab__pane--focused"
-                  : "agents-tab__pane"
-              }
-              onClick={() => setFocusedPaneId(p.paneId)}
-              onFocus={() => setFocusedPaneId(p.paneId)}
-            >
-              <AgentDetailPane
-                machineId={p.machineId}
-                agentId={p.agentId}
-                onClose={() => closePane(p.paneId)}
-                onDeleted={() => closePane(p.paneId)}
-              />
-            </div>
-          );
-        })}
+        {panesNode}
       </div>
     </div>
   );

--- a/src/styles.css
+++ b/src/styles.css
@@ -10,30 +10,41 @@
    ========================================================== */
 
 @theme {
-  --color-bg-base: #0c0c0e;
-  --color-bg-surface: #131316;
-  --color-bg-elevated: #1b1b1f;
-  --color-bg-hover: #242429;
+  /* Desaturated dark palette (Ghostty-inspired). Cooler grays with a
+   * subtle blue tint, accents pulled back from full Tailwind saturation
+   * so the UI reads calm instead of alarmed. */
+  --color-bg-base: #0d1014;
+  --color-bg-surface: #14181d;
+  --color-bg-elevated: #1a1f25;
+  --color-bg-hover: #1f252c;
+  --color-bg-pane: #0a0c0f; /* pane interior — darker than surrounding chrome */
 
-  --color-border-subtle: #1f1f24;
-  --color-border-default: #2a2a30;
-  --color-border-strong: #3a3a42;
+  --color-border-subtle: #1f252c;
+  --color-border-default: #2b333c;
+  --color-border-strong: #3a4453; /* visible dividers between panes */
 
-  --color-text-primary: #ededef;
-  --color-text-secondary: #8e8e96;
-  --color-text-muted: #5c5c66;
+  --color-text-primary: #d4d8de; /* warm gray, not pure white */
+  --color-text-secondary: #7c8693;
+  --color-text-muted: #4a525c;
 
-  --color-accent: #10b981;
-  --color-accent-hover: #34d399;
-  --color-accent-muted: rgba(16, 185, 129, 0.12);
+  --color-accent: #88b4ff; /* desat periwinkle, was emerald */
+  --color-accent-hover: #a5c4ff;
+  --color-accent-muted: rgba(136, 180, 255, 0.14);
 
-  --color-danger: #ef4444;
-  --color-danger-muted: rgba(239, 68, 68, 0.12);
-  --color-warning: #f59e0b;
-  --color-success: #22c55e;
+  --color-danger: #e08585;
+  --color-danger-muted: rgba(224, 133, 133, 0.14);
+  --color-warning: #d4a76a;
+  --color-success: #7ec699;
 
-  --font-sans: "Geist", system-ui, -apple-system, sans-serif;
-  --font-mono: "JetBrains Mono", "Menlo", "Monaco", monospace;
+  /* Aliases the agent surfaces have been using via fallback — make them
+   * real so they pick up the desaturated palette. */
+  --color-bg: var(--color-bg-base);
+  --color-text: var(--color-text-primary);
+  --color-border: var(--color-border-default);
+  --color-link: var(--color-accent);
+
+  --font-sans: "Inter", "Geist", system-ui, -apple-system, sans-serif;
+  --font-mono: "JetBrains Mono", "SF Mono", "Menlo", "Cascadia Code", monospace;
 
   --radius-sm: 4px;
   --radius-md: 6px;
@@ -41,37 +52,40 @@
 }
 
 :root {
-  /* Background layers (darkest → lightest) */
-  --bg-base: #0c0c0e;
-  --bg-surface: #131316;
-  --bg-elevated: #1b1b1f;
-  --bg-hover: #242429;
+  /* Background layers (darkest → lightest) — kept in sync with @theme.
+   * The duplicate exists because Tailwind 4's @theme block isn't visible
+   * to plain CSS files; non-utility surfaces read from these. */
+  --bg-base: #0d1014;
+  --bg-surface: #14181d;
+  --bg-elevated: #1a1f25;
+  --bg-hover: #1f252c;
+  --bg-pane: #0a0c0f;
 
   /* Borders */
-  --border-subtle: #1f1f24;
-  --border: #2a2a30;
-  --border-strong: #3a3a42;
+  --border-subtle: #1f252c;
+  --border: #2b333c;
+  --border-strong: #3a4453;
 
   /* Text */
-  --text-primary: #ededef;
-  --text-secondary: #8e8e96;
-  --text-muted: #5c5c66;
+  --text-primary: #d4d8de;
+  --text-secondary: #7c8693;
+  --text-muted: #4a525c;
 
   /* Accent */
-  --accent: #10b981;
-  --accent-hover: #34d399;
-  --accent-muted: rgba(16, 185, 129, 0.12);
-  --accent-glow: rgba(16, 185, 129, 0.25);
+  --accent: #88b4ff;
+  --accent-hover: #a5c4ff;
+  --accent-muted: rgba(136, 180, 255, 0.14);
+  --accent-glow: rgba(136, 180, 255, 0.22);
 
   /* Semantic */
-  --danger: #ef4444;
-  --danger-muted: rgba(239, 68, 68, 0.12);
-  --warning: #f59e0b;
-  --success: #22c55e;
+  --danger: #e08585;
+  --danger-muted: rgba(224, 133, 133, 0.14);
+  --warning: #d4a76a;
+  --success: #7ec699;
 
   /* Typography */
-  --font-sans: "Geist", system-ui, -apple-system, sans-serif;
-  --font-mono: "JetBrains Mono", "Menlo", "Monaco", monospace;
+  --font-sans: "Inter", "Geist", system-ui, -apple-system, sans-serif;
+  --font-mono: "JetBrains Mono", "SF Mono", "Menlo", "Cascadia Code", monospace;
 
   /* Radii */
   --radius-sm: 4px;

--- a/src/styles/agent-detail.css
+++ b/src/styles/agent-detail.css
@@ -2,15 +2,16 @@
  * scrolls. That's what makes sticky-bottom auto-scroll work — header,
  * usage row, and reply box stay parked while transcript flows below. */
 /* Pane interior is darker than the surrounding chrome so it reads as a
- * "terminal surface". List pane keeps the lighter chrome bg. */
+ * "terminal surface". List pane keeps the lighter chrome bg. Tighter
+ * paddings than v0.3.1 — Ghostty cells start at ~6-8px from the edge. */
 .agent-detail {
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  padding: 12px 16px;
+  gap: 8px;
+  padding: 8px 10px;
   height: 100%;
   overflow: hidden;
-  background: #0a0a0a;
+  background: var(--bg-pane, #0a0c0f);
 }
 
 /* Single-row pane header: state pill · name · repo:branch @ machine · ⋯ · ×.
@@ -20,16 +21,17 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 4px 6px 6px 6px;
+  padding: 2px 4px 4px 4px;
   border-bottom: 1px solid var(--color-border, #2a2a2a);
   font-size: 12px;
   flex: 0 0 auto;
-  min-height: 28px;
   min-width: 0;
 }
 
+/* Mono on the agent name — it's an identifier, not prose. */
 .agent-detail__name {
-  font-size: 13px;
+  font-family: var(--font-mono, monospace);
+  font-size: 12px;
   font-weight: 600;
   color: var(--color-text, #e4e4e4);
   white-space: nowrap;
@@ -269,16 +271,14 @@
 
 /* ---- messages (user / assistant / thinking) ---- */
 
-/* Chat alignment — user right, assistant left. Bubble chrome is dialed
- * down (smaller radius, tighter padding) and the body uses mono so the
- * transcript reads as terminal output. Alignment + color carry the role. */
+/* Per the Ghostty rethink: assistant messages are bare left-aligned
+ * mono text — no bubble, no chrome — so the transcript reads like
+ * a terminal log. User messages keep a *very* subtle bubble so you
+ * can still tell turn-from-turn at a glance. */
 .agent-detail__msg {
   display: flex;
   flex-direction: column;
-  padding: 6px 10px;
   font-size: 12px;
-  max-width: min(78%, 640px);
-  border-radius: 4px;
   word-break: break-word;
 }
 
@@ -291,28 +291,27 @@
 
 .agent-detail__msg--user {
   align-self: flex-end;
-  background: rgba(96, 165, 250, 0.14);
-  border: 1px solid rgba(96, 165, 250, 0.3);
+  max-width: min(78%, 640px);
+  padding: 4px 8px;
+  background: var(--color-accent-muted, rgba(136, 180, 255, 0.14));
+  border-left: 2px solid var(--color-accent, #88b4ff);
   color: var(--color-text, #e4e4e4);
 }
 
 .agent-detail__msg--assistant {
-  align-self: flex-start;
-  background: var(--color-bg-secondary, #181818);
-  border: 1px solid var(--color-border, #2a2a2a);
+  align-self: stretch;
+  padding: 0 0 0 4px;
+  background: transparent;
+  border: none;
   color: var(--color-text, #e4e4e4);
 }
 
 .agent-detail__msg--thinking {
-  align-self: flex-start;
-  background: transparent;
-  border: none;
-  border-radius: 0;
-  padding: 2px 0 2px 8px;
-  color: var(--color-text-secondary, #888);
+  align-self: stretch;
+  padding: 0 0 0 4px;
+  color: var(--color-text-muted, #5c5c66);
   font-style: italic;
   font-size: 11px;
-  max-width: 100%;
 }
 
 .agent-detail__msg-toggle {

--- a/src/styles/agents-tab.css
+++ b/src/styles/agents-tab.css
@@ -25,50 +25,96 @@
   border-right: 1px solid var(--color-border, #2a2a2a);
 }
 
-/* ---- splits container (the right side, holds 1–4 detail panes) ---- */
-
+/* ---- splits container — flex with draggable dividers ----
+ * Was a fixed CSS grid; replaced with flex so each pair of adjacent
+ * panes gets a real visible divider you can grab. Topology is still
+ * hardcoded for n=2/3/4 but the divider lives between the actual flex
+ * children (no more "1px gap" trick that you can't grab). */
 .agents-tab__panes {
   flex: 1 1 auto;
   min-width: 0;
   min-height: 0;
-  display: grid;
-  gap: 1px;
-  background: var(--color-border, #2a2a2a);
+  display: flex;
+  flex-direction: column; /* outer container stacks rows for n=3/4 */
+  background: var(--bg-pane, #0a0c0f);
   overflow: hidden;
 }
 
-.agents-tab__panes--n1 {
-  grid-template-columns: 1fr;
-}
+/* Single pane and 2-pane layouts run as a single row. */
+.agents-tab__panes--n1,
 .agents-tab__panes--n2 {
-  grid-template-columns: 1fr 1fr;
+  flex-direction: row;
 }
-.agents-tab__panes--n3 {
-  grid-template-columns: 1fr 1fr;
-  grid-template-rows: 1fr 1fr;
-}
-.agents-tab__panes--n3 .agents-tab__pane:nth-child(3) {
-  grid-column: 1 / -1; /* third pane spans the full bottom row */
-}
-.agents-tab__panes--n4 {
-  grid-template-columns: 1fr 1fr;
-  grid-template-rows: 1fr 1fr;
+
+/* A row of panes (used inside n=3 / n=4 to split top vs bottom). */
+.agents-tab__split-row {
+  display: flex;
+  flex-direction: row;
+  flex: 0 0 auto;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
 }
 
 .agents-tab__pane {
   position: relative;
   display: flex;
   flex-direction: column;
+  flex: 1 1 0;
   min-width: 0;
   min-height: 0;
   overflow: hidden;
-  background: var(--color-bg, #111);
-  outline: 2px solid transparent;
-  outline-offset: -2px;
+  background: var(--bg-pane, #0a0c0f);
 }
 
+/* Focus affordance is a subtle inset 1 px rule, not a 2 px outline ring.
+ * Closer to Ghostty's "the active pane just looks slightly brighter". */
 .agents-tab__pane--focused {
-  outline-color: var(--color-accent, #60a5fa);
+  box-shadow: inset 0 0 0 1px
+    var(--color-accent-muted, rgba(136, 180, 255, 0.3));
+}
+
+/* Draggable divider between two panes. 6 px hit area, 2 px visible bar
+ * centered. Hover/active brighten the bar so you can see what you're
+ * grabbing. */
+.agents-tab__divider {
+  flex: 0 0 6px;
+  position: relative;
+  background: transparent;
+  z-index: 1;
+}
+
+.agents-tab__divider::before {
+  content: "";
+  position: absolute;
+  background: var(--border-strong, #3a4453);
+  transition: background 120ms ease;
+}
+
+.agents-tab__divider--vertical {
+  cursor: col-resize;
+}
+.agents-tab__divider--vertical::before {
+  top: 0;
+  bottom: 0;
+  left: 2px;
+  width: 2px;
+}
+
+.agents-tab__divider--horizontal {
+  flex-basis: 6px;
+  cursor: row-resize;
+}
+.agents-tab__divider--horizontal::before {
+  left: 0;
+  right: 0;
+  top: 2px;
+  height: 2px;
+}
+
+.agents-tab__divider:hover::before,
+.agents-tab__divider:active::before {
+  background: var(--color-accent, #88b4ff);
 }
 
 .agents-tab__hint {


### PR DESCRIPTION
Wedge PR after a planner-led rethink. The user has been telling us v0.3.x **still doesn't feel like Ghostty**:

> "the UI is still not that great … no way to make it multipane view like I do in Ghostty, also font and color is not that great"
> "I would also like to drag the terminal boxes!"

The diagnosis: **the fixed N-pane CSS grid was the wrong layout model**, and the saturated emerald accent + pure white text were reading "alarmed web app" not "calm terminal." Polish wasn't going to fix it.

This PR is the "we heard you" wedge — biggest visible cues fixed, before the bigger refactor (recursive split tree → next PR).

## What changed

### Layout: kill the grid, ship visible draggable dividers

- `agents-tab__panes` was a CSS grid with a 1 px gap of border color. The user couldn't grab it and could barely see it.
- Replaced with **flex + a real `Divider` component** between adjacent panes:
  - 6 px hit area, 2 px visible bar
  - `cursor: col-resize` / `row-resize`
  - Hover/active brightens the bar to the accent color — you can see what you're grabbing
- Drag actually resizes (writes to a ratio, applied via `flex-basis`).
- Topology still hardcoded for n=1..4 (recursive split tree is **next PR**). n=2: single vertical divider. n=3: top row splits horizontally + spanning bottom. n=4: top + bottom rows each split + horizontal cut between them.

### Palette: pull saturation back

Updated `@theme` + `:root` in `styles.css`:

| Token | Before | After | Reason |
|-------|--------|-------|--------|
| `--color-bg-base` | `#0c0c0e` | `#0d1014` | Cooler grey |
| `--color-bg-pane` | *(new)* | `#0a0c0f` | Pane interior darker than chrome |
| `--color-border-strong` | `#3a3a42` | `#3a4453` | More visible dividers |
| `--color-text-primary` | `#ededef` | `#d4d8de` | Warm gray, not pure white |
| `--color-accent` | `#10b981` (emerald) | `#88b4ff` (periwinkle) | Calmer |
| `--color-danger / warning / success` | full Tailwind sat | Desaturated 25-40% | Calmer |

Added missing aliases (`--color-bg`, `--color-text`, `--color-border`, `--color-link`) so the agent CSS that's been falling back to hardcoded values now picks up the new palette.

Font stack now leads with **JetBrains Mono / Inter** (was Geist), matching Ghostty defaults.

### Pane chrome: less web-app

- **Focus affordance:** dropped the 2 px outline ring; subtle 1 px inset shadow on accent-muted instead. Closer to "active pane just looks slightly brighter."
- **Tighter paddings** on `.agent-detail` (12/16 → 8/10).
- **Mono font** on the agent name in the header (it's an identifier, not prose).
- **Icon glyphs:** `⋯` → `[…]`, `×` → `[x]` — kbd-style brackets stay in the type system.

### Messages: drop the assistant bubble

The assistant bubble fought the terminal feel even with mono inside. Now:
- **Assistant messages**: bare left-aligned mono text spanning the pane width — like log output
- **User messages**: keep a *very* subtle treatment (left rule + faint accent bg) so you can still tell turn-from-turn
- **Thinking** stays dim italic, no chrome

## What's NOT in this PR (intentionally)

- **Recursive split tree** (`PaneTree` data structure, splitting any leaf horizontally / vertically, hotkeys `⌘D` / `⌘⇧D`). That's the next PR — needs more thought + will be invasive. The flex layout here is structurally ready to receive it.
- **Drag a pane header to swap or re-split.** PR #3.
- **`Cmd+Enter` zoom.** Was on a separate WIP branch; will rebuild on top of the tree refactor since the model changes.

## Bump

**v0.4.0** — minor because the layout primitive (grid → flex with dividers) changed.

## Test plan
- [ ] Local: typecheck ✅, lint ✅, format ✅, build ✅
- [ ] CI green
- [ ] Smoke: open 2 panes, see a visible divider between them; drag it left/right, panes resize
- [ ] Smoke: open 3 panes, drag both the vertical (top row) and horizontal (top/bottom) dividers
- [ ] Smoke: open 4 panes, drag all three dividers (top row, bottom row, between rows)
- [ ] Smoke: focus a pane — subtle inset rule appears, no outline ring
- [ ] Smoke: header shows `[STATE]` colored, `[…]` and `[x]` instead of `⋯` / `×`
- [ ] Smoke: assistant messages render as bare mono text, no bubble