### PR TITLE
Layout picker (1-4 cells) + pin pane (v0.4.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "workroot"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["Saurav Panda <saurav@workroot.dev>"]
 description = "A local-first developer workspace for managing projects, terminals, and Git workflows."

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/components/AgentDetailPane.tsx
+++ b/src/components/AgentDetailPane.tsx
@@ -20,6 +20,11 @@ interface AgentDetailPaneProps {
   /** Called after a successful DELETE so the parent can drop selection
    *  before the next poll catches up. */
   onDeleted?: () => void;
+  /** Pin state, controlled by the parent (AgentsTab). When undefined,
+   *  the Pin menu item + the indicator are hidden — the standalone /
+   *  legacy single-pane usage doesn't need the concept. */
+  pinned?: boolean;
+  onTogglePin?: () => void;
 }
 
 const TERMINAL_STATES = new Set(["done", "failed"]);
@@ -348,6 +353,8 @@ export function AgentDetailPane({
   agentId,
   onClose,
   onDeleted,
+  pinned,
+  onTogglePin,
 }: AgentDetailPaneProps) {
   const { detail, machine, loading, error, refresh } = useAgentDetail(
     machineId,
@@ -608,6 +615,14 @@ export function AgentDetailPane({
             >
               {machine?.label ?? detail.machine_name}
             </span>
+            {pinned && (
+              <span
+                className="agent-detail__pin-tag"
+                title="Pinned — won't be evicted when opening another agent"
+              >
+                [pinned]
+              </span>
+            )}
           </>
         )}
         <span className="agent-detail__spacer" />
@@ -685,6 +700,20 @@ export function AgentDetailPane({
                   </button>
                 )}
                 <div className="agent-detail__menu-sep" />
+                {onTogglePin && (
+                  <button
+                    type="button"
+                    className="agent-detail__menu-item"
+                    onClick={onTogglePin}
+                    title={
+                      pinned
+                        ? "Unpin — pane can be evicted by FIFO again"
+                        : "Pin — pane won't be evicted when opening another agent"
+                    }
+                  >
+                    {pinned ? "Unpin pane" : "Pin pane"}
+                  </button>
+                )}
                 <button
                   type="button"
                   className="agent-detail__menu-item"

--- a/src/components/AgentsTab.tsx
+++ b/src/components/AgentsTab.tsx
@@ -12,11 +12,16 @@ interface Pane {
   paneId: number;
   machineId: number;
   agentId: string;
+  /** Pinned panes are never evicted by FIFO when opening a new agent
+   *  at capacity. The user toggles via the ⋯ menu. */
+  pinned: boolean;
 }
 
-// Cap on simultaneously open agent panes. 4 fits a 2×2 grid; beyond
-// that each pane gets too narrow to be useful and the per-pane 3 s
-// poll starts adding up.
+type LayoutSize = 1 | 2 | 3 | 4;
+
+// Hard cap. The layout picker lets the user choose 1..4; we don't
+// allow more because each extra pane gets too narrow to be useful and
+// the per-pane 3 s poll starts adding up.
 const MAX_PANES = 4;
 
 const STATE_LABELS: Record<string, string> = {
@@ -148,6 +153,13 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
   const { agents, machines, loading, refresh } = useAllAgents();
   const [panes, setPanes] = useState<Pane[]>([]);
   const [focusedPaneId, setFocusedPaneId] = useState<number | null>(null);
+  // Layout shape (1-4 cells). Defaults to 1 + auto-grows on open so the
+  // out-of-the-box behavior matches v0.4.0 (click two agents → see two
+  // splits). Once the user explicitly picks a layout via the picker,
+  // userPickedLayout flips to true and auto-grow stops — pick is the
+  // intent, don't fight it.
+  const [layoutSize, setLayoutSize] = useState<LayoutSize>(1);
+  const [userPickedLayout, setUserPickedLayout] = useState(false);
   // Split ratios (0..1) — first sibling fraction. The fixed-grid model
   // is gone; layouts are now flex with draggable dividers between any
   // two adjacent panes. We track three ratios because n=4 has two
@@ -172,30 +184,99 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
     return () => window.clearInterval(id);
   }, []);
 
-  // Open an agent in a pane. If it's already open, just focus that pane.
-  // If we're at MAX_PANES, evict the oldest.
-  const openAgent = useCallback((machineId: number, agentId: string) => {
+  // Open an agent. Behavior:
+  //   - already open → focus that pane
+  //   - room left in the layout (panes.length < layoutSize) → append
+  //   - at capacity → replace the focused pane if unpinned;
+  //     else replace the oldest unpinned pane;
+  //     else replace focused anyway (everything pinned, force).
+  // The "pinned never evicted" rule is the whole point of the pin.
+  const openAgent = useCallback(
+    (machineId: number, agentId: string) => {
+      setPanes((prev) => {
+        const existing = prev.find(
+          (p) => p.machineId === machineId && p.agentId === agentId,
+        );
+        if (existing) {
+          setFocusedPaneId(existing.paneId);
+          return prev;
+        }
+        const newPane: Pane = {
+          paneId: paneIdRef.current++,
+          machineId,
+          agentId,
+          pinned: false,
+        };
+        // Room in the current layout? Append.
+        if (prev.length < layoutSize) {
+          setFocusedPaneId(newPane.paneId);
+          return [...prev, newPane];
+        }
+        // Layout's full but auto-grow still active (user hasn't picked
+        // a layout) and there's room within MAX_PANES → grow the
+        // layout by one and append.
+        if (!userPickedLayout && prev.length < MAX_PANES) {
+          setLayoutSize((prev.length + 1) as LayoutSize);
+          setFocusedPaneId(newPane.paneId);
+          return [...prev, newPane];
+        }
+        // Pick a slot to replace.
+        const focusedIdx = prev.findIndex((p) => p.paneId === focusedPaneId);
+        let replaceIdx = -1;
+        if (focusedIdx >= 0 && !prev[focusedIdx].pinned) {
+          replaceIdx = focusedIdx;
+        } else {
+          replaceIdx = prev.findIndex((p) => !p.pinned);
+        }
+        if (replaceIdx === -1) {
+          // Everything pinned — replace focused (or first) anyway.
+          replaceIdx = focusedIdx >= 0 ? focusedIdx : 0;
+        }
+        const next = prev.slice();
+        next[replaceIdx] = newPane;
+        setFocusedPaneId(newPane.paneId);
+        return next;
+      });
+    },
+    [layoutSize, focusedPaneId, userPickedLayout],
+  );
+
+  const togglePin = useCallback((paneId: number) => {
+    setPanes((prev) =>
+      prev.map((p) => (p.paneId === paneId ? { ...p, pinned: !p.pinned } : p)),
+    );
+  }, []);
+
+  // Switch to a different layout size. Marks the user as having picked
+  // explicitly (locks auto-grow). If the new size is smaller than the
+  // current pane count, trim — keep pinned first, drop oldest unpinned.
+  const setLayout = useCallback((size: LayoutSize) => {
+    setUserPickedLayout(true);
+    setLayoutSize(size);
     setPanes((prev) => {
-      const existing = prev.find(
-        (p) => p.machineId === machineId && p.agentId === agentId,
-      );
-      if (existing) {
-        setFocusedPaneId(existing.paneId);
-        return prev;
-      }
-      const newPane: Pane = {
-        paneId: paneIdRef.current++,
-        machineId,
-        agentId,
-      };
-      const next =
-        prev.length >= MAX_PANES
-          ? [...prev.slice(1), newPane]
-          : [...prev, newPane];
-      setFocusedPaneId(newPane.paneId);
-      return next;
+      if (prev.length <= size) return prev;
+      const toDrop = prev.length - size;
+      // Build a list of (idx, p) so we can sort while preserving the
+      // original order for the kept set. Sort dropped-first by:
+      //   1. pinned later (drop unpinned first)
+      //   2. lower idx first (drop older first)
+      const indexed = prev.map((p, idx) => ({ idx, p }));
+      indexed.sort((a, b) => {
+        if (a.p.pinned !== b.p.pinned) return a.p.pinned ? 1 : -1;
+        return a.idx - b.idx;
+      });
+      const dropIds = new Set(indexed.slice(0, toDrop).map((x) => x.p.paneId));
+      return prev.filter((p) => !dropIds.has(p.paneId));
     });
   }, []);
+
+  // If the focused pane gets dropped (close, layout trim, agent
+  // disappears), move focus to the new last pane (or null).
+  useEffect(() => {
+    if (focusedPaneId === null) return;
+    if (panes.some((p) => p.paneId === focusedPaneId)) return;
+    setFocusedPaneId(panes.length > 0 ? panes[panes.length - 1].paneId : null);
+  }, [panes, focusedPaneId]);
 
   const closePane = useCallback((paneId: number) => {
     setPanes((prev) => {
@@ -392,8 +473,34 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
 
       {splitView && (
         <div className="agents-tab__hint">
-          {panes.length} of {MAX_PANES} · click row to open · drag dividers to
-          resize · Esc closes focused
+          <div
+            className="agents-tab__layout-picker"
+            role="radiogroup"
+            aria-label="Layout"
+          >
+            <span className="agents-tab__layout-label">layout:</span>
+            {([1, 2, 3, 4] as LayoutSize[]).map((n) => (
+              <button
+                key={n}
+                type="button"
+                role="radio"
+                aria-checked={layoutSize === n}
+                className={
+                  layoutSize === n
+                    ? "agents-tab__layout-btn agents-tab__layout-btn--active"
+                    : "agents-tab__layout-btn"
+                }
+                onClick={() => setLayout(n)}
+                title={`${n} pane${n > 1 ? "s" : ""}`}
+              >
+                [{n}]
+              </button>
+            ))}
+          </div>
+          <div className="agents-tab__hint-text">
+            {panes.length}/{layoutSize} · click row to open · drag dividers to
+            resize · Esc closes focused
+          </div>
         </div>
       )}
     </>
@@ -403,64 +510,92 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
     return <div className="agents-tab">{list}</div>;
   }
 
-  // Render a leaf pane (the AgentDetailPane wrapped in the focus/click
-  // chrome). Pulled out so the n=1..4 layout code below stays readable.
-  const leaf = (p: Pane, basis?: number) => {
-    const focused = focusedPaneId === p.paneId;
+  // Build cells = filled panes padded with nulls up to layoutSize.
+  // Empty cells render as placeholders.
+  const cells: (Pane | null)[] = [];
+  for (let i = 0; i < layoutSize; i++) {
+    cells.push(panes[i] ?? null);
+  }
+
+  // Render a single grid cell — either the AgentDetailPane wrapped in
+  // focus/click chrome, or an empty placeholder telling the user to
+  // click an agent to fill it.
+  const cell = (c: Pane | null, key: string | number, basis?: number) => {
+    if (!c) {
+      return (
+        <div
+          key={`empty-${key}`}
+          className="agents-tab__pane agents-tab__pane--empty"
+          style={
+            basis !== undefined ? { flexBasis: `${basis * 100}%` } : undefined
+          }
+        >
+          <div className="agents-tab__placeholder">
+            click an agent in the list to open here
+          </div>
+        </div>
+      );
+    }
+    const focused = focusedPaneId === c.paneId;
+    const cls = [
+      "agents-tab__pane",
+      focused && "agents-tab__pane--focused",
+      c.pinned && "agents-tab__pane--pinned",
+    ]
+      .filter(Boolean)
+      .join(" ");
     return (
       <div
-        key={p.paneId}
-        className={
-          focused
-            ? "agents-tab__pane agents-tab__pane--focused"
-            : "agents-tab__pane"
-        }
+        key={c.paneId}
+        className={cls}
         style={
           basis !== undefined ? { flexBasis: `${basis * 100}%` } : undefined
         }
-        onClick={() => setFocusedPaneId(p.paneId)}
-        onFocus={() => setFocusedPaneId(p.paneId)}
+        onClick={() => setFocusedPaneId(c.paneId)}
+        onFocus={() => setFocusedPaneId(c.paneId)}
       >
         <AgentDetailPane
-          machineId={p.machineId}
-          agentId={p.agentId}
-          onClose={() => closePane(p.paneId)}
-          onDeleted={() => closePane(p.paneId)}
+          machineId={c.machineId}
+          agentId={c.agentId}
+          onClose={() => closePane(c.paneId)}
+          onDeleted={() => closePane(c.paneId)}
+          pinned={c.pinned}
+          onTogglePin={() => togglePin(c.paneId)}
         />
       </div>
     );
   };
 
   let panesNode: React.ReactNode;
-  if (panes.length === 1) {
-    panesNode = leaf(panes[0]);
-  } else if (panes.length === 2) {
+  if (layoutSize === 1) {
+    panesNode = cell(cells[0], 0);
+  } else if (layoutSize === 2) {
     panesNode = (
       <>
-        {leaf(panes[0], ratios.twoCol)}
+        {cell(cells[0], 0, ratios.twoCol)}
         <Divider
           direction="vertical"
           ratio={ratios.twoCol}
           onChange={(n) => setRatio("twoCol", n)}
         />
-        {leaf(panes[1], 1 - ratios.twoCol)}
+        {cell(cells[1], 1, 1 - ratios.twoCol)}
       </>
     );
-  } else if (panes.length === 3) {
-    // Top row: panes[0] | panes[1]; bottom row spans: panes[2].
+  } else if (layoutSize === 3) {
+    // Top row: cells[0] | cells[1]; bottom row spans: cells[2].
     panesNode = (
       <>
         <div
           className="agents-tab__split-row"
           style={{ flexBasis: `${ratios.vertical * 100}%` }}
         >
-          {leaf(panes[0], ratios.topRow)}
+          {cell(cells[0], 0, ratios.topRow)}
           <Divider
             direction="vertical"
             ratio={ratios.topRow}
             onChange={(n) => setRatio("topRow", n)}
           />
-          {leaf(panes[1], 1 - ratios.topRow)}
+          {cell(cells[1], 1, 1 - ratios.topRow)}
         </div>
         <Divider
           direction="horizontal"
@@ -471,7 +606,7 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
           className="agents-tab__split-row"
           style={{ flexBasis: `${(1 - ratios.vertical) * 100}%` }}
         >
-          {leaf(panes[2], 1)}
+          {cell(cells[2], 2, 1)}
         </div>
       </>
     );
@@ -483,13 +618,13 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
           className="agents-tab__split-row"
           style={{ flexBasis: `${ratios.vertical * 100}%` }}
         >
-          {leaf(panes[0], ratios.topRow)}
+          {cell(cells[0], 0, ratios.topRow)}
           <Divider
             direction="vertical"
             ratio={ratios.topRow}
             onChange={(n) => setRatio("topRow", n)}
           />
-          {leaf(panes[1], 1 - ratios.topRow)}
+          {cell(cells[1], 1, 1 - ratios.topRow)}
         </div>
         <Divider
           direction="horizontal"
@@ -500,13 +635,13 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
           className="agents-tab__split-row"
           style={{ flexBasis: `${(1 - ratios.vertical) * 100}%` }}
         >
-          {leaf(panes[2], ratios.botRow)}
+          {cell(cells[2], 2, ratios.botRow)}
           <Divider
             direction="vertical"
             ratio={ratios.botRow}
             onChange={(n) => setRatio("botRow", n)}
           />
-          {leaf(panes[3], 1 - ratios.botRow)}
+          {cell(cells[3], 3, 1 - ratios.botRow)}
         </div>
       </>
     );
@@ -515,7 +650,7 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
   return (
     <div className="agents-tab agents-tab--splits">
       <div className="agents-tab__list-pane">{list}</div>
-      <div className={`agents-tab__panes agents-tab__panes--n${panes.length}`}>
+      <div className={`agents-tab__panes agents-tab__panes--n${layoutSize}`}>
         {panesNode}
       </div>
     </div>

--- a/src/styles/agent-detail.css
+++ b/src/styles/agent-detail.css
@@ -57,6 +57,16 @@
   min-width: 0;
 }
 
+.agent-detail__pin-tag {
+  font-family: var(--font-mono, monospace);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--color-warning, #d4a76a);
+  flex: 0 0 auto;
+}
+
 .agent-detail__spacer {
   flex: 1 1 auto;
 }

--- a/src/styles/agents-tab.css
+++ b/src/styles/agents-tab.css
@@ -123,6 +123,80 @@
   color: var(--color-text-secondary, #888);
   padding: 6px 8px;
   border-top: 1px solid var(--color-border, #2a2a2a);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+/* Layout picker — small bracketed [1] [2] [3] [4] buttons. Active one
+ * gets the accent color. Stays in the terminal type system. */
+.agents-tab__layout-picker {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+}
+
+.agents-tab__layout-label {
+  color: var(--color-text-muted, #5c5c66);
+  margin-right: 2px;
+}
+
+.agents-tab__layout-btn {
+  background: transparent;
+  border: none;
+  padding: 2px 4px;
+  font: inherit;
+  color: var(--color-text-secondary, #7c8693);
+  cursor: pointer;
+  border-radius: 3px;
+}
+
+.agents-tab__layout-btn:hover {
+  color: var(--color-text, #d4d8de);
+  background: var(--color-bg-hover, #1f252c);
+}
+
+.agents-tab__layout-btn--active {
+  color: var(--color-accent, #88b4ff);
+  font-weight: 600;
+}
+
+.agents-tab__hint-text {
+  font-family: var(--font-mono, monospace);
+}
+
+/* Empty placeholder cell — shown when layoutSize > panes.length. */
+.agents-tab__pane--empty {
+  background: var(--bg-pane, #0a0c0f);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.agents-tab__placeholder {
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  color: var(--color-text-muted, #5c5c66);
+  padding: 12px 16px;
+  text-align: center;
+  border: 1px dashed var(--color-border-subtle, #1f252c);
+  border-radius: 4px;
+  max-width: 80%;
+}
+
+/* Pinned pane: subtle accent rule on the left edge so the user can
+ * tell the pane is sticky at a glance. The [pinned] tag in the header
+ * is the explicit signal. */
+.agents-tab__pane--pinned {
+  box-shadow: inset 2px 0 0 0 var(--color-warning, #d4a76a);
+}
+
+.agents-tab__pane--pinned.agents-tab__pane--focused {
+  box-shadow:
+    inset 2px 0 0 0 var(--color-warning, #d4a76a),
+    inset 0 0 0 1px var(--color-accent-muted, rgba(136, 180, 255, 0.3));
 }
 
 .agents-tab__header {


### PR DESCRIPTION
The two asks from this round:
> "Can I also have a split mode, like I want 2 panes or 4 panes etc? also pin a pane"

## Layout picker

Bracketed buttons in the splits-view footer:

```
layout: [1] [2] [3] [4]
```

- Active value highlighted in the accent color
- Picking **smaller** than current → trims (keeps pinned first, drops oldest unpinned)
- Picking **larger** → reveals empty placeholder cells (`click an agent in the list to open here`)
- Opening an agent fills the next empty cell
- The empty placeholder lives inside the same `.agents-tab__pane` container so the divider you drag still works between empty and filled cells

**Default behavior unchanged from v0.4.0:** layoutSize starts at 1 and auto-grows on open up to 4. First explicit pick locks the layout (auto-grow stops — pick is intent).

## Pin pane

New entry in the `⋯` popover: **Pin pane** / **Unpin pane**.

- Pinned panes get a small `[PINNED]` mono tag in the header (amber, next to the machine label)
- 2 px amber rule on the pane's left edge so you can see at a glance which panes are sticky
- Eviction logic now respects pin:
  1. Replace focused pane if unpinned
  2. Else replace oldest unpinned
  3. Else replace focused anyway (everything pinned → force, so pinning all 4 doesn't block a 5th open)

Layout trim is also pin-aware (drops unpinned first when shrinking).

## Implementation notes

- `Pane` interface gains `pinned: boolean`
- `AgentDetailPane` gets two new optional props (`pinned`, `onTogglePin`); when undefined the pin item / indicator are hidden — the legacy single-pane usage of the component doesn't need the concept
- New `setLayout(size)` callback handles the trim + sets `userPickedLayout = true`
- Focus cleanup `useEffect` extracted so trim, close, and external delete all reassign focus the same way

## Test plan

- [ ] Local: typecheck ✅, lint ✅, format ✅, build ✅
- [ ] CI green
- [ ] Smoke: open 1 agent → only 1 pane, no placeholders. Open another → auto-grows to 2.
- [ ] Smoke: click `[4]` → see 1 filled + 3 empty placeholder cells. Click 3 more agents → all 4 cells filled.
- [ ] Smoke: with 4 panes, click `[2]` → trimmed to 2 (oldest unpinned dropped first).
- [ ] Smoke: open ⋯ menu on a pane → "Pin pane". Click → `[PINNED]` tag appears, amber left rule visible.
- [ ] Smoke: open a 5th agent when all 4 are filled and pane 1 is pinned → pane 2 (oldest unpinned) gets replaced, pinned pane 1 untouched.