### PR TITLE
Stale working bubble + context % usage row (v0.4.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "workroot"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 authors = ["Saurav Panda <saurav@workroot.dev>"]
 description = "A local-first developer workspace for managing projects, terminals, and Git workflows."

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/components/AgentDetailPane.tsx
+++ b/src/components/AgentDetailPane.tsx
@@ -28,9 +28,23 @@ interface AgentDetailPaneProps {
 }
 
 const TERMINAL_STATES = new Set(["done", "failed"]);
-// States where the agent is actively doing something — used to surface a
-// "thinking" / typing-bubble at the bottom of the events list.
+// States where the agent is *supposed* to be doing something — used to
+// surface the typing-bubble at the bottom of the events list. The bubble
+// is *also* gated on recent activity (see WORKING_STALE_MS): if the
+// daemon's state says working but updated_at hasn't moved in a while,
+// the state is stale and we suppress the bubble.
 const ACTIVE_STATES = new Set(["working", "planning", "queued"]);
+
+// If updated_at hasn't advanced in this long, treat the active state
+// as stale and hide the bubble. Polling is 3 s, so a real working agent
+// refreshes well within this window.
+const WORKING_STALE_MS = 60_000;
+
+// Assumed context window for the % display. Claude Sonnet defaults to
+// 200 k; Sonnet 1M-context users will see lower %, Opus users similar.
+// The daemon doesn't currently expose the model so we have to assume.
+// See follow-up issue for exposing model + rate-limit % per minute.
+const CONTEXT_WINDOW_TOKENS = 200_000;
 
 const ACTIVE_STATE_LABEL: Record<string, string> = {
   working: "Agent is working",
@@ -585,6 +599,39 @@ export function AgentDetailPane({
   const canReply = !!detail && detail.backend === "claude";
   const hasTranscript = items.length > 0;
 
+  // Show the "Agent is working" bubble only when state is active AND
+  // updated_at is fresh. The state alone lies — daemons sometimes leave
+  // an agent in `working` after it goes idle, leaving the bubble
+  // spinning forever. Recheck on every poll re-render.
+  const isActive = (() => {
+    if (!detail || !ACTIVE_STATES.has(detail.state)) return false;
+    const updated = Date.parse(detail.updated_at);
+    if (Number.isNaN(updated)) return true; // can't tell, assume active
+    return Date.now() - updated < WORKING_STALE_MS;
+  })();
+
+  // Cumulative tokens across the session vs the assumed 200 k Claude
+  // Sonnet context. Not the *current* prompt size (daemon doesn't
+  // expose per-call usage), but a useful "how full has this conversation
+  // gotten" number. Cache reads count too — they're still in the prompt.
+  const contextPct = detail?.usage
+    ? Math.min(
+        999,
+        Math.round(
+          ((detail.usage.input_tokens +
+            detail.usage.output_tokens +
+            detail.usage.cache_read_tokens) /
+            CONTEXT_WINDOW_TOKENS) *
+            100,
+        ),
+      )
+    : 0;
+  const totalCtxTokens = detail?.usage
+    ? detail.usage.input_tokens +
+      detail.usage.output_tokens +
+      detail.usage.cache_read_tokens
+    : 0;
+
   return (
     <aside className="agent-detail">
       <header className="agent-detail__header">
@@ -795,7 +842,7 @@ export function AgentDetailPane({
               );
             })
           )}
-          {detail && ACTIVE_STATES.has(detail.state) && (
+          {isActive && detail && (
             <div
               className="agent-detail__working"
               aria-live="polite"
@@ -827,13 +874,21 @@ export function AgentDetailPane({
 
       {detail?.usage && (
         <div className="agent-detail__usage">
-          <span>
-            in {formatTokens(detail.usage.input_tokens)} · out{" "}
-            {formatTokens(detail.usage.output_tokens)}
+          <span
+            className={
+              contextPct >= 80
+                ? "agent-detail__ctx agent-detail__ctx--hot"
+                : "agent-detail__ctx"
+            }
+            title={`${formatTokens(totalCtxTokens)} of ${formatTokens(CONTEXT_WINDOW_TOKENS)} (assumes Claude Sonnet 200 k context — daemon doesn't expose actual model)`}
+          >
+            ctx {contextPct}%
           </span>
-          <span>
-            cache w {formatTokens(detail.usage.cache_write_tokens)} · r{" "}
-            {formatTokens(detail.usage.cache_read_tokens)}
+          <span
+            className="agent-detail__rate"
+            title="Rate-limit % needs daemon API exposing per-minute usage — not available yet"
+          >
+            rate —
           </span>
           <span>{formatCost(detail.usage.cost_usd)}</span>
         </div>

--- a/src/styles/agent-detail.css
+++ b/src/styles/agent-detail.css
@@ -454,15 +454,28 @@
 /* ---- footer (usage + reply) ---- */
 
 .agent-detail__usage {
-  padding-top: 12px;
+  padding-top: 8px;
   border-top: 1px solid var(--color-border, #2a2a2a);
   display: flex;
   flex-wrap: wrap;
-  gap: 4px 16px;
+  gap: 4px 14px;
   font-size: 11px;
   color: var(--color-text-secondary, #888);
   font-family: var(--font-mono, monospace);
   flex: 0 0 auto;
+}
+
+.agent-detail__ctx {
+  color: var(--color-text-secondary, #888);
+}
+
+.agent-detail__ctx--hot {
+  color: var(--color-warning, #d4a76a);
+  font-weight: 600;
+}
+
+.agent-detail__rate {
+  color: var(--color-text-muted, #5c5c66);
 }
 
 .agent-detail__actions {


### PR DESCRIPTION
Two user-reported polish fixes.

## Working bubble was lying

> "Even though the agent is not working I see \`Agent is working\` loader, can we fix this?"

The bubble was gated only on `ACTIVE_STATES` (working / planning / queued). When the daemon's state was stuck on "working" after the agent went idle, the bubble spun forever even though nothing was happening.

**Fix:** added a freshness gate. Also require `detail.updated_at` to be within the last 60 s. The 3 s poll re-evaluates each tick, so the bubble disappears within one poll of the agent going idle.

```
ACTIVE_STATES has state  AND  now − Date.parse(updated_at) < 60s
```

When `updated_at` is unparseable, fall back to "active" so we don't suppress the bubble for an unrelated date-format issue.

## Tokens row → context %

> "the tokens thing is actually absolute count which I dont care, I care about % of context used and % of rate limit use"

Replaced two rows of cumulative token counts (`in 45K · out 12K`, `cache w … r …`) with a single **`ctx XX%`** computed from cumulative `(input + output + cache_read) / 200 000`.

- Goes **amber-bold** at ≥ 80 % so you notice when context is filling up
- Tooltip shows the absolute number + the 200 k assumption

200 k is hardcoded — Claude Sonnet default. Called out in the tooltip; the daemon doesn't expose the actual model yet (follow-up).

**Rate-limit %** shows `rate —` with a tooltip:
> Rate-limit % needs daemon API exposing per-minute usage — not available yet

Cost stays as `$0.4321`.

## Not in this PR (next)

- **Code highlighting + diff coloring** (your Ghostty screenshot ask) — `highlight.js` is already in deps; will use it to syntax-color tool args/results, render Edit tool calls as red/green diffs. Filed for **v0.4.3**.
- **Settings page cleanup** — your "hideous + dead things" feedback. Filed for **v0.4.4**.

## Test plan
- [ ] Local: typecheck ✅, lint ✅, format ✅, build ✅
- [ ] CI green
- [ ] Smoke: open a `working` agent that just finished its last tool call >1 min ago — bubble disappears
- [ ] Smoke: open a busy agent — bubble shows
- [ ] Smoke: usage row shows `ctx XX%`, hover for absolute, `rate —` tooltip explains