### PR TITLE
Code highlighting + Edit-as-diff + ANSI Bash output (v0.4.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "workroot"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 authors = ["Saurav Panda <saurav@workroot.dev>"]
 description = "A local-first developer workspace for managing projects, terminals, and Git workflows."

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/components/AgentDetailPane.tsx
+++ b/src/components/AgentDetailPane.tsx
@@ -9,8 +9,10 @@ import {
 import * as Popover from "@radix-ui/react-popover";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { open as openShell } from "@tauri-apps/plugin-shell";
+import AnsiConvert from "ansi-to-html";
 import { useAgentDetail } from "../hooks/useAgentDetail";
 import { clientFor, type ThreadEvent, type Turn } from "../lib/helm-api";
+import { escapeHtml, getLanguageFromPath, highlightCode } from "../lib/syntax";
 import "../styles/agent-detail.css";
 
 interface AgentDetailPaneProps {
@@ -275,6 +277,187 @@ function MessageItem({
   );
 }
 
+// Highlighted code block — used for Write content, Read result body,
+// and the generic tool args/result panes. `language` from the file
+// path when known, else highlight.js auto-detect.
+function CodeBlock({
+  code,
+  language,
+}: {
+  code: string;
+  language?: string | null;
+}) {
+  const html = useMemo(
+    () => highlightCode(code, language ?? null),
+    [code, language],
+  );
+  return (
+    <pre className="agent-detail__code">
+      <code className="hljs" dangerouslySetInnerHTML={{ __html: html }} />
+    </pre>
+  );
+}
+
+// Edit tool args rendered as a unified-style diff. Old lines red,
+// new lines green, file path + line counts in the header. Falls back
+// to JSON if the args don't look like an Edit shape.
+function EditDiff({ input }: { input: string }) {
+  const obj = asRecord(safeJsonParse(input)) ?? {};
+  const filePath = asString(obj.file_path) || asString(obj.path);
+  const oldStr = asString(obj.old_string);
+  const newStr = asString(obj.new_string);
+  const lang = getLanguageFromPath(filePath);
+
+  if (!filePath || (!oldStr && !newStr)) {
+    return <CodeBlock code={prettyJson(input)} language="json" />;
+  }
+
+  const oldLines = oldStr ? oldStr.split("\n") : [];
+  const newLines = newStr ? newStr.split("\n") : [];
+
+  return (
+    <div className="agent-detail__diff">
+      <div className="agent-detail__diff-file">
+        <span className="agent-detail__diff-path">{filePath}</span>
+        <span className="agent-detail__diff-stats">
+          <span className="agent-detail__diff-stat agent-detail__diff-stat--del">
+            −{oldLines.length}
+          </span>
+          <span className="agent-detail__diff-stat agent-detail__diff-stat--add">
+            +{newLines.length}
+          </span>
+        </span>
+      </div>
+      <div className="agent-detail__diff-body">
+        {oldLines.map((line, i) => (
+          <div
+            key={`o${i}`}
+            className="agent-detail__diff-line agent-detail__diff-line--del"
+          >
+            <span className="agent-detail__diff-marker">−</span>
+            <code
+              className="hljs"
+              dangerouslySetInnerHTML={{ __html: highlightCode(line, lang) }}
+            />
+          </div>
+        ))}
+        {newLines.map((line, i) => (
+          <div
+            key={`n${i}`}
+            className="agent-detail__diff-line agent-detail__diff-line--add"
+          >
+            <span className="agent-detail__diff-marker">+</span>
+            <code
+              className="hljs"
+              dangerouslySetInnerHTML={{ __html: highlightCode(line, lang) }}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// Write tool args: file path header + the content as highlighted code.
+function WriteCode({ input }: { input: string }) {
+  const obj = asRecord(safeJsonParse(input)) ?? {};
+  const filePath = asString(obj.file_path) || asString(obj.path);
+  const content = asString(obj.content);
+  if (!content) return <CodeBlock code={prettyJson(input)} language="json" />;
+  const lang = getLanguageFromPath(filePath);
+  return (
+    <div className="agent-detail__write">
+      {filePath && <div className="agent-detail__write-file">{filePath}</div>}
+      <CodeBlock code={content} language={lang} />
+    </div>
+  );
+}
+
+// ANSI-to-HTML for Bash results so colored CLI output (rg, eslint,
+// cargo, claude etc.) renders the way it does in a real terminal.
+// The Convert instance is per-render — its only state is across
+// chunks of one stream, which we don't have here.
+function AnsiBlock({ text }: { text: string }) {
+  const html = useMemo(() => {
+    try {
+      const conv = new AnsiConvert({ newline: false, escapeXML: true });
+      return conv.toHtml(text);
+    } catch {
+      return escapeHtml(text);
+    }
+  }, [text]);
+  return (
+    <pre
+      className="agent-detail__code agent-detail__code--ansi"
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}
+
+// Dispatch the args body based on tool name. Edit gets a diff view,
+// Write gets a code-with-file-path view, anything else falls back to
+// JSON pretty-print.
+function ToolArgs({ toolUse }: { toolUse: ToolUseEv }) {
+  const lower = toolUse.tool.toLowerCase();
+  if (lower === "edit") {
+    return (
+      <div className="agent-detail__tool-args">
+        <EditDiff input={toolUse.input} />
+      </div>
+    );
+  }
+  if (lower === "write") {
+    return (
+      <div className="agent-detail__tool-args">
+        <WriteCode input={toolUse.input} />
+      </div>
+    );
+  }
+  return (
+    <div className="agent-detail__tool-args">
+      <CodeBlock code={prettyJson(toolUse.input)} language="json" />
+    </div>
+  );
+}
+
+// Dispatch the result body based on tool name. Bash output gets ANSI
+// parsing; Read result gets language-highlighted from the file_path
+// arg; everything else is plain mono. When trimmed (collapsed view),
+// we render the trimmed text unstyled — coloring a 14-line head/tail
+// snippet adds noise, not signal.
+function ToolResultBody({
+  toolUse,
+  toolResult,
+  expanded,
+  trimmed,
+}: {
+  toolUse: ToolUseEv;
+  toolResult: ToolResultEv;
+  expanded: boolean;
+  trimmed: { display: string; hiddenCount: number };
+}) {
+  const text = expanded ? toolResult.preview : trimmed.display;
+  const lower = toolUse.tool.toLowerCase();
+
+  // Collapsed view: keep it lightweight (no highlighter pass on trimmed).
+  if (!expanded) {
+    return <pre className="agent-detail__code">{text}</pre>;
+  }
+
+  if (lower === "bash" || lower.includes("shell")) {
+    return <AnsiBlock text={text} />;
+  }
+
+  if (lower === "read") {
+    const args = asRecord(safeJsonParse(toolUse.input)) ?? {};
+    const filePath = asString(args.file_path) || asString(args.path);
+    const lang = getLanguageFromPath(filePath);
+    return <CodeBlock code={text} language={lang} />;
+  }
+
+  return <pre className="agent-detail__code">{text}</pre>;
+}
+
 function ToolItem({
   toolUse,
   toolResult,
@@ -322,15 +505,16 @@ function ToolItem({
         {hasError && <span className="agent-detail__tool-err-tag">error</span>}
       </button>
 
-      {expanded && (
-        <div className="agent-detail__tool-args">
-          <pre>{prettyJson(toolUse.input)}</pre>
-        </div>
-      )}
+      {expanded && <ToolArgs toolUse={toolUse} />}
 
       {toolResult && (
         <div className="agent-detail__tool-result">
-          <pre>{expanded ? toolResult.preview : trimmed.display}</pre>
+          <ToolResultBody
+            toolUse={toolUse}
+            toolResult={toolResult}
+            expanded={expanded}
+            trimmed={trimmed}
+          />
           {!expanded && trimmed.hiddenCount > 0 && (
             <button
               type="button"

--- a/src/lib/syntax.ts
+++ b/src/lib/syntax.ts
@@ -1,0 +1,114 @@
+// Syntax highlighting helpers shared between the agent detail pane and
+// any other surface that wants colorized code. Wraps highlight.js with
+// a path → language map and a single `highlightCode` entry point.
+//
+// Languages are registered once at module import. Callers don't need to
+// register anything.
+
+import hljs from "highlight.js/lib/core";
+import bash from "highlight.js/lib/languages/bash";
+import css from "highlight.js/lib/languages/css";
+import diff from "highlight.js/lib/languages/diff";
+import go from "highlight.js/lib/languages/go";
+import javascript from "highlight.js/lib/languages/javascript";
+import json from "highlight.js/lib/languages/json";
+import markdown from "highlight.js/lib/languages/markdown";
+import python from "highlight.js/lib/languages/python";
+import rust from "highlight.js/lib/languages/rust";
+import sql from "highlight.js/lib/languages/sql";
+import typescript from "highlight.js/lib/languages/typescript";
+import xml from "highlight.js/lib/languages/xml";
+import yaml from "highlight.js/lib/languages/yaml";
+
+hljs.registerLanguage("bash", bash);
+hljs.registerLanguage("css", css);
+hljs.registerLanguage("diff", diff);
+hljs.registerLanguage("go", go);
+hljs.registerLanguage("javascript", javascript);
+hljs.registerLanguage("json", json);
+hljs.registerLanguage("markdown", markdown);
+hljs.registerLanguage("python", python);
+hljs.registerLanguage("rust", rust);
+hljs.registerLanguage("sql", sql);
+hljs.registerLanguage("typescript", typescript);
+hljs.registerLanguage("xml", xml);
+hljs.registerLanguage("yaml", yaml);
+
+const EXT_TO_LANG: Record<string, string> = {
+  ts: "typescript",
+  tsx: "typescript",
+  mts: "typescript",
+  cts: "typescript",
+  js: "javascript",
+  jsx: "javascript",
+  mjs: "javascript",
+  cjs: "javascript",
+  py: "python",
+  pyi: "python",
+  rs: "rust",
+  json: "json",
+  jsonc: "json",
+  css: "css",
+  scss: "css",
+  html: "xml",
+  htm: "xml",
+  xml: "xml",
+  svg: "xml",
+  sh: "bash",
+  bash: "bash",
+  zsh: "bash",
+  fish: "bash",
+  yml: "yaml",
+  yaml: "yaml",
+  toml: "yaml", // close enough — hljs has no toml in our bundle
+  sql: "sql",
+  md: "markdown",
+  mdx: "markdown",
+  go: "go",
+  patch: "diff",
+  diff: "diff",
+};
+
+/** Get the highlight.js language id for a file path, or null when we
+ *  don't recognize the extension. */
+export function getLanguageFromPath(path: string): string | null {
+  if (!path) return null;
+  const ext = path.split(".").pop()?.toLowerCase() ?? "";
+  return EXT_TO_LANG[ext] ?? null;
+}
+
+const HTML_ESCAPES: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+};
+
+export function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => HTML_ESCAPES[c] ?? c);
+}
+
+/** Highlight code as HTML. When `language` is unknown or highlight
+ *  fails, returns the escaped raw code so the caller can still
+ *  dangerouslySetInnerHTML safely. */
+export function highlightCode(code: string, language?: string | null): string {
+  try {
+    if (language) {
+      return hljs.highlight(code, { language, ignoreIllegals: true }).value;
+    }
+    // Auto-detect is expensive — only use when caller doesn't know.
+    return hljs.highlightAuto(code, [
+      "typescript",
+      "javascript",
+      "python",
+      "rust",
+      "go",
+      "json",
+      "bash",
+      "yaml",
+    ]).value;
+  } catch {
+    return escapeHtml(code);
+  }
+}

--- a/src/styles/agent-detail.css
+++ b/src/styles/agent-detail.css
@@ -433,6 +433,203 @@
   line-height: 1.45;
 }
 
+/* ---- code blocks (highlight.js) + diff renderer ---- */
+
+.agent-detail__code {
+  margin: 0;
+  padding: 6px 8px;
+  background: var(--color-bg-secondary, #181818);
+  border-radius: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  color: var(--color-text-secondary, #aaa);
+  max-height: 480px;
+  overflow: auto;
+  line-height: 1.45;
+}
+
+.agent-detail__code--ansi {
+  /* ansi-to-html emits <span style="color: …"> — let those colors win
+   * over our base text color. */
+  color: var(--color-text, #d4d8de);
+}
+
+/* highlight.js theme — desaturated to match the Workroot palette
+ * rather than the saturated "atom-one-dark" defaults. Scoped to .hljs
+ * so we don't bleed into other places that use highlight.js classes. */
+.agent-detail__code .hljs,
+.agent-detail__diff .hljs {
+  color: var(--color-text, #d4d8de);
+  background: transparent;
+}
+
+.agent-detail__code .hljs-keyword,
+.agent-detail__code .hljs-selector-tag,
+.agent-detail__code .hljs-meta-keyword,
+.agent-detail__diff .hljs-keyword,
+.agent-detail__diff .hljs-selector-tag {
+  color: #c89dd6; /* desat purple */
+}
+
+.agent-detail__code .hljs-string,
+.agent-detail__code .hljs-template-variable,
+.agent-detail__diff .hljs-string,
+.agent-detail__diff .hljs-template-variable {
+  color: #a8c285; /* desat green */
+}
+
+.agent-detail__code .hljs-comment,
+.agent-detail__code .hljs-quote,
+.agent-detail__diff .hljs-comment {
+  color: var(--color-text-muted, #5c5c66);
+  font-style: italic;
+}
+
+.agent-detail__code .hljs-number,
+.agent-detail__code .hljs-literal,
+.agent-detail__diff .hljs-number,
+.agent-detail__diff .hljs-literal {
+  color: #d4a76a; /* desat amber */
+}
+
+.agent-detail__code .hljs-function .hljs-title,
+.agent-detail__code .hljs-title.function_,
+.agent-detail__diff .hljs-title.function_ {
+  color: #88b4ff; /* accent periwinkle */
+}
+
+.agent-detail__code .hljs-type,
+.agent-detail__code .hljs-built_in,
+.agent-detail__diff .hljs-type,
+.agent-detail__diff .hljs-built_in {
+  color: #d4c186; /* desat yellow */
+}
+
+.agent-detail__code .hljs-attr,
+.agent-detail__code .hljs-attribute,
+.agent-detail__diff .hljs-attr {
+  color: #d4a76a;
+}
+
+.agent-detail__code .hljs-variable,
+.agent-detail__code .hljs-params,
+.agent-detail__code .hljs-tag,
+.agent-detail__code .hljs-name,
+.agent-detail__diff .hljs-variable,
+.agent-detail__diff .hljs-tag,
+.agent-detail__diff .hljs-name {
+  color: #e0a3a3; /* desat red */
+}
+
+.agent-detail__code .hljs-meta,
+.agent-detail__diff .hljs-meta {
+  color: #88b4ff;
+}
+
+.agent-detail__code .hljs-punctuation,
+.agent-detail__diff .hljs-punctuation {
+  color: var(--color-text-secondary, #888);
+}
+
+/* ---- Edit-as-diff renderer ---- */
+
+.agent-detail__diff {
+  margin: 0;
+  background: var(--color-bg-secondary, #181818);
+  border-radius: 0;
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  line-height: 1.45;
+  max-height: 480px;
+  overflow: auto;
+}
+
+.agent-detail__diff-file {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--color-border-subtle, #1f252c);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.agent-detail__diff-path {
+  color: var(--color-text, #d4d8de);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.agent-detail__diff-stats {
+  display: inline-flex;
+  gap: 6px;
+  flex: 0 0 auto;
+}
+
+.agent-detail__diff-stat--del {
+  color: #e08585;
+}
+.agent-detail__diff-stat--add {
+  color: #7ec699;
+}
+
+.agent-detail__diff-body {
+  padding: 4px 0;
+}
+
+.agent-detail__diff-line {
+  display: flex;
+  gap: 6px;
+  padding: 0 8px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.agent-detail__diff-line--del {
+  background: rgba(224, 133, 133, 0.08);
+}
+.agent-detail__diff-line--add {
+  background: rgba(126, 198, 153, 0.08);
+}
+
+.agent-detail__diff-marker {
+  flex: 0 0 auto;
+  width: 10px;
+  text-align: center;
+  user-select: none;
+}
+
+.agent-detail__diff-line--del .agent-detail__diff-marker {
+  color: #e08585;
+}
+.agent-detail__diff-line--add .agent-detail__diff-marker {
+  color: #7ec699;
+}
+
+.agent-detail__diff-line code {
+  flex: 1 1 auto;
+  min-width: 0;
+  background: transparent;
+  font: inherit;
+}
+
+/* Write file header */
+.agent-detail__write {
+  display: flex;
+  flex-direction: column;
+}
+
+.agent-detail__write-file {
+  padding: 4px 8px;
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  color: var(--color-text, #d4d8de);
+  background: rgba(255, 255, 255, 0.02);
+  border-bottom: 1px solid var(--color-border-subtle, #1f252c);
+}
+
 .agent-detail__tool.is-error .agent-detail__tool-result pre {
   color: var(--color-danger, #f87171);
 }


### PR DESCRIPTION
The Ghostty screenshot ask: *"ghostty shows code so well colored and stuff"*. Workroot was rendering all tool args/results as plain mono. Now four targeted renderers based on tool name.

## Edit tool → unified diff

Args parsed as `{ file_path, old_string, new_string }`.

```
src/components/Foo.tsx              −3  +5
─────────────────────────────────────────
−  if (x === 1) {
−    return null;
−  }
+  if (x === 1 || y === undefined) {
+    return null;
+  }
+  if (z) {
+    log(z);
+  }
```

- Header: file path + `−N / +M` line counts in red/green
- Body: each old line `−` red bg, each new line `+` green bg
- Both **highlight.js-colored** using the language inferred from the file extension
- Falls back to JSON pretty-print when args don't fit Edit shape

## Write tool → file path + highlighted code

Header: file path. Body: content highlighted by file-extension language.

## Read tool → highlighted file content (when expanded)

Result body uses the language inferred from the input args' `file_path`.

## Bash tool → ANSI parsing

Uses `ansi-to-html` (already in deps) to render colored CLI output the way the terminal would. `cargo`, `eslint`, `rg`, `claude`, `gh` all emit ANSI escapes that were rendering as raw bytes in v0.4.2.

## Generic tools → JSON-highlighted args

Args block now uses `CodeBlock` with `language="json"` instead of plain `<pre>`, so prettier JSON gets keyword/string/number colors.

## New module: `src/lib/syntax.ts`

- Wraps `highlight.js` with the same language registry `FileExplorer` already uses (typescript, python, rust, go, json, css, xml, bash, yaml, sql, markdown). Adds diff language too.
- `getLanguageFromPath(path)` → hljs language id from file extension
- `highlightCode(code, language?)` → highlighted HTML
- `escapeHtml(s)` for safe fallback when highlight fails

## CSS theme matched to Workroot palette

Existing FileExplorer hljs theme uses full Atom-One-Dark saturation. The new agent-detail theme is **desaturated** to match v0.4.0's Ghostty palette: purples → muted lilac, greens → sage, reds → terracotta. Scoped to `.agent-detail__code` and `.agent-detail__diff` so it doesn't bleed elsewhere.

Diff renderer: 1 px subtle file-header bar, alternating red/green line backgrounds at low alpha (8 %) so the colored hljs output stays readable.

## Bundle size

highlight.js + 13 languages adds ~50 KB gzipped to the agents-tab chunk. `ansi-to-html` adds another ~3 KB. Acceptable for the visible improvement.

## Test plan
- [ ] Local: typecheck ✅, lint ✅, format ✅, build ✅
- [ ] CI green
- [ ] Smoke: Edit tool args expand → red/green diff with file path + line counts
- [ ] Smoke: Write tool args → file path header + highlighted code
- [ ] Smoke: Read result expanded → highlighted file content
- [ ] Smoke: Bash result with `rg` / `cargo` output → ANSI colors render
- [ ] Smoke: any other tool args (Grep, Glob, etc) → JSON gets keyword colors