### PR TITLE
Fix ctx % was double-counting cumulative tokens (v0.4.4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.4.3",
+  "version": "0.4.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "workroot"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 authors = ["Saurav Panda <saurav@workroot.dev>"]
 description = "A local-first developer workspace for managing projects, terminals, and Git workflows."

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/components/AgentDetailPane.tsx
+++ b/src/components/AgentDetailPane.tsx
@@ -794,26 +794,32 @@ export function AgentDetailPane({
     return Date.now() - updated < WORKING_STALE_MS;
   })();
 
-  // Cumulative tokens across the session vs the assumed 200 k Claude
-  // Sonnet context. Not the *current* prompt size (daemon doesn't
-  // expose per-call usage), but a useful "how full has this conversation
-  // gotten" number. Cache reads count too — they're still in the prompt.
-  const contextPct = detail?.usage
-    ? Math.min(
-        999,
-        Math.round(
-          ((detail.usage.input_tokens +
-            detail.usage.output_tokens +
-            detail.usage.cache_read_tokens) /
-            CONTEXT_WINDOW_TOKENS) *
-            100,
-        ),
+  // Estimate "current per-turn context size" from the cumulative
+  // session tokens. The daemon only gives totals (no per-call
+  // breakdown), so we approximate: cumulative input grows by roughly
+  // the full prompt size each turn, so dividing by the number of
+  // assistant turns gives the average input per call ≈ current
+  // context size. v0.4.2 forgot this and summed cumulative input +
+  // output + cache_read directly, which doubled-counted every turn
+  // and showed 200%+ on long sessions.
+  //
+  // Cache reads count toward context too — they're still part of the
+  // prompt that the model has to "read."
+  // Plain expression (no useMemo) — this block runs after early returns,
+  // and a one-pass filter on the events array is cheap.
+  const assistantTurns =
+    detail?.thread_events?.filter((e) => e.kind === "assistant").length ?? 0;
+  const perTurnInputTokens = detail?.usage
+    ? Math.round(
+        (detail.usage.input_tokens + detail.usage.cache_read_tokens) /
+          Math.max(1, assistantTurns),
       )
     : 0;
-  const totalCtxTokens = detail?.usage
-    ? detail.usage.input_tokens +
-      detail.usage.output_tokens +
-      detail.usage.cache_read_tokens
+  const contextPct = detail?.usage
+    ? Math.min(
+        99,
+        Math.round((perTurnInputTokens / CONTEXT_WINDOW_TOKENS) * 100),
+      )
     : 0;
 
   return (
@@ -1064,7 +1070,7 @@ export function AgentDetailPane({
                 ? "agent-detail__ctx agent-detail__ctx--hot"
                 : "agent-detail__ctx"
             }
-            title={`${formatTokens(totalCtxTokens)} of ${formatTokens(CONTEXT_WINDOW_TOKENS)} (assumes Claude Sonnet 200 k context — daemon doesn't expose actual model)`}
+            title={`~${formatTokens(perTurnInputTokens)} per turn of ${formatTokens(CONTEXT_WINDOW_TOKENS)} (estimate: cumulative input ÷ ${assistantTurns} turns; assumes Claude Sonnet 200 k. Real per-call usage needs a daemon API change.)`}
           >
             ctx {contextPct}%
           </span>


### PR DESCRIPTION
> "btw ctx seems wrong in 0.4.2"

You were right. v0.4.2 computed ctx % as:

```
(cumulative_input + cumulative_output + cumulative_cache_read) / 200_000 * 100
```

That sums **every turn's** tokens — long sessions hit 200 %+ which is meaningless.

## Why it broke

The daemon only exposes session-cumulative usage. There's no per-call breakdown. So `input_tokens` after N turns ≈ `N × actual_per_turn_input`, which grows unboundedly even if each turn's context stays the same size.

## Fix

Divide cumulative input + cache_read by the number of assistant turns to estimate per-turn input ≈ current context size:

```
per_turn_input = (input_tokens + cache_read_tokens) / max(1, assistant_turns)
ctx_pct = per_turn_input / 200_000 * 100
```

For a session with 10 turns averaging 50 k context each (`input_tokens = 500 k`, `turns = 10`), ctx now reads **25 %** instead of **425 %**.

Capped at 99 % so it never lies about being over.

Tooltip explicitly calls out the estimate:

> ~50K per turn of 200K (estimate: cumulative input ÷ 10 turns; assumes Claude Sonnet 200 k. Real per-call usage needs a daemon API change.)

## Real fix needs daemon work

The honest per-call ctx % requires the daemon to expose per-call usage (or at least the most recent call's `input_tokens`). I'll file that as a daemon API issue. This PR is the best we can do client-side.

## Bump

v0.4.4. Settings cleanup (was tagged for v0.4.4) bumped to v0.4.5.

## Test plan
- [ ] Local: typecheck ✅, lint ✅, format ✅, build ✅
- [ ] CI green
- [ ] Smoke: open a long session — ctx is now < 100 %
- [ ] Smoke: hover ctx → tooltip shows "~XX K per turn of 200K (estimate: cumulative input ÷ N turns; …)"