### PR TITLE
Planner-sweep bundle: 5 quiet wins (v0.4.6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.4.5",
+  "version": "0.4.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "workroot"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.4.5"
+version = "0.4.6"
 edition = "2021"
 authors = ["Saurav Panda <saurav@workroot.dev>"]
 description = "A local-first developer workspace for managing projects, terminals, and Git workflows."

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/components/AgentDetailPane.tsx
+++ b/src/components/AgentDetailPane.tsx
@@ -12,12 +12,20 @@ import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { open as openShell } from "@tauri-apps/plugin-shell";
 import AnsiConvert from "ansi-to-html";
 import { useAgentDetail } from "../hooks/useAgentDetail";
-import { clientFor, type ThreadEvent, type Turn } from "../lib/helm-api";
+import {
+  clientFor,
+  type HelmMachine,
+  type ThreadEvent,
+  type Turn,
+} from "../lib/helm-api";
 import { escapeHtml, getLanguageFromPath, highlightCode } from "../lib/syntax";
 import "../styles/agent-detail.css";
 
 interface AgentDetailPaneProps {
-  machineId: number | null;
+  /** Resolved machine the agent runs on. Parent (AgentsTab) does the
+   *  lookup once from the shared machines list and passes it in —
+   *  saves an N+1 list_helm_machines invoke per pane per poll. */
+  machine: HelmMachine | null;
   agentId: string | null;
   onClose: () => void;
   /** Called after a successful DELETE so the parent can drop selection
@@ -42,12 +50,6 @@ const ACTIVE_STATES = new Set(["working", "planning", "queued"]);
 // as stale and hide the bubble. Polling is 3 s, so a real working agent
 // refreshes well within this window.
 const WORKING_STALE_MS = 60_000;
-
-// Assumed context window for the % display. Claude Sonnet defaults to
-// 200 k; Sonnet 1M-context users will see lower %, Opus users similar.
-// The daemon doesn't currently expose the model so we have to assume.
-// See follow-up issue for exposing model + rate-limit % per minute.
-const CONTEXT_WINDOW_TOKENS = 200_000;
 
 const ACTIVE_STATE_LABEL: Record<string, string> = {
   working: "Agent is working",
@@ -618,17 +620,14 @@ function TurnItem({ turn }: { turn: Turn }) {
 // ----- main component -----
 
 export function AgentDetailPane({
-  machineId,
+  machine,
   agentId,
   onClose,
   onDeleted,
   pinned,
   onTogglePin,
 }: AgentDetailPaneProps) {
-  const { detail, machine, loading, error, refresh } = useAgentDetail(
-    machineId,
-    agentId,
-  );
+  const { detail, loading, error, refresh } = useAgentDetail(machine, agentId);
   const [reply, setReply] = useState("");
   const [busy, setBusy] = useState<"reply" | "kill" | "delete" | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
@@ -713,7 +712,7 @@ export function AgentDetailPane({
     userAtBottomRef.current = true;
     setUnseen(0);
     setExpanded(new Set());
-  }, [machineId, agentId]);
+  }, [machine?.id, agentId]);
 
   // After every render that changes items: scroll if at bottom, else count
   // the new ones into `unseen`. Runs in useLayoutEffect so we measure the
@@ -752,7 +751,41 @@ export function AgentDetailPane({
     // clicks the pill.
   }, [items, fingerprint, unseen]);
 
-  if (machineId === null || agentId === null) {
+  // Two-click confirm for destructive actions. Replaces window.confirm
+  // (which yanked focus across all panes via a system-modal sheet on
+  // macOS). The popover stays open after the first click and shows
+  // "Click again to confirm". Auto-resets after 4 s if the user
+  // wanders off. Defined above the early return so the hooks always
+  // run in the same order.
+  const [confirming, setConfirming] = useState<"kill" | "delete" | null>(null);
+  const confirmTimeoutRef = useRef<number | null>(null);
+  const armConfirm = useCallback((action: "kill" | "delete") => {
+    if (confirmTimeoutRef.current !== null) {
+      window.clearTimeout(confirmTimeoutRef.current);
+    }
+    setConfirming(action);
+    confirmTimeoutRef.current = window.setTimeout(() => {
+      setConfirming(null);
+      confirmTimeoutRef.current = null;
+    }, 4_000);
+  }, []);
+  const clearConfirm = useCallback(() => {
+    if (confirmTimeoutRef.current !== null) {
+      window.clearTimeout(confirmTimeoutRef.current);
+      confirmTimeoutRef.current = null;
+    }
+    setConfirming(null);
+  }, []);
+  useEffect(
+    () => () => {
+      if (confirmTimeoutRef.current !== null) {
+        window.clearTimeout(confirmTimeoutRef.current);
+      }
+    },
+    [],
+  );
+
+  if (!machine || agentId === null) {
     return (
       <aside className="agent-detail">
         <p className="agent-detail__empty">Select an agent to inspect.</p>
@@ -797,7 +830,7 @@ export function AgentDetailPane({
 
   const kill = async () => {
     if (!machine || !detail) return;
-    if (!window.confirm(`Kill agent "${detail.name}"?`)) return;
+    clearConfirm();
     setBusy("kill");
     setActionError(null);
     try {
@@ -828,12 +861,7 @@ export function AgentDetailPane({
 
   const remove = async () => {
     if (!machine || !detail) return;
-    if (
-      !window.confirm(
-        `Delete agent "${detail.name}"? This removes the worktree, logs, and DB row.`,
-      )
-    )
-      return;
+    clearConfirm();
     setBusy("delete");
     setActionError(null);
     try {
@@ -884,12 +912,6 @@ export function AgentDetailPane({
     ? Math.round(
         (detail.usage.input_tokens + detail.usage.cache_read_tokens) /
           Math.max(1, assistantTurns),
-      )
-    : 0;
-  const contextPct = detail?.usage
-    ? Math.min(
-        99,
-        Math.round((perTurnInputTokens / CONTEXT_WINDOW_TOKENS) * 100),
       )
     : 0;
 
@@ -953,24 +975,42 @@ export function AgentDetailPane({
               >
                 <button
                   type="button"
-                  className="agent-detail__menu-item"
-                  onClick={() => void kill()}
+                  className={
+                    confirming === "kill"
+                      ? "agent-detail__menu-item agent-detail__menu-item--danger"
+                      : "agent-detail__menu-item"
+                  }
+                  onClick={() => {
+                    if (confirming === "kill") void kill();
+                    else armConfirm("kill");
+                  }}
                   disabled={isTerminal || busy !== null}
                 >
-                  {busy === "kill" ? "Killing…" : "Kill"}
+                  {busy === "kill"
+                    ? "Killing…"
+                    : confirming === "kill"
+                      ? "Click again to confirm"
+                      : "Kill"}
                 </button>
                 <button
                   type="button"
                   className="agent-detail__menu-item agent-detail__menu-item--danger"
-                  onClick={() => void remove()}
+                  onClick={() => {
+                    if (confirming === "delete") void remove();
+                    else armConfirm("delete");
+                  }}
                   disabled={!isTerminal || busy !== null}
                   title={
                     isTerminal
-                      ? "Delete agent"
+                      ? "Delete the worktree, logs, and DB row"
                       : "Kill the agent before deleting"
                   }
                 >
-                  {busy === "delete" ? "Deleting…" : "Delete"}
+                  {busy === "delete"
+                    ? "Deleting…"
+                    : confirming === "delete"
+                      ? "Click again to confirm"
+                      : "Delete"}
                 </button>
                 <div className="agent-detail__menu-sep" />
                 <button
@@ -1152,20 +1192,10 @@ export function AgentDetailPane({
       {detail?.usage && (
         <div className="agent-detail__usage">
           <span
-            className={
-              contextPct >= 80
-                ? "agent-detail__ctx agent-detail__ctx--hot"
-                : "agent-detail__ctx"
-            }
-            title={`~${formatTokens(perTurnInputTokens)} per turn of ${formatTokens(CONTEXT_WINDOW_TOKENS)} (estimate: cumulative input ÷ ${assistantTurns} turns; assumes Claude Sonnet 200 k. Real per-call usage needs a daemon API change.)`}
+            className="agent-detail__ctx"
+            title={`Estimated current prompt size, computed as cumulative input ÷ ${assistantTurns || 1} turns. Real per-call tokens need a daemon API change. Sonnet context = 200 k; Sonnet 1M = 1 M.`}
           >
-            ctx {contextPct}%
-          </span>
-          <span
-            className="agent-detail__rate"
-            title="Rate-limit % needs daemon API exposing per-minute usage — not available yet"
-          >
-            rate —
+            ctx ~{formatTokens(perTurnInputTokens)}/turn
           </span>
           <span>{formatCost(detail.usage.cost_usd)}</span>
         </div>

--- a/src/components/AgentsTab.tsx
+++ b/src/components/AgentsTab.tsx
@@ -33,12 +33,12 @@ const STATE_LABELS: Record<string, string> = {
   failed: "Failed",
 };
 
-// "Office Mac" → "Office", "personal-mac" → "personal". The "-mac"
-// suffix is the same on every machine and is wasted column width.
+// Strip common suffixes — "Office Mac" → "Office", "build-server" →
+// "build", etc. The suffix is rarely useful in the column and just
+// eats width.
 function shortMachineLabel(label: string): string {
   return label
-    .replace(/[\s_-]?mac$/i, "")
-    .replace(/[\s_-]?macbook$/i, "")
+    .replace(/[\s_-]?(?:mac|macbook|linux|server|host|machine)$/i, "")
     .trim();
 }
 
@@ -291,15 +291,24 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
     });
   }, []);
 
-  // Drop any pane whose underlying agent has disappeared (deleted
-  // remotely, or its machine went offline).
+  // Drop a pane only when its machine is online AND the agent is no
+  // longer in the list (deleted remotely or kill+wipe). If the machine
+  // failed its latest poll (transient network blip on Tailscale, daemon
+  // restart), keep the pane — closing it under the user is catastrophic
+  // when 3 panes are open and wifi hiccups for one cycle.
   useEffect(() => {
-    setPanes((prev) =>
-      prev.filter((p) =>
-        agents.some((a) => a.id === p.agentId && a.machine_id === p.machineId),
-      ),
+    const onlineMachineIds = new Set(
+      machines.filter((m) => m.error === null).map((m) => m.machine.id),
     );
-  }, [agents]);
+    setPanes((prev) =>
+      prev.filter((p) => {
+        if (!onlineMachineIds.has(p.machineId)) return true; // keep — machine offline, can't tell
+        return agents.some(
+          (a) => a.id === p.agentId && a.machine_id === p.machineId,
+        );
+      }),
+    );
+  }, [agents, machines]);
 
   // Esc closes the focused pane.
   useEffect(() => {
@@ -536,6 +545,10 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
         </div>
       );
     }
+    // Resolve the machine once here so the pane (and useAgentDetail
+    // inside it) doesn't have to do a per-pane lookup every poll.
+    const paneMachine =
+      machines.find((m) => m.machine.id === c.machineId)?.machine ?? null;
     const focused = focusedPaneId === c.paneId;
     const cls = [
       "agents-tab__pane",
@@ -555,7 +568,7 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
         onFocus={() => setFocusedPaneId(c.paneId)}
       >
         <AgentDetailPane
-          machineId={c.machineId}
+          machine={paneMachine}
           agentId={c.agentId}
           onClose={() => closePane(c.paneId)}
           onDeleted={() => closePane(c.paneId)}

--- a/src/hooks/useAgentDetail.ts
+++ b/src/hooks/useAgentDetail.ts
@@ -1,19 +1,27 @@
 // Single-agent live detail fetch.
 //
-// Given a (machine_id, agent_id) pair, repeatedly fetches /v1/agents/:id
-// against the matching machine. Used by the right pane in AgentsTab to
-// keep the thread/usage view current while an agent runs.
+// Given a (machine, agent_id) pair, repeatedly polls /v1/agents/:id
+// against that machine. Used by the right pane in AgentsTab to keep
+// the thread/usage view current while an agent runs.
+//
+// History: v0.4.5 and earlier called `invoke("list_helm_machines")`
+// inside this hook every poll tick to look up the machine row by id.
+// At 4 panes × 3 s polling that was ~80 SQLite calls/min just for
+// machine lookups. v0.4.6 has the parent (AgentsTab) pass the
+// resolved machine in directly — same data, no DB round-trip.
+//
+// Also new in v0.4.6: polling pauses while document.hidden, so a
+// minimised window doesn't burn battery firing useless requests.
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { invoke } from "@tauri-apps/api/core";
 import { type AgentDetail, type HelmMachine, clientFor } from "../lib/helm-api";
 
 const POLL_INTERVAL_MS = 3_000;
 
 export interface AgentDetailResult {
   detail: AgentDetail | null;
-  /** Machine the agent belongs to. Null when not yet resolved or if the
-   *  machine row has been removed. */
+  /** Echoed back from the input — exposed here so the consumer doesn't
+   *  have to thread the same value separately. Null when no machine. */
   machine: HelmMachine | null;
   loading: boolean;
   error: string | null;
@@ -21,34 +29,28 @@ export interface AgentDetailResult {
 }
 
 export function useAgentDetail(
-  machineId: number | null,
+  machine: HelmMachine | null,
   agentId: string | null,
 ): AgentDetailResult {
   const [detail, setDetail] = useState<AgentDetail | null>(null);
-  const [machine, setMachine] = useState<HelmMachine | null>(null);
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
   const cancelledRef = useRef(false);
+  // Always-fresh ref so polling closures pick up new machine objects
+  // (e.g., token rotation) without re-creating the interval.
+  const machineRef = useRef(machine);
+  machineRef.current = machine;
 
   const fetchOnce = useCallback(async () => {
-    if (machineId === null || agentId === null) {
-      setDetail(null);
-      setMachine(null);
-      setError(null);
+    const m = machineRef.current;
+    if (!m || !agentId) {
+      if (!cancelledRef.current) {
+        setDetail(null);
+        setError(null);
+      }
       return;
     }
     try {
-      const machines = await invoke<HelmMachine[]>("list_helm_machines");
-      const m = machines.find((x) => x.id === machineId) ?? null;
-      if (!m) {
-        if (!cancelledRef.current) {
-          setMachine(null);
-          setDetail(null);
-          setError("Machine no longer registered");
-        }
-        return;
-      }
-      if (!cancelledRef.current) setMachine(m);
       const d = await clientFor(m).agent(agentId);
       if (!cancelledRef.current) {
         setDetail(d);
@@ -59,25 +61,55 @@ export function useAgentDetail(
     } finally {
       if (!cancelledRef.current) setLoading(false);
     }
-  }, [machineId, agentId]);
+  }, [agentId]);
 
   useEffect(() => {
     cancelledRef.current = false;
-    if (machineId === null || agentId === null) {
+    if (!machine || !agentId) {
       setDetail(null);
-      setMachine(null);
       setError(null);
       setLoading(false);
       return;
     }
     setLoading(true);
     void fetchOnce();
-    const id = window.setInterval(() => void fetchOnce(), POLL_INTERVAL_MS);
+
+    let interval: number | null = null;
+    const startPolling = () => {
+      if (interval !== null) return;
+      interval = window.setInterval(() => void fetchOnce(), POLL_INTERVAL_MS);
+    };
+    const stopPolling = () => {
+      if (interval !== null) {
+        window.clearInterval(interval);
+        interval = null;
+      }
+    };
+
+    if (!document.hidden) startPolling();
+
+    const onVisibility = () => {
+      if (document.hidden) {
+        stopPolling();
+      } else {
+        // Catch up immediately, then resume the regular tick.
+        void fetchOnce();
+        startPolling();
+      }
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+
     return () => {
       cancelledRef.current = true;
-      window.clearInterval(id);
+      stopPolling();
+      document.removeEventListener("visibilitychange", onVisibility);
     };
-  }, [fetchOnce, machineId, agentId]);
+    // machine.id rather than `machine` so identity changes (a fresh
+    // object with the same id from each useAllAgents poll) don't tear
+    // down the interval. Token / label changes still get picked up via
+    // machineRef on the next poll tick.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fetchOnce, machine?.id, agentId]);
 
   return {
     detail,

--- a/src/hooks/useAllAgents.ts
+++ b/src/hooks/useAllAgents.ts
@@ -130,10 +130,37 @@ export function useAllAgents(): AllAgentsResult {
   useEffect(() => {
     cancelledRef.current = false;
     void fetchOnce();
-    const id = window.setInterval(() => void fetchOnce(), POLL_INTERVAL_MS);
+
+    // Pause polling while the document is hidden — saves daemon
+    // round-trips and battery when the window is minimised. Catch
+    // up on visibility-change so the user doesn't see stale data
+    // when they come back.
+    let id: number | null = null;
+    const start = () => {
+      if (id !== null) return;
+      id = window.setInterval(() => void fetchOnce(), POLL_INTERVAL_MS);
+    };
+    const stop = () => {
+      if (id !== null) {
+        window.clearInterval(id);
+        id = null;
+      }
+    };
+    if (!document.hidden) start();
+    const onVisibility = () => {
+      if (document.hidden) {
+        stop();
+      } else {
+        void fetchOnce();
+        start();
+      }
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+
     return () => {
       cancelledRef.current = true;
-      window.clearInterval(id);
+      stop();
+      document.removeEventListener("visibilitychange", onVisibility);
     };
   }, [fetchOnce]);
 


### PR DESCRIPTION
A planning-agent audit caught five things you'd hit and not bother to report. All quiet wins, no risk.

## 1. Pane vanishes on network blip *(catastrophic)*

`AgentsTab` was dropping any pane whose agent wasn't in the latest poll. If a single fetch failed for one machine (Tailscale hiccup, daemon restart), **every pane for that machine got force-closed silently**. Open 3 panes for your work laptop, wifi hiccups for one cycle, all 3 vanish.

**Fix:** only drop when the machine is online AND the agent is gone. Offline machines → keep the pane (we can't tell yet).

## 2. N+1 `list_helm_machines` polling

`useAgentDetail` invoked `list_helm_machines` every 3 s **per pane** to look up the machine row by id. 4 panes = ~80 SQLite calls/min on data the parent already had.

**Fix:** parent (`AgentsTab`) resolves the machine once from the shared list and passes it in. `AgentDetailPane` / `useAgentDetail` now take `machine: HelmMachine | null` instead of `machineId`.

## 3. Polling kept running while document hidden

Both `useAgentDetail` and `useAllAgents` now pause on `visibilitychange` and catch up with one fetch on resume. 4 hidden panes for an hour was ~4800 wasted requests + battery.

## 4. `window.confirm` for Kill / Delete

The native confirm sheet on macOS yanks focus from every pane. Replaced with an inline two-click pattern in the ⋯ popover:
- First click arms (button turns red, label → "Click again to confirm")
- Second click executes
- Auto-resets after 4 s if you wander off

No focus theft.

## 5. ctx % was lying to non-Sonnet users

The 200 k assumption was wrong for Sonnet 1 M / Opus users — they'd see `ctx 5%` forever. Switched display from a percent to raw tokens-per-turn:

```
ctx ~12K/turn  ·  $0.4321
```

Tooltip explains the math (cumulative input ÷ assistant turns) and notes both 200 k and 1 M context windows. Honest signal.

## Bonus QoL

`shortMachineLabel` now strips `-linux` / `-server` / `-host` / `-machine` in addition to `-mac` / `-macbook`.

## Bump

v0.4.6.

## Test plan

- [ ] Local: typecheck ✅, lint ✅, format ✅, build ✅
- [ ] CI green
- [ ] Smoke: open 2-3 panes, kill the daemon on one machine — those panes stay open (no force-close)
- [ ] Smoke: minimize the window for a minute, restore — single catch-up fetch then resume
- [ ] Smoke: Kill in ⋯ menu — first click → red "Click again to confirm"; second click executes
- [ ] Smoke: usage row shows "ctx ~XK/turn $0.X" — not a percent