### PR TITLE
Responsive list columns (v0.4.9, closes #468)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.4.8",
+  "version": "0.4.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "workroot"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.4.8"
+version = "0.4.9"
 edition = "2021"
 authors = ["Saurav Panda <saurav@workroot.dev>"]
 description = "A local-first developer workspace for managing projects, terminals, and Git workflows."

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/components/AgentsTab.tsx
+++ b/src/components/AgentsTab.tsx
@@ -42,6 +42,25 @@ function shortMachineLabel(label: string): string {
     .trim();
 }
 
+// 6 desaturated colors used as a per-machine left-rule on rows when
+// the list pane gets narrow enough that the Machine column collapses.
+// Picked from the Workroot palette (periwinkle / amber / sage / coral
+// / lavender / teal) — saturation matched so no one machine pops more
+// than another.
+const MACHINE_COLORS = [
+  "#88b4ff",
+  "#d4a76a",
+  "#7ec699",
+  "#e08585",
+  "#c89dd6",
+  "#7ec0c6",
+];
+
+function machineColor(machineId: number): string {
+  const idx = Math.abs(machineId) % MACHINE_COLORS.length;
+  return MACHINE_COLORS[idx];
+}
+
 // Compact "time ago" — 1m / 2h / 3d / "now". Driven by a 30 s tick;
 // resolution coarser than 1 m doesn't matter for an agent log.
 function ageSince(iso: string, now: number): string {
@@ -449,6 +468,7 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
               const stateLabel = STATE_LABELS[a.state] ?? a.state;
               const activity = a.last_activity ?? a.task;
               const machineShort = shortMachineLabel(a.machine_label);
+              const ageStr = ageSince(a.updated_at, now);
               return (
                 <div
                   key={`${a.machine_id}:${a.id}`}
@@ -456,6 +476,15 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
                     isOpen
                       ? "agents-tab__row agents-tab__row--selected"
                       : "agents-tab__row"
+                  }
+                  // CSS variable used by container queries when the
+                  // Machine column is hidden — becomes the 6 px left
+                  // rule on each row, encoding machine identity
+                  // spatially when label text isn't available.
+                  style={
+                    {
+                      "--row-machine-color": machineColor(a.machine_id),
+                    } as React.CSSProperties
                   }
                   onClick={() => openAgent(a.machine_id, a.id)}
                   role="row"
@@ -487,8 +516,11 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
                   >
                     {machineShort}
                   </span>
-                  <span className="agents-tab__cell-age">
-                    {ageSince(a.updated_at, now)}
+                  <span
+                    className="agents-tab__cell-age"
+                    title={`updated ${ageStr} ago — on ${a.machine_label}`}
+                  >
+                    {ageStr}
                   </span>
                 </div>
               );

--- a/src/styles/agents-tab.css
+++ b/src/styles/agents-tab.css
@@ -23,6 +23,11 @@
   padding: 16px 20px;
   overflow: auto;
   border-right: 1px solid var(--color-border, #2a2a2a);
+  /* Establish a containment context so the table can drop columns
+   * based on its own width, not the viewport's. Triggers when the
+   * panes container expands and squeezes us. */
+  container-type: inline-size;
+  container-name: agents-list;
 }
 
 /* ---- splits container — flex with draggable dividers ----
@@ -444,6 +449,57 @@
   font-size: 11px;
   color: var(--color-text-secondary, #888);
   text-align: right;
+}
+
+/* ---- responsive list — drop columns as the list pane gets squeezed
+ * (4 panes open clamps the list to ~280-320 px). At narrow widths the
+ * Machine column collapses into a 6 px colored left rule (per-machine
+ * via the inline --row-machine-color CSS variable). At very narrow
+ * widths the Age column disappears — it's still in the row's title
+ * tooltip on hover. State pill / Name / Activity always visible. */
+
+@container agents-list (max-width: 360px) {
+  /* Drop Machine + Repo header cells */
+  .agents-tab__thead > [role="columnheader"]:nth-child(4),
+  .agents-tab__thead > [role="columnheader"]:nth-child(5) {
+    display: none;
+  }
+  /* Drop Machine + Repo row cells */
+  .agents-tab__cell-repo,
+  .agents-tab__cell-machine {
+    display: none;
+  }
+  /* Reflow grid to 4 visible cells: state · name · activity · age */
+  .agents-tab__thead,
+  .agents-tab__row {
+    grid-template-columns:
+      72px /* state */
+      minmax(80px, 1.4fr) /* name */
+      minmax(90px, 2fr) /* activity */
+      44px; /* age */
+  }
+  /* Replace machine-label column with a 6 px colored left rule keyed
+   * to the row's machineId hash. Selected-row accent rule is on the
+   * border-left, so we keep them on different visual layers. */
+  .agents-tab__row {
+    box-shadow: inset 6px 0 0 0
+      var(--row-machine-color, var(--color-border-subtle, transparent));
+    padding-left: 14px;
+  }
+}
+
+@container agents-list (max-width: 300px) {
+  .agents-tab__thead > [role="columnheader"]:nth-child(6),
+  .agents-tab__cell-age {
+    display: none;
+  }
+  .agents-tab__thead,
+  .agents-tab__row {
+    grid-template-columns:
+      72px /* state */
+      minmax(70px, 1fr) /* name */
+      minmax(80px, 2fr); /* activity */
+  }
 }
 
 /* ---- empty / loading ---- */


### PR DESCRIPTION
Closes #468.

When the panes container grows (3-4 panes open) the list pane is clamped to ~280-320 px. The agents table was overflowing — Machine + Age columns clipped, Repo got an ellipsis mid-word.

## What

**Container queries** on `.agents-tab__list-pane` (`container-type: inline-size`) so the table drops columns based on its *own* width, not the viewport's. Opens more panes → list shrinks → columns drop in order.

| List width | Visible columns |
|---|---|
| Default (≥360 px) | state · name · activity · repo · machine · age |
| < 360 px | state · name · activity · age — Machine becomes a **6 px colored left rule** keyed to `machineId % 6` |
| < 300 px | state · name · activity (age moves to the row's hover tooltip) |

State pill, name, activity always visible.

## Per-machine left rule

When the Machine column collapses, identity moves to a colored 6 px rule on the row's left edge. Hash `machineId` → one of 6 desaturated palette colors (periwinkle / amber / sage / coral / lavender / teal — saturation matched so no machine pops more than another). Done via inline `--row-machine-color` CSS variable + `box-shadow: inset` so the existing selected-row accent border stays on its own layer.

## Tooltips preserve info

The Age cell's `title` now includes the machine label too — `"updated 3m ago — on Office Mac"` — so hovering at narrow widths still answers "which machine, when?".

## Bump

v0.4.9

## Test plan
- [ ] Local: typecheck ✅, lint ✅, format ✅, build ✅
- [ ] CI green
- [ ] Smoke: 1 pane open → list wide, all columns visible
- [ ] Smoke: 4 panes open → list narrow, only state/name/activity/age visible + colored left rule
- [ ] Smoke: shrink window further → age also drops, state/name/activity remain