### PR TITLE
Settings close + always-on highlight + appearance settings + planner-bundle UX (v0.4.11)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.4.9",
+  "version": "0.4.10",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.4.10",
+  "version": "0.4.11",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "workroot"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "workroot"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.4.9"
+version = "0.4.10"
 edition = "2021"
 authors = ["Saurav Panda <saurav@workroot.dev>"]
 description = "A local-first developer workspace for managing projects, terminals, and Git workflows."

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.4.10"
+version = "0.4.11"
 edition = "2021"
 authors = ["Saurav Panda <saurav@workroot.dev>"]
 description = "A local-first developer workspace for managing projects, terminals, and Git workflows."

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { ErrorProvider } from "./contexts/ErrorContext";
 import { ErrorBoundary, PanelBoundary } from "./components/ErrorBoundary";
 import { GlobalErrorToast } from "./components/GlobalErrorToast";
 import { invoke } from "@tauri-apps/api/core";
+import { applyAppearance, loadAppearance } from "./lib/appearance";
 import { MainLayout } from "./layouts/MainLayout";
 import { QuickActions } from "./components/QuickActions";
 import { StatusBar } from "./components/StatusBar";
@@ -77,6 +78,13 @@ function AppContent({
     markAgentRunning,
     clearAgentRunning,
   } = useUiStore();
+
+  // Apply the user's saved appearance (mono font + transcript body
+  // size) on first paint. SettingsTab updates the same CSS vars on
+  // change, so this is just the cold-start path.
+  useEffect(() => {
+    void loadAppearance().then(applyAppearance);
+  }, []);
 
   const [isGitHubConnected, setIsGitHubConnected] = useState(false);
   useEffect(() => {

--- a/src/components/AgentDetailPane.tsx
+++ b/src/components/AgentDetailPane.tsx
@@ -178,6 +178,41 @@ function linkifyText(text: string): ReactNode {
   return parts;
 }
 
+// Markdown ```lang\n...\n``` code fences. Assistant messages routinely
+// wrap code/diffs/configs this way; rendering them as plain mono
+// dropped all the syntax color the user expected. Parser is regex —
+// nested fences aren't a real concern in agent transcripts.
+const FENCE_RE = /```([a-zA-Z0-9_+-]*)\n([\s\S]*?)```/g;
+
+type MdSegment =
+  | { type: "text"; body: string }
+  | { type: "code"; lang: string | null; body: string };
+
+function splitMarkdownFences(text: string): MdSegment[] {
+  if (!text || text.indexOf("```") === -1) {
+    return [{ type: "text", body: text }];
+  }
+  const out: MdSegment[] = [];
+  let lastIdx = 0;
+  // matchAll preserves indexes across iterations (regex /g).
+  for (const m of text.matchAll(FENCE_RE)) {
+    const start = m.index!;
+    if (start > lastIdx) {
+      out.push({ type: "text", body: text.slice(lastIdx, start) });
+    }
+    out.push({
+      type: "code",
+      lang: m[1] || null,
+      body: m[2].replace(/\n$/, ""),
+    });
+    lastIdx = start + m[0].length;
+  }
+  if (lastIdx < text.length) {
+    out.push({ type: "text", body: text.slice(lastIdx) });
+  }
+  return out.length > 0 ? out : [{ type: "text", body: text }];
+}
+
 // Wrap bare URLs in HTML with anchor tags. Skip URLs already inside an
 // attribute value (e.g. `href="..."` from highlight.js output) by
 // requiring a non-attribute character right before the URL.
@@ -337,6 +372,11 @@ function MessageItem({
       </div>
     );
   }
+  // Assistant messages routinely wrap code in ```lang fences; parse
+  // them out and render each fenced block as a CodeBlock so syntax
+  // highlighting fires inside the message body. Plain prose between
+  // fences still gets linkifyText for clickable URLs.
+  const segments = splitMarkdownFences(text);
   return (
     <div
       className={
@@ -345,7 +385,15 @@ function MessageItem({
           : "agent-detail__msg agent-detail__msg--assistant"
       }
     >
-      <div className="agent-detail__msg-body">{linkifyText(text)}</div>
+      <div className="agent-detail__msg-body">
+        {segments.map((seg, i) =>
+          seg.type === "code" ? (
+            <CodeBlock key={i} code={seg.body} language={seg.lang} />
+          ) : (
+            <span key={i}>{linkifyText(seg.body)}</span>
+          ),
+        )}
+      </div>
     </div>
   );
 }
@@ -495,9 +543,12 @@ function ToolArgs({ toolUse }: { toolUse: ToolUseEv }) {
 
 // Dispatch the result body based on tool name. Bash output gets ANSI
 // parsing; Read result gets language-highlighted from the file_path
-// arg; everything else is plain mono. When trimmed (collapsed view),
-// we render the trimmed text unstyled — coloring a 14-line head/tail
-// snippet adds noise, not signal.
+// arg; everything else uses CodeBlock with auto-detect so even
+// arbitrary stdout gets a pass at colorization. v0.4.10 dropped the
+// "plain text in collapsed mode" early return — the user couldn't
+// see any highlighting on tool results because they were collapsed
+// by default. Highlighting a 14-line trimmed snippet is fine; the
+// overhead is negligible.
 function ToolResultBody({
   toolUse,
   toolResult,
@@ -512,11 +563,6 @@ function ToolResultBody({
   const text = expanded ? toolResult.preview : trimmed.display;
   const lower = toolUse.tool.toLowerCase();
 
-  // Collapsed view: keep it lightweight (no highlighter pass on trimmed).
-  if (!expanded) {
-    return <pre className="agent-detail__code">{text}</pre>;
-  }
-
   if (lower === "bash" || lower.includes("shell")) {
     return <AnsiBlock text={text} />;
   }
@@ -528,7 +574,7 @@ function ToolResultBody({
     return <CodeBlock code={text} language={lang} />;
   }
 
-  return <pre className="agent-detail__code">{text}</pre>;
+  return <CodeBlock code={text} />;
 }
 
 function ToolItem({

--- a/src/components/AgentDetailPane.tsx
+++ b/src/components/AgentDetailPane.tsx
@@ -969,7 +969,7 @@ export function AgentDetailPane({
             className={`agent-detail__state-tag agent-detail__state-tag--${detail.state}`}
             title={detail.state}
           >
-            [{detail.state}]
+            {detail.state}
           </span>
         )}
         <span className="agent-detail__name" title={detail?.name ?? undefined}>
@@ -996,7 +996,7 @@ export function AgentDetailPane({
                 className="agent-detail__pin-tag"
                 title="Pinned — won't be evicted when opening another agent"
               >
-                [pinned]
+                pinned
               </span>
             )}
           </>

--- a/src/components/AgentsTab.tsx
+++ b/src/components/AgentsTab.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { open as openShell } from "@tauri-apps/plugin-shell";
 import { useAllAgents, type MachineStatus } from "../hooks/useAllAgents";
 import { AgentDetailPane } from "./AgentDetailPane";
 import "../styles/agents-tab.css";
@@ -40,25 +41,6 @@ function shortMachineLabel(label: string): string {
   return label
     .replace(/[\s_-]?(?:mac|macbook|linux|server|host|machine)$/i, "")
     .trim();
-}
-
-// 6 desaturated colors used as a per-machine left-rule on rows when
-// the list pane gets narrow enough that the Machine column collapses.
-// Picked from the Workroot palette (periwinkle / amber / sage / coral
-// / lavender / teal) — saturation matched so no one machine pops more
-// than another.
-const MACHINE_COLORS = [
-  "#88b4ff",
-  "#d4a76a",
-  "#7ec699",
-  "#e08585",
-  "#c89dd6",
-  "#7ec0c6",
-];
-
-function machineColor(machineId: number): string {
-  const idx = Math.abs(machineId) % MACHINE_COLORS.length;
-  return MACHINE_COLORS[idx];
 }
 
 // Compact "time ago" — 1m / 2h / 3d / "now". Driven by a 30 s tick;
@@ -433,29 +415,58 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
 
       {noMachines ? (
         <div className="agents-tab__empty">
-          <p>No helm machines registered.</p>
-          <p style={{ fontSize: 12, marginTop: 8 }}>
-            Add a daemon endpoint to start watching agents.
+          <h3 className="agents-tab__empty-title">
+            Workroot watches AI agents running on your machines.
+          </h3>
+          <p>
+            Connect a helm-daemon — local, remote over SSH, or Tailscale — to
+            see what your agents are doing right now.
           </p>
-          <button className="agents-tab__empty-cta" onClick={onOpenMachines}>
-            Add machine
-          </button>
+          <div className="agents-tab__empty-actions">
+            <button
+              className="agents-tab__empty-cta agents-tab__empty-cta--primary"
+              onClick={onOpenMachines}
+            >
+              Add a machine
+            </button>
+            <button
+              type="button"
+              className="agents-tab__empty-cta"
+              onClick={() => {
+                void openShell(
+                  "https://github.com/sauravpanda/workroot#readme",
+                ).catch(() => {});
+              }}
+            >
+              Read the setup docs
+            </button>
+          </div>
         </div>
       ) : loading ? (
         <div className="agents-tab__empty">Loading agents…</div>
       ) : agents.length === 0 ? (
         <div className="agents-tab__empty">
-          <p>No active agents.</p>
-          <p style={{ fontSize: 12, marginTop: 8 }}>
-            Spawn one from the helm CLI or phone app — it'll show up here.
-          </p>
+          <h3 className="agents-tab__empty-title">No active agents yet.</h3>
+          <p>Spawn one from the helm CLI:</p>
+          <pre className="agents-tab__empty-code">
+            helm spawn &lt;repo&gt; "&lt;task&gt;"
+          </pre>
+          <p>It'll show up here within a few seconds of starting.</p>
         </div>
       ) : (
-        <div className="agents-tab__table" role="table" aria-label="Agents">
+        <div
+          className={
+            machines.length <= 1
+              ? "agents-tab__table agents-tab__table--solo-machine"
+              : "agents-tab__table"
+          }
+          role="table"
+          aria-label="Agents"
+        >
           <div className="agents-tab__thead" role="row">
             <span role="columnheader">State</span>
             <span role="columnheader">Name</span>
-            <span role="columnheader">Activity</span>
+            <span role="columnheader">Doing</span>
             <span role="columnheader">Repo</span>
             <span role="columnheader">Machine</span>
             <span role="columnheader" className="agents-tab__col-age">
@@ -476,15 +487,6 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
                     isOpen
                       ? "agents-tab__row agents-tab__row--selected"
                       : "agents-tab__row"
-                  }
-                  // CSS variable used by container queries when the
-                  // Machine column is hidden — becomes the 6 px left
-                  // rule on each row, encoding machine identity
-                  // spatially when label text isn't available.
-                  style={
-                    {
-                      "--row-machine-color": machineColor(a.machine_id),
-                    } as React.CSSProperties
                   }
                   onClick={() => openAgent(a.machine_id, a.id)}
                   role="row"

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -4,6 +4,16 @@ import { getVersion } from "@tauri-apps/api/app";
 import { check } from "@tauri-apps/plugin-updater";
 import { relaunch } from "@tauri-apps/plugin-process";
 import { open as openShell } from "@tauri-apps/plugin-shell";
+import {
+  type Appearance,
+  BODY_SIZE_OPTIONS,
+  DEFAULT_APPEARANCE,
+  MONO_FONT_OPTIONS,
+  applyAppearance,
+  loadAppearance,
+  persistBodySize,
+  persistMonoFont,
+} from "../lib/appearance";
 import "../styles/settings.css";
 
 interface SettingField {
@@ -82,6 +92,29 @@ export function SettingsTab({
     getVersion()
       .then(setAppVersion)
       .catch(() => setAppVersion("unknown"));
+  }, []);
+
+  const [appearance, setAppearance] = useState<Appearance>(DEFAULT_APPEARANCE);
+  useEffect(() => {
+    void loadAppearance().then(setAppearance);
+  }, []);
+
+  const handleMonoFontChange = useCallback((id: string) => {
+    setAppearance((prev) => {
+      const next = { ...prev, monoFontId: id };
+      applyAppearance(next);
+      void persistMonoFont(id);
+      return next;
+    });
+  }, []);
+
+  const handleBodySizeChange = useCallback((px: number) => {
+    setAppearance((prev) => {
+      const next = { ...prev, bodySize: px };
+      applyAppearance(next);
+      void persistBodySize(px);
+      return next;
+    });
   }, []);
 
   // Esc closes the settings tab. Doesn't fire inside text inputs
@@ -165,14 +198,22 @@ export function SettingsTab({
             aria-label="Close settings"
             title="Close settings (Esc)"
           >
-            <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 14 14"
+              fill="none"
+              aria-hidden="true"
+            >
               <path
-                d="M3 3L11 11M11 3L3 11"
+                d="M9 3L4 7L9 11"
                 stroke="currentColor"
                 strokeWidth="1.5"
                 strokeLinecap="round"
+                strokeLinejoin="round"
               />
             </svg>
+            <span>Back</span>
           </button>
         )}
         <p className="settings-loading">Loading settings...</p>
@@ -291,6 +332,66 @@ export function SettingsTab({
           <li>Copy the Client ID and paste it below</li>
         </ol>
         {GITHUB_FIELDS.map(renderField)}
+      </section>
+
+      <hr className="settings-divider" />
+
+      <section className="settings-section">
+        <h3 className="settings-section-title">Appearance</h3>
+        <p className="settings-section-desc">
+          Tune the agent transcript font and size. Changes apply immediately and
+          persist across launches.
+        </p>
+
+        <div className="settings-field">
+          <label
+            className="settings-label"
+            htmlFor="setting-appearance-mono-font"
+          >
+            Mono Font
+          </label>
+          <select
+            id="setting-appearance-mono-font"
+            className="settings-input"
+            value={appearance.monoFontId}
+            onChange={(e) => handleMonoFontChange(e.target.value)}
+          >
+            {MONO_FONT_OPTIONS.map((opt) => (
+              <option key={opt.id} value={opt.id}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+          <p className="settings-help">
+            Used everywhere mono renders — chat body, tool args, code blocks,
+            diff viewer.
+          </p>
+        </div>
+
+        <div className="settings-field">
+          <label
+            className="settings-label"
+            htmlFor="setting-appearance-font-size"
+          >
+            Transcript Font Size
+          </label>
+          <select
+            id="setting-appearance-font-size"
+            className="settings-input"
+            value={appearance.bodySize}
+            onChange={(e) => handleBodySizeChange(parseInt(e.target.value, 10))}
+          >
+            {BODY_SIZE_OPTIONS.map((px) => (
+              <option key={px} value={px}>
+                {px}px
+              </option>
+            ))}
+          </select>
+          <p className="settings-help">
+            Sets the body size for assistant + user messages. Code blocks size
+            relative to this.
+          </p>
+        </div>
       </section>
 
       <hr className="settings-divider" />

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -84,6 +84,20 @@ export function SettingsTab({
       .catch(() => setAppVersion("unknown"));
   }, []);
 
+  // Esc closes the settings tab. Doesn't fire inside text inputs
+  // (where Esc is sometimes used to clear/blur the field).
+  useEffect(() => {
+    if (!onClose) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      const t = e.target as HTMLElement | null;
+      if (t && (t.tagName === "INPUT" || t.tagName === "TEXTAREA")) return;
+      onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
   const handleCheckForUpdate = useCallback(async () => {
     setUpdateStatus({ state: "checking" });
     try {
@@ -229,14 +243,22 @@ export function SettingsTab({
           aria-label="Close settings"
           title="Close settings (Esc)"
         >
-          <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 14 14"
+            fill="none"
+            aria-hidden="true"
+          >
             <path
-              d="M3 3L11 11M11 3L3 11"
+              d="M9 3L4 7L9 11"
               stroke="currentColor"
               strokeWidth="1.5"
               strokeLinecap="round"
+              strokeLinejoin="round"
             />
           </svg>
+          <span>Back</span>
         </button>
       )}
       <h2 className="settings-title">Settings</h2>

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
+import { useFleetSnapshot } from "../hooks/useAllAgents";
 import "../styles/status-bar.css";
 
 /* ------------------------------------------------------------------ */
@@ -17,6 +18,49 @@ interface StatusBarProps {
 
 function formatTime(date: Date): string {
   return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+/* ------------------------------------------------------------------ */
+/*  Fleet summary — left-most status zone                              */
+/* ------------------------------------------------------------------ */
+
+// One-line ambient answer to "is anything on fire across the fleet."
+// Renders nothing when the user hasn't registered any helm machines
+// yet; otherwise: "N machines online · M agents (K need you)".
+// "K need you" goes amber when > 0.
+function FleetSummary() {
+  const { machines, agents } = useFleetSnapshot();
+  const summary = useMemo(() => {
+    if (machines.length === 0) return null;
+    const online = machines.filter((m) => m.error === null).length;
+    const needsYou = agents.filter((a) => a.state === "waiting_input").length;
+    return { online, total: machines.length, agents: agents.length, needsYou };
+  }, [machines, agents]);
+  if (!summary) return null;
+
+  const machineLabel =
+    summary.total === summary.online
+      ? `${summary.online} machine${summary.online === 1 ? "" : "s"}`
+      : `${summary.online}/${summary.total} machines`;
+  const agentLabel = `${summary.agents} agent${summary.agents === 1 ? "" : "s"}`;
+
+  return (
+    <span
+      className={
+        summary.needsYou > 0
+          ? "status-bar-item status-bar-fleet status-bar-fleet--alert"
+          : "status-bar-item status-bar-fleet"
+      }
+      title={
+        summary.online < summary.total
+          ? `${summary.total - summary.online} machine(s) unreachable`
+          : undefined
+      }
+    >
+      {machineLabel} · {agentLabel}
+      {summary.needsYou > 0 && ` (${summary.needsYou} need you)`}
+    </span>
+  );
 }
 
 /* ------------------------------------------------------------------ */
@@ -53,6 +97,7 @@ export function StatusBar({
     <div className="status-bar">
       {/* -- Left side -- */}
       <div className="status-bar-left">
+        <FleetSummary />
         <span className="status-bar-item">
           {projectName ?? "No project selected"}
         </span>

--- a/src/hooks/useAllAgents.ts
+++ b/src/hooks/useAllAgents.ts
@@ -58,6 +58,48 @@ function sortByAttention(a: MergedAgent, b: MergedAgent): number {
 
 const POLL_INTERVAL_MS = 5_000;
 
+// Module-level snapshot of the latest fleet poll so other surfaces
+// (StatusBar, future fleet widgets) can read without spinning up
+// their own polling instance. Updated by useAllAgents on each
+// successful fetch and broadcast via a CustomEvent.
+let cachedFleet: AllAgentsResult = {
+  agents: [],
+  machines: [],
+  loading: true,
+  refresh: () => {},
+};
+
+function publishFleet(next: Omit<AllAgentsResult, "refresh">): void {
+  cachedFleet = { ...next, refresh: cachedFleet.refresh };
+  window.dispatchEvent(new CustomEvent("workroot:fleet"));
+}
+
+/** Read-only view of the latest fleet snapshot. Subscribes to the
+ *  same updates useAllAgents broadcasts — no separate polling. */
+export function useFleetSnapshot(): {
+  agents: MergedAgent[];
+  machines: MachineStatus[];
+  loading: boolean;
+} {
+  const [snap, setSnap] = useState(() => ({
+    agents: cachedFleet.agents,
+    machines: cachedFleet.machines,
+    loading: cachedFleet.loading,
+  }));
+  useEffect(() => {
+    const sync = () =>
+      setSnap({
+        agents: cachedFleet.agents,
+        machines: cachedFleet.machines,
+        loading: cachedFleet.loading,
+      });
+    window.addEventListener("workroot:fleet", sync);
+    sync(); // pick up any updates that happened between mount + subscribe
+    return () => window.removeEventListener("workroot:fleet", sync);
+  }, []);
+  return snap;
+}
+
 export function useAllAgents(): AllAgentsResult {
   const [agents, setAgents] = useState<MergedAgent[]>([]);
   const [machines, setMachines] = useState<MachineStatus[]>([]);
@@ -116,15 +158,19 @@ export function useAllAgents(): AllAgentsResult {
       .filter((a) => !a.archived)
       .sort(sortByAttention);
 
+    const machineStatuses = results.map(({ machine, error, agent_count }) => ({
+      machine,
+      error,
+      agent_count,
+    }));
     setAgents(merged);
-    setMachines(
-      results.map(({ machine, error, agent_count }) => ({
-        machine,
-        error,
-        agent_count,
-      })),
-    );
+    setMachines(machineStatuses);
     setLoading(false);
+    publishFleet({
+      agents: merged,
+      machines: machineStatuses,
+      loading: false,
+    });
   }, []);
 
   useEffect(() => {

--- a/src/lib/appearance.ts
+++ b/src/lib/appearance.ts
@@ -1,0 +1,117 @@
+// User-tunable appearance: mono font + transcript body size. Persists
+// in the existing settings table via two keys (appearance_mono_font,
+// appearance_font_size). Applies via two CSS variables on the
+// document root:
+//   --font-mono       (overrides the @theme default → cascades
+//                       everywhere mono is used)
+//   --app-msg-size    (consumed only by .agent-detail__msg-body)
+//
+// Kept tiny and pure — no React state. Callers (App.tsx for the
+// initial paint, SettingsTab for the controls) own their own state
+// and call applyAppearance() to push it to the DOM.
+
+import { invoke } from "@tauri-apps/api/core";
+
+export interface MonoFontOption {
+  id: string;
+  label: string;
+  stack: string;
+}
+
+export const MONO_FONT_OPTIONS: MonoFontOption[] = [
+  {
+    id: "jetbrains",
+    label: "JetBrains Mono",
+    stack: '"JetBrains Mono", "SF Mono", "Menlo", "Cascadia Code", monospace',
+  },
+  {
+    id: "sfmono",
+    label: "SF Mono",
+    stack: '"SF Mono", "Menlo", "Monaco", monospace',
+  },
+  {
+    id: "menlo",
+    label: "Menlo",
+    stack: '"Menlo", "Monaco", "Courier New", monospace',
+  },
+  {
+    id: "cascadia",
+    label: "Cascadia Code",
+    stack: '"Cascadia Code", "Cascadia Mono", "Menlo", monospace',
+  },
+  {
+    id: "geist",
+    label: "Geist Mono",
+    stack: '"Geist Mono", "JetBrains Mono", "SF Mono", monospace',
+  },
+];
+
+export const BODY_SIZE_OPTIONS = [12, 13, 14, 15, 16] as const;
+
+export interface Appearance {
+  monoFontId: string;
+  bodySize: number;
+}
+
+export const DEFAULT_APPEARANCE: Appearance = {
+  monoFontId: "jetbrains",
+  bodySize: 13,
+};
+
+export function fontStackFor(id: string): string {
+  return (
+    MONO_FONT_OPTIONS.find((o) => o.id === id)?.stack ??
+    MONO_FONT_OPTIONS[0].stack
+  );
+}
+
+export function applyAppearance(a: Appearance): void {
+  const root = document.documentElement;
+  root.style.setProperty("--font-mono", fontStackFor(a.monoFontId));
+  root.style.setProperty("--app-msg-size", `${a.bodySize}px`);
+}
+
+/** Load the persisted appearance from the settings table. Returns
+ *  defaults on any error (table empty, key missing, network blip). */
+export async function loadAppearance(): Promise<Appearance> {
+  try {
+    const entries =
+      await invoke<{ key: string; value: string }[]>("get_all_settings");
+    const map: Record<string, string> = {};
+    for (const e of entries) map[e.key] = e.value;
+    const fontId = map.appearance_mono_font || DEFAULT_APPEARANCE.monoFontId;
+    const sizeRaw = map.appearance_font_size;
+    const size = sizeRaw ? parseInt(sizeRaw, 10) : DEFAULT_APPEARANCE.bodySize;
+    return {
+      monoFontId: MONO_FONT_OPTIONS.some((o) => o.id === fontId)
+        ? fontId
+        : DEFAULT_APPEARANCE.monoFontId,
+      bodySize:
+        Number.isFinite(size) &&
+        (BODY_SIZE_OPTIONS as readonly number[]).includes(size)
+          ? size
+          : DEFAULT_APPEARANCE.bodySize,
+    };
+  } catch {
+    return DEFAULT_APPEARANCE;
+  }
+}
+
+export async function persistMonoFont(id: string): Promise<void> {
+  try {
+    await invoke("set_setting", { key: "appearance_mono_font", value: id });
+  } catch {
+    // ignore — applied to DOM regardless; SQLite write failure is rare
+  }
+}
+
+export async function persistBodySize(px: number): Promise<void> {
+  try {
+    await invoke("set_setting", {
+      key: "appearance_font_size",
+      value: String(px),
+    });
+  } catch {
+    // ignore
+  }
+}

--- a/src/styles/agent-detail.css
+++ b/src/styles/agent-detail.css
@@ -313,6 +313,9 @@
   white-space: pre-wrap;
   word-break: break-word;
   font-family: var(--font-mono, monospace);
+  /* User-tunable transcript body size — see Settings → Appearance.
+   * Defaults to 13px when no preference is stored. */
+  font-size: var(--app-msg-size, 13px);
   line-height: 1.5;
   /* Body text is the primary read surface — use --color-text, not
    * the dim secondary fallback that bled in from the v0.4.0 swap. */

--- a/src/styles/agent-detail.css
+++ b/src/styles/agent-detail.css
@@ -59,10 +59,7 @@
 
 .agent-detail__pin-tag {
   font-family: var(--font-mono, monospace);
-  font-size: 10px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
+  font-size: 11px;
   color: var(--color-warning, #d4a76a);
   flex: 0 0 auto;
 }
@@ -133,15 +130,12 @@
   margin: 4px 0;
 }
 
-/* Bracketed state tag in the collapsed header — pure text, no chrome.
- * The agents-table still uses the rounded color pill (better for color
- * scanning across many rows). */
+/* State tag in the collapsed header — pure text, no chrome, no
+ * uppercase. Color encodes state, weight separates from prose. */
 .agent-detail__state-tag {
   font-family: var(--font-mono, monospace);
   font-size: 11px;
   font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
   color: var(--color-text-secondary, #888);
   flex: 0 0 auto;
 }
@@ -331,10 +325,12 @@
 
 .agent-detail__msg--user {
   align-self: flex-end;
-  max-width: min(78%, 640px);
+  /* Tighter than 78 % — single-line user replies were reading like
+   * quoted blocks at the wider cap. The bg tint + right alignment
+   * carry the "user message" signal; the left rule was redundant. */
+  max-width: min(62%, 520px);
   padding: 4px 8px;
   background: var(--color-accent-muted, rgba(136, 180, 255, 0.14));
-  border-left: 2px solid var(--color-accent, #88b4ff);
   color: var(--color-text, #e4e4e4);
 }
 
@@ -388,8 +384,11 @@
   border-left-color: var(--color-danger, #f87171);
 }
 
+/* Running tool — accent (not green). Green is reserved for diff-add
+ * + successful completion. A pending tool that looks like a finished
+ * one was a real "it lies to me" complaint. */
 .agent-detail__tool.is-pending {
-  border-left-color: var(--color-success, #7ec699);
+  border-left-color: var(--color-accent, #88b4ff);
 }
 
 .agent-detail__tool-head {
@@ -428,9 +427,9 @@
 
 .agent-detail__tool-pending {
   font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  color: var(--color-success, #7ec699);
+  letter-spacing: 0.3px;
+  /* Accent, not green — see is-pending rule above for the reason. */
+  color: var(--color-accent, #88b4ff);
   flex: 0 0 auto;
 }
 

--- a/src/styles/agent-detail.css
+++ b/src/styles/agent-detail.css
@@ -305,7 +305,7 @@
 .agent-detail__msg {
   display: flex;
   flex-direction: column;
-  font-size: 12px;
+  font-size: 13px;
   word-break: break-word;
 }
 
@@ -313,7 +313,17 @@
   white-space: pre-wrap;
   word-break: break-word;
   font-family: var(--font-mono, monospace);
-  line-height: 1.45;
+  line-height: 1.5;
+  /* Body text is the primary read surface — use --color-text, not
+   * the dim secondary fallback that bled in from the v0.4.0 swap. */
+  color: var(--color-text, #d4d8de);
+}
+
+/* Inline code blocks parsed from ```lang fences in assistant
+ * messages. Sit snug inside the bubble with a slight margin. */
+.agent-detail__msg-body .agent-detail__code {
+  margin: 6px 0;
+  font-size: 12px;
 }
 
 .agent-detail__msg--user {
@@ -460,11 +470,13 @@
   white-space: pre-wrap;
   word-break: break-word;
   font-family: var(--font-mono, monospace);
-  font-size: 11px;
-  color: var(--color-text-secondary, #aaa);
+  font-size: 12px;
+  /* Use primary text — this is the actual content, not secondary
+   * meta. hljs-* spans override per-token; this is the fallback. */
+  color: var(--color-text, #d4d8de);
   max-height: 480px;
   overflow: auto;
-  line-height: 1.45;
+  line-height: 1.5;
 }
 
 .agent-detail__code--ansi {

--- a/src/styles/agents-tab.css
+++ b/src/styles/agents-tab.css
@@ -478,14 +478,6 @@
       minmax(90px, 2fr) /* activity */
       44px; /* age */
   }
-  /* Replace machine-label column with a 6 px colored left rule keyed
-   * to the row's machineId hash. Selected-row accent rule is on the
-   * border-left, so we keep them on different visual layers. */
-  .agents-tab__row {
-    box-shadow: inset 6px 0 0 0
-      var(--row-machine-color, var(--color-border-subtle, transparent));
-    padding-left: 14px;
-  }
 }
 
 @container agents-list (max-width: 300px) {
@@ -502,20 +494,74 @@
   }
 }
 
+/* Solo-machine mode — when only one helm machine is registered the
+ * Machine column is dead pixels (every cell shows the same string).
+ * The .agents-tab__table--solo-machine class added by AgentsTab.tsx
+ * collapses it for both header + rows. */
+.agents-tab__table--solo-machine
+  .agents-tab__thead
+  > [role="columnheader"]:nth-child(5),
+.agents-tab__table--solo-machine .agents-tab__cell-machine {
+  display: none;
+}
+.agents-tab__table--solo-machine .agents-tab__thead,
+.agents-tab__table--solo-machine .agents-tab__row {
+  grid-template-columns:
+    72px /* state */
+    minmax(120px, 1.4fr) /* name */
+    minmax(140px, 2.4fr) /* activity */
+    minmax(96px, 1fr) /* repo */
+    44px; /* age */
+}
+
+/* "Needs you" rows shout — bold name + subtle amber wash. The state
+ * pill alone wasn't loud enough to grab attention across a full
+ * screen of working/done agents. */
+.agents-tab__row:has(.agents-tab__state-pill--waiting_input) {
+  background: rgba(212, 167, 106, 0.06);
+}
+.agents-tab__row:has(.agents-tab__state-pill--waiting_input)
+  .agents-tab__cell-name {
+  font-weight: 600;
+}
+
 /* ---- empty / loading ---- */
 
 .agents-tab__empty {
-  margin-top: 32px;
-  padding: 32px;
+  margin: 48px auto 0;
+  max-width: 520px;
+  padding: 28px 32px;
   text-align: center;
   border: 1px dashed var(--color-border, #2a2a2a);
   border-radius: 6px;
   color: var(--color-text-secondary, #888);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.agents-tab__empty-title {
+  margin: 0 0 12px;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--color-text, #d4d8de);
+  letter-spacing: -0.005em;
+}
+
+.agents-tab__empty p {
+  margin: 8px 0;
+}
+
+.agents-tab__empty-actions {
+  margin-top: 18px;
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  flex-wrap: wrap;
 }
 
 .agents-tab__empty-cta {
   margin-top: 12px;
-  padding: 6px 12px;
+  padding: 6px 14px;
   font-size: 12px;
   border: 1px solid var(--color-border, #2a2a2a);
   border-radius: 4px;
@@ -526,4 +572,29 @@
 
 .agents-tab__empty-cta:hover {
   background: var(--color-bg-hover, #222);
+}
+
+.agents-tab__empty-cta--primary {
+  border-color: var(--color-accent, #88b4ff);
+  color: var(--color-accent, #88b4ff);
+}
+
+.agents-tab__empty-cta--primary:hover {
+  background: var(--color-accent-muted, rgba(136, 180, 255, 0.14));
+}
+
+/* "helm spawn …" code line — copyable look. Inherits the mono +
+ * surface bg from the rest of the design. */
+.agents-tab__empty-code {
+  margin: 12px auto;
+  padding: 8px 12px;
+  font-family: var(--font-mono, monospace);
+  font-size: 12px;
+  background: var(--color-bg-elevated, #1a1f25);
+  border: 1px solid var(--color-border-subtle, #1f252c);
+  border-radius: 4px;
+  color: var(--color-text, #d4d8de);
+  text-align: left;
+  display: inline-block;
+  white-space: pre;
 }

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -10,20 +10,26 @@
   position: relative;
 }
 
+/* Top-left so it reads as "back to where I came from" rather than
+ * "dismiss this dialog". Labeled, not just a tiny X — many users
+ * told us it was hard to find. Matches the Esc key behavior. */
 .settings-close-btn {
   position: absolute;
   top: 1em;
-  right: 1em;
+  left: 1em;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 28px;
+  gap: 6px;
   height: 28px;
+  padding: 0 12px 0 10px;
   background: transparent;
-  border: 1px solid transparent;
+  border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   color: var(--text-secondary);
   cursor: pointer;
+  font-size: 12px;
+  font-family: var(--font-mono);
   transition:
     background-color 0.15s ease,
     color 0.15s ease,
@@ -44,7 +50,8 @@
 .settings-title {
   font-size: 1.15em;
   font-weight: 600;
-  margin: 0 0 1.5em;
+  /* Top margin clears the absolute "Back" button at top-left. */
+  margin: 2.5em 0 1.5em;
   letter-spacing: -0.01em;
 }
 

--- a/src/styles/status-bar.css
+++ b/src/styles/status-bar.css
@@ -59,6 +59,16 @@
     color-mix(in srgb, var(--border-subtle) 70%, transparent);
 }
 
+/* Fleet summary — first item in the left zone, ambient health
+ * line. Goes amber when at least one agent needs the user. */
+.status-bar-fleet {
+  font-family: var(--font-mono);
+}
+
+.status-bar-fleet--alert {
+  color: var(--warning, #d4a76a);
+}
+
 .status-bar-right .status-bar-item:first-child {
   border-left: 1px solid
     color-mix(in srgb, var(--border-subtle) 70%, transparent);


### PR DESCRIPTION
Big bundle, four stacked commits — all UX fixes from the planner sweeps + your direct asks. Ship together as **v0.4.11**.

## 1. Settings close fix *(your earlier ask)*
- Esc handler (no-ops inside text inputs)
- Top-left **labeled "Back" button** with a chevron (was a tiny X — easy to miss)

## 2. Always-on highlight + markdown fences
- `ToolResultBody` no longer falls back to plain text in collapsed mode — same per-tool renderer (Bash → ANSI, Read → file-extension language, generic → auto) in both modes
- Assistant messages now parse `\`\`\`lang` code fences and route fenced blocks through `CodeBlock` so they syntax-color
- `.agent-detail__code` text color bumped from dim secondary → primary
- `msg-body` 12 → 13 px, line-height 1.45 → 1.5

## 3. Appearance settings *(your direct ask)*
New **Settings → Appearance** section:
- **Mono Font**: 5 options (JetBrains Mono / SF Mono / Menlo / Cascadia Code / Geist Mono). Overrides `--font-mono` on the document root → cascades to every mono surface.
- **Transcript Font Size**: 12 / 13 / 14 / 15 / 16 px. Sets `--app-msg-size` consumed only by `.agent-detail__msg-body`.
- Persisted in the existing settings table; live-applied on change.

## 4. Planner-bundle (third sweep)

**Top 3 visual fixes:**
- Pane header was screaming all-caps brackets — drop bracket chars in JSX, drop `text-transform: uppercase` + `letter-spacing` from `--state-tag` / `--pin-tag`
- User messages had triple "I'm a user" signal — drop the 2 px left rule, max-width 78% → 62%
- Pending-tool color was green (= same as success). Switched to accent. Green now strictly diff-add.

**Over-engineering deleted (-28 LOC):**
- `MACHINE_COLORS` 6-color hash + `machineColor()` + inline `--row-machine-color` style + the colored-rule container query branch. Encoded zero bits for the 1-machine median user. Replaced with a `solo-machine` mode that hides the Machine column entirely when `machines.length ≤ 1`.

**Agents table audit:**
- "Activity" → "Doing" (present-continuous matches the data)
- `waiting_input` rows: bold name + subtle amber row bg via `:has()` — louder than a pill, reserved for the only state that needs to shout

**Empty-state copy:**
- "No helm machines": product pitch + two CTAs (Add machine, Read setup docs)
- "No active agents": copyable `helm spawn <repo> "<task>"` mono block

**Status bar fleet telemetry:**
- New left-most zone: `N machine(s) · M agent(s) (K need you)` — goes amber when `K > 0`; tooltip shows offline count
- Hidden when no machines registered
- New `useFleetSnapshot` hook — module-level cache, no second polling instance

## Bump
**v0.4.11** — substantial UX work but not the structural split-tree refactor that's queued for v0.5.0.

## Test plan
- [ ] Local: typecheck ✅, lint ✅, format ✅, build ✅
- [ ] CI green
- [ ] Smoke: open Settings → Appearance, change Mono Font / Transcript Font Size, see live update; persists across launches
- [ ] Smoke: tool args + results render with syntax color in collapsed mode
- [ ] Smoke: assistant messages with `\`\`\`python` blocks render colored
- [ ] Smoke: pane header reads `working name · repo:branch @ machine ⋯ ×` (lowercase, no brackets, no caps)
- [ ] Smoke: status bar shows "N machines · M agents" (amber if any need you)
- [ ] Smoke: with 1 machine, the Machine column is gone; with 2+, it's back