### PR TITLE
feat: visible zoom button on each agent pane header (v0.4.13)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.4.12",
+  "version": "0.4.13",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "workroot"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.4.12"
+version = "0.4.13"
 edition = "2021"
 authors = ["Saurav Panda <saurav@workroot.dev>"]
 description = "A local-first developer workspace for managing projects, terminals, and Git workflows."

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/components/AgentDetailPane.tsx
+++ b/src/components/AgentDetailPane.tsx
@@ -36,6 +36,11 @@ interface AgentDetailPaneProps {
    *  legacy single-pane usage doesn't need the concept. */
   pinned?: boolean;
   onTogglePin?: () => void;
+  /** Zoom state + handler for the visible zoom button in the header.
+   *  When undefined, the button is hidden (single-pane usage doesn't
+   *  need it). */
+  zoomed?: boolean;
+  onToggleZoom?: () => void;
 }
 
 const TERMINAL_STATES = new Set(["done", "failed"]);
@@ -672,6 +677,8 @@ export function AgentDetailPane({
   onDeleted,
   pinned,
   onTogglePin,
+  zoomed,
+  onToggleZoom,
 }: AgentDetailPaneProps) {
   const { detail, loading, error, refresh } = useAgentDetail(machine, agentId);
   const [reply, setReply] = useState("");
@@ -1118,6 +1125,22 @@ export function AgentDetailPane({
               </Popover.Content>
             </Popover.Portal>
           </Popover.Root>
+        )}
+        {onToggleZoom && (
+          <button
+            className={
+              zoomed
+                ? "agent-detail__icon-btn agent-detail__icon-btn--zoomed"
+                : "agent-detail__icon-btn"
+            }
+            onClick={onToggleZoom}
+            aria-label={zoomed ? "Unzoom pane" : "Zoom pane"}
+            title={
+              zoomed ? "Restore pane (⌘⇧Z or Esc)" : "Zoom pane to fill (⌘⇧Z)"
+            }
+          >
+            {zoomed ? "⤡" : "⤢"}
+          </button>
         )}
         <button
           className="agent-detail__icon-btn"

--- a/src/components/AgentsTab.tsx
+++ b/src/components/AgentsTab.tsx
@@ -671,6 +671,11 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
           onDeleted={() => closePane(c.paneId)}
           pinned={c.pinned}
           onTogglePin={() => togglePin(c.paneId)}
+          zoomed={zoomedPaneId === c.paneId}
+          onToggleZoom={() => {
+            setZoomedPaneId((cur) => (cur === c.paneId ? null : c.paneId));
+            setFocusedPaneId(c.paneId);
+          }}
         />
       </div>
     );

--- a/src/styles/agent-detail.css
+++ b/src/styles/agent-detail.css
@@ -85,6 +85,15 @@
   color: var(--color-text, #e4e4e4);
 }
 
+/* Zoom button when its pane is currently zoomed — accent color so
+ * the user can see at a glance which icon is the "active" one. */
+.agent-detail__icon-btn--zoomed {
+  color: var(--color-accent, #88b4ff);
+}
+.agent-detail__icon-btn--zoomed:hover {
+  color: var(--color-accent-hover, #a5c4ff);
+}
+
 /* ---- ⋯ popover menu ---- */
 
 .agent-detail__menu {


### PR DESCRIPTION
## Summary
- Add a clickable zoom/unzoom icon to each agent pane's header so users don't have to remember ⌘⇧Z to expand a pane
- Button shows ⤢ when normal and ⤡ in accent color when its pane is zoomed
- Bumps version to 0.4.13

## Why
The Zed-style pane zoom feature shipped in 0.4.12 only had a keyboard shortcut, which isn't discoverable. This wires it into the existing icon row in each pane header, between the ⋯ menu and the × close button.

## Test plan
- [ ] Open the Agents tab with at least 2 panes
- [ ] Click the ⤢ icon on a pane → that pane fills the splits area, others hide, icon turns ⤡ in accent color
- [ ] Click ⤡ on the same pane → restores the split layout
- [ ] ⌘⇧Z and Esc still work as before