### PR TITLE
fix: ctx % overshoot + code/diff font-size setting (v0.4.14)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.4.13",
+  "version": "0.4.14",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "workroot"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 authors = ["Saurav Panda <saurav@workroot.dev>"]
 description = "A local-first developer workspace for managing projects, terminals, and Git workflows."

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/components/AgentDetailPane.tsx
+++ b/src/components/AgentDetailPane.tsx
@@ -946,26 +946,25 @@ export function AgentDetailPane({
     return Date.now() - updated < WORKING_STALE_MS;
   })();
 
-  // Estimate "current per-turn context size" from the cumulative
-  // session tokens. The daemon only gives totals (no per-call
-  // breakdown), so we approximate: cumulative input grows by roughly
-  // the full prompt size each turn, so dividing by the number of
-  // assistant turns gives the average input per call ≈ current
-  // context size. v0.4.2 forgot this and summed cumulative input +
-  // output + cache_read directly, which doubled-counted every turn
-  // and showed 200%+ on long sessions.
-  //
-  // Cache reads count toward context too — they're still part of the
-  // prompt that the model has to "read."
-  // Plain expression (no useMemo) — this block runs after early returns,
-  // and a one-pass filter on the events array is cheap.
-  const assistantTurns =
-    detail?.thread_events?.filter((e) => e.kind === "assistant").length ?? 0;
-  const perTurnInputTokens = detail?.usage
-    ? Math.round(
-        (detail.usage.input_tokens + detail.usage.cache_read_tokens) /
-          Math.max(1, assistantTurns),
-      )
+  // Estimate current context-window utilization from the cumulative
+  // session tokens. The daemon only exposes session totals (no per-call
+  // breakdown), so we sum the *unique* content added to the
+  // conversation:
+  //   input_tokens       — non-cached prompt portion of every call
+  //   cache_write_tokens — content written into prompt cache
+  //   output_tokens      — every assistant response
+  // We deliberately exclude cache_read_tokens: a cache read is a
+  // re-read of content that was already counted in cache_write, and
+  // it accumulates as O(N²) over N turns (each turn re-reads
+  // everything cached so far), so any formula that includes it pegs
+  // ctx % at the 99 % clamp even on agents that have plenty of head-
+  // room. This still over-estimates somewhat because cache writes
+  // refresh on the 5-minute TTL, but it's a much closer floor than
+  // the prior "per-turn average" approach.
+  const sessionCtxTokens = detail?.usage
+    ? detail.usage.input_tokens +
+      detail.usage.cache_write_tokens +
+      detail.usage.output_tokens
     : 0;
 
   return (
@@ -1273,7 +1272,7 @@ export function AgentDetailPane({
           })();
           const pct = Math.min(
             99,
-            Math.round((perTurnInputTokens / ctxWin) * 100),
+            Math.round((sessionCtxTokens / ctxWin) * 100),
           );
           const ctxClass =
             pct >= 80
@@ -1283,7 +1282,7 @@ export function AgentDetailPane({
             <div className="agent-detail__usage">
               <span
                 className={ctxClass}
-                title={`~${formatTokens(perTurnInputTokens)} per turn of ${formatTokens(ctxWin)} (${pct}%). Estimate: cumulative input ÷ ${assistantTurns || 1} turns. Set the model's context window in Settings → Appearance. Real per-call usage needs a daemon API change.`}
+                title={`~${formatTokens(sessionCtxTokens)} of ${formatTokens(ctxWin)} (${pct}%). Estimate: input + cache_write + output (cache reads excluded — they re-read already-counted content). Set the model's context window in Settings → Appearance. Real per-call usage needs a daemon API change.`}
               >
                 ctx {pct}%
               </span>

--- a/src/lib/appearance.ts
+++ b/src/lib/appearance.ts
@@ -4,7 +4,9 @@
 // document root:
 //   --font-mono       (overrides the @theme default → cascades
 //                       everywhere mono is used)
-//   --app-msg-size    (consumed only by .agent-detail__msg-body)
+//   --app-msg-size    (consumed by .agent-detail__msg-body,
+//                       .agent-detail__code, .agent-detail__diff —
+//                       i.e. all the readable transcript surfaces)
 //
 // Kept tiny and pure — no React state. Callers (App.tsx for the
 // initial paint, SettingsTab for the controls) own their own state

--- a/src/styles/agent-detail.css
+++ b/src/styles/agent-detail.css
@@ -326,10 +326,11 @@
 }
 
 /* Inline code blocks parsed from ```lang fences in assistant
- * messages. Sit snug inside the bubble with a slight margin. */
+ * messages. Sit snug inside the bubble with a slight margin. Font
+ * size inherits from the base .agent-detail__code rule (which scales
+ * with --app-msg-size). */
 .agent-detail__msg-body .agent-detail__code {
   margin: 6px 0;
-  font-size: 12px;
 }
 
 .agent-detail__msg--user {
@@ -481,7 +482,10 @@
   white-space: pre-wrap;
   word-break: break-word;
   font-family: var(--font-mono, monospace);
-  font-size: 12px;
+  /* Scale code blocks with the user-tunable body size — see
+   * Settings → Appearance. Without this, bumping body to 15 px left
+   * code blocks stuck at 12 px and looking cramped. */
+  font-size: var(--app-msg-size, 13px);
   /* Use primary text — this is the actual content, not secondary
    * meta. hljs-* spans override per-token; this is the fallback. */
   color: var(--color-text, #d4d8de);
@@ -583,7 +587,8 @@
   background: var(--color-bg-secondary, #181818);
   border-radius: 0;
   font-family: var(--font-mono, monospace);
-  font-size: 11px;
+  /* Diffs scale with the user-tunable body size too. */
+  font-size: var(--app-msg-size, 13px);
   line-height: 1.45;
   max-height: 480px;
   overflow: auto;


### PR DESCRIPTION
## Summary

Two fixes bundled into v0.4.14:

### 1. ctx % was pegging to 99 % even on light agents
Old formula: `(input + cache_read) / assistant_turns`. Cumulative `cache_read_tokens` grows as O(N²) over N turns (every turn re-reads everything in cache), so even after dividing by N the metric climbed linearly and tripped the 99 % clamp on any agent past ~30–50 turns regardless of how much actual headroom was left.

New formula: `input + cache_write + output` (no division, cache reads excluded — they're re-reads of content already counted in cache_write). Stays in a sane range. Tooltip updated to match.

### 2. Code blocks + diffs ignored the body font-size setting
`.agent-detail__code` was hardcoded at 12 px and `.agent-detail__diff` at 11 px, so bumping Settings → Appearance → Body Size to 15 px left them stuck small. Both now read the same `--app-msg-size` variable as the message body.

## Test plan
- [ ] Open an agent that's been running for 50+ turns — ctx % should NOT show 99 %
- [ ] Settings → Appearance → set Body Size to 15 → fenced code blocks and diff blocks scale up