### PR TITLE
feat: send button in the agent reply UI (v0.4.15)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.4.14",
+  "version": "0.4.15",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "workroot"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.4.14"
+version = "0.4.15"
 edition = "2021"
 authors = ["Saurav Panda <saurav@workroot.dev>"]
 description = "A local-first developer workspace for managing projects, terminals, and Git workflows."

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/components/AgentDetailPane.tsx
+++ b/src/components/AgentDetailPane.tsx
@@ -1327,6 +1327,16 @@ export function AgentDetailPane({
           >
             +
           </button>
+          <button
+            type="button"
+            className="agent-detail__send-icon"
+            onClick={() => void sendReply()}
+            disabled={busy !== null || !reply.trim()}
+            aria-label="Send reply"
+            title="Send (⌘↵)"
+          >
+            ↑
+          </button>
         </div>
       )}
     </aside>

--- a/src/styles/agent-detail.css
+++ b/src/styles/agent-detail.css
@@ -769,7 +769,8 @@
   min-height: 28px;
   max-height: 160px;
   resize: none;
-  padding: 6px 36px 6px 10px; /* right padding leaves room for the + */
+  /* right padding leaves room for the attach (+) and send (↑) icons */
+  padding: 6px 66px 6px 10px;
   font-size: 13px;
   font-family: inherit;
   line-height: 1.4;
@@ -789,7 +790,7 @@
 
 .agent-detail__attach-icon {
   position: absolute;
-  right: 6px;
+  right: 36px;
   bottom: 6px;
   width: 24px;
   height: 24px;
@@ -814,6 +815,39 @@
 
 .agent-detail__attach-icon:disabled {
   opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* Primary send button — accent-filled so it reads as the main action,
+ * sits to the right of the attach (+). Disabled until the textarea has
+ * non-whitespace content. */
+.agent-detail__send-icon {
+  position: absolute;
+  right: 6px;
+  bottom: 6px;
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-accent, #60a5fa);
+  border: 1px solid var(--color-accent, #60a5fa);
+  border-radius: 4px;
+  color: var(--color-bg, #0d0d0d);
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1;
+  padding: 0;
+}
+
+.agent-detail__send-icon:hover:not(:disabled) {
+  background: var(--color-accent-hover, #88b4ff);
+  border-color: var(--color-accent-hover, #88b4ff);
+}
+
+.agent-detail__send-icon:disabled {
+  opacity: 0.35;
   cursor: not-allowed;
 }
 


### PR DESCRIPTION
## Summary
- Adds a visible primary send button (↑, accent-filled) next to the attach (+) icon in the agent reply UI
- Was relying on the ⌘↵ shortcut alone, which isn't discoverable
- Disabled until the textarea has non-whitespace content; ⌘↵ still works

## Test plan
- [ ] Open an agent → send button visible to the right of + icon
- [ ] Empty textarea → button is disabled (greyed)
- [ ] Type something → button enables, click sends
- [ ] ⌘↵ still works