### PR TITLE
feat: agents in the Cmd+P palette (#469, v0.4.16)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.4.15",
+  "version": "0.4.16",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "workroot"
-version = "0.4.15"
+version = "0.4.16"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.4.15"
+version = "0.4.16"
 edition = "2021"
 authors = ["Saurav Panda <saurav@workroot.dev>"]
 description = "A local-first developer workspace for managing projects, terminals, and Git workflows."

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,8 @@ import { usePanels } from "./hooks/usePanels";
 import { useTerminalSettings } from "./hooks/useTerminalSettings";
 import { useAppTheme } from "./hooks/useAppTheme";
 import { useShellData } from "./hooks/useShellData";
+import { useFleetSnapshot } from "./hooks/useAllAgents";
+import { requestOpenAgent } from "./lib/openAgent";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const namedLazy = <K extends string>(
@@ -219,6 +221,10 @@ function AppContent({
   } = useAppTheme();
   const { allProjects, allWorktrees, selectedProjectName, selectWorktree } =
     useShellData(openPanel);
+  // Read-only fleet snapshot — no extra polling, just shares whatever
+  // the AgentsTab is already fetching. Used to register each agent as
+  // a command in the Cmd+P palette so users can jump by name.
+  const { agents: fleetAgents } = useFleetSnapshot();
 
   // Build commands from current app state
   const commands: Command[] = useMemo(() => {
@@ -444,6 +450,45 @@ function AppContent({
       });
     }
 
+    // Add agents from the helm fleet \u2014 each becomes an "Open Agent"
+    // command in Cmd+P. Pre-sort by attention so empty-palette and
+    // generic-query results put waiting_input/working at the top.
+    // (#469)
+    const AGENT_RANK: Record<string, number> = {
+      waiting_input: 0,
+      working: 1,
+      planning: 2,
+      queued: 3,
+      done: 4,
+      failed: 5,
+    };
+    const sortedAgents = [...fleetAgents].sort((a, b) => {
+      const ra = AGENT_RANK[a.state] ?? 99;
+      const rb = AGENT_RANK[b.state] ?? 99;
+      if (ra !== rb) return ra - rb;
+      return a.name.localeCompare(b.name);
+    });
+    for (const a of sortedAgents) {
+      const repo = a.repo?.split("/").pop() ?? "";
+      const meta = repo ? `${a.state} \u00b7 ${repo}` : a.state;
+      cmds.push({
+        id: `agent:${a.machine_id}:${a.id}`,
+        label: `${a.name} \u2014 ${meta}`,
+        category: "Open Agent",
+        icon: "\u25c6",
+        action: () => {
+          // Navigate to AgentsTab (same as Go Home) and request the
+          // pane open. Latched in openAgent.ts so it survives the
+          // mount race.
+          setShowSettings(false);
+          setSelectedWorktreeId(null);
+          setSelectedWorktreePath(null);
+          setSelectedWorktreeName(null);
+          requestOpenAgent(a.machine_id, a.id);
+        },
+      });
+    }
+
     return cmds;
   }, [
     showSettings,
@@ -460,6 +505,7 @@ function AppContent({
     setSelectedWorktreeName,
     openPanel,
     togglePanel,
+    fleetAgents,
   ]);
 
   // Register commands whenever they change

--- a/src/components/AgentsTab.tsx
+++ b/src/components/AgentsTab.tsx
@@ -10,6 +10,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { open as openShell } from "@tauri-apps/plugin-shell";
 import { useAllAgents, type MachineStatus } from "../hooks/useAllAgents";
 import { AgentDetailPane } from "./AgentDetailPane";
+import { consumePendingOpen } from "../lib/openAgent";
 import "../styles/agents-tab.css";
 
 interface AgentsTabProps {
@@ -277,6 +278,22 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
       prev.map((p) => (p.paneId === paneId ? { ...p, pinned: !p.pinned } : p)),
     );
   }, []);
+
+  // Bridge for the Cmd+P palette → "Open Agent" commands. Two paths:
+  //   1. AgentsTab was already mounted and the user picked an agent
+  //      from the palette — the CustomEvent fires and we open it.
+  //   2. App-level navigation just mounted us as a side effect of the
+  //      same palette command — drain any latched request now.
+  useEffect(() => {
+    const pending = consumePendingOpen();
+    if (pending) openAgent(pending.machineId, pending.agentId);
+    const onOpen = () => {
+      const p = consumePendingOpen();
+      if (p) openAgent(p.machineId, p.agentId);
+    };
+    window.addEventListener("workroot:open-agent", onOpen);
+    return () => window.removeEventListener("workroot:open-agent", onOpen);
+  }, [openAgent]);
 
   // Switch to a different layout size. Marks the user as having picked
   // explicitly (locks auto-grow). If the new size is smaller than the

--- a/src/lib/openAgent.ts
+++ b/src/lib/openAgent.ts
@@ -1,0 +1,32 @@
+// Cross-component "open this agent" channel. The Cmd+P palette
+// (rendered at App level) needs to ask AgentsTab (rendered as a child
+// view) to open a specific agent in a pane. They don't share state,
+// so we route the request through a module-level latch + a
+// CustomEvent broadcast — same pattern as useAllAgents' fleet
+// snapshot.
+//
+// Two delivery modes:
+//   - AgentsTab is already mounted → it picks up the event and calls
+//     its local openAgent() immediately.
+//   - AgentsTab is being mounted by the same palette command (because
+//     we navigated home first) → on mount it consumes the pending
+//     latch.
+
+export interface PendingOpen {
+  machineId: number;
+  agentId: string;
+}
+
+let pendingOpen: PendingOpen | null = null;
+
+export function requestOpenAgent(machineId: number, agentId: string): void {
+  pendingOpen = { machineId, agentId };
+  window.dispatchEvent(new CustomEvent("workroot:open-agent"));
+}
+
+/** Returns and clears the latched pending request, if any. */
+export function consumePendingOpen(): PendingOpen | null {
+  const v = pendingOpen;
+  pendingOpen = null;
+  return v;
+}


### PR DESCRIPTION
Closes #469.

## Summary
Each agent in the helm fleet now shows up under an "Open Agent" category in Cmd+P. Selecting one navigates to the Agents tab and opens that agent in a pane (focusing an existing pane if it's already open).

Pre-sorted by attention (`waiting_input → working → planning → queued → done → failed`, alphabetical within state) so the empty palette and generic queries surface agents that need you first.

Cross-tab navigation goes through a small module-level latch in \`src/lib/openAgent.ts\` so the request survives the AgentsTab mount race when the palette is opened from Settings or a worktree view.

## Test plan
- [ ] \`Cmd+P\`, type part of an agent name → it appears under "Open Agent"
- [ ] Selecting it opens that agent in a new pane
- [ ] Already-open agents → focuses the existing pane instead of duplicating
- [ ] Empty palette → \`waiting_input\` / \`working\` agents appear above \`done\`
- [ ] Open palette from Settings → still navigates correctly to AgentsTab