### PR TITLE
feat: honest keymap hint on the status bar (#467 partial, v0.4.17)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.4.16",
+  "version": "0.4.17",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "workroot"
-version = "0.4.16"
+version = "0.4.17"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.4.16"
+version = "0.4.17"
 edition = "2021"
 authors = ["Saurav Panda <saurav@workroot.dev>"]
 description = "A local-first developer workspace for managing projects, terminals, and Git workflows."

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -143,8 +143,21 @@ export function StatusBar({
         <span className="status-bar-item">
           <span className="status-bar-time">{time}</span>
         </span>
-        <span className="status-bar-item">
+        {/* Honest keymap hint \u2014 only the shortcuts that are actually
+         *  wired today (#467). Once the keyboard layer (#466) lands,
+         *  this becomes context-aware (list / pane / zoomed). */}
+        <span
+          className="status-bar-item status-bar-hints"
+          title="Keyboard shortcuts"
+        >
           <kbd className="status-bar-kbd">{"\u2318K"}</kbd>
+          <span className="status-bar-hint-label">palette</span>
+          <span className="status-bar-hint-sep">\u00b7</span>
+          <kbd className="status-bar-kbd">{"\u2318\u21e7Z"}</kbd>
+          <span className="status-bar-hint-label">zoom</span>
+          <span className="status-bar-hint-sep">\u00b7</span>
+          <kbd className="status-bar-kbd">Esc</kbd>
+          <span className="status-bar-hint-label">unzoom</span>
         </span>
       </div>
     </div>

--- a/src/styles/status-bar.css
+++ b/src/styles/status-bar.css
@@ -147,3 +147,22 @@
   color: var(--text-muted);
   line-height: 1.3;
 }
+
+/* Multi-shortcut hint group — kbd + label, repeated, with thin
+ * separators. Each kbd uses the .status-bar-kbd styling above. */
+.status-bar-hints {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.status-bar-hint-label {
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-left: -1px;
+}
+.status-bar-hint-sep {
+  font-size: 11px;
+  color: var(--text-muted);
+  opacity: 0.5;
+  margin: 0 2px;
+}


### PR DESCRIPTION
Partial pickoff from #467 (full re-scoping in [this comment](https://github.com/sauravpanda/workroot/issues/467#issuecomment-4413469834)).

## Summary
Status bar's right side previously advertised only \`⌘K\`. Expand it to also show \`⌘⇧Z zoom · Esc unzoom\` so users discover the existing pane shortcut without having to read source.

No state lifting, no list filter, no dependency on the unimplemented keyboard layer (#466). Once #466 lands, the same area becomes context-aware (list / pane / zoomed) per the original spec.

## Test plan
- [ ] Status bar bottom-right shows \`⌘K palette · ⌘⇧Z zoom · Esc unzoom\`
- [ ] Each kbd is styled like the existing one (existing \`.status-bar-kbd\` class)
- [ ] Hover tooltip says "Keyboard shortcuts"