### PR TITLE
feat: paste + drag-drop image attachments in agent reply (#489 partial, v0.4.18)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.4.17",
+  "version": "0.4.18",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "workroot"
-version = "0.4.17"
+version = "0.4.18"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.4.17"
+version = "0.4.18"
 edition = "2021"
 authors = ["Saurav Panda <saurav@workroot.dev>"]
 description = "A local-first developer workspace for managing projects, terminals, and Git workflows."

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/components/AgentDetailPane.tsx
+++ b/src/components/AgentDetailPane.tsx
@@ -8,6 +8,7 @@ import {
   type ReactNode,
 } from "react";
 import * as Popover from "@radix-ui/react-popover";
+import { invoke } from "@tauri-apps/api/core";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { open as openShell } from "@tauri-apps/plugin-shell";
 import AnsiConvert from "ansi-to-html";
@@ -846,11 +847,19 @@ export function AgentDetailPane({
     );
   }
 
-  // Open the system file picker and append "[attached: <abs path>]" to
-  // the reply text. The daemon's /reply endpoint accepts only a string
-  // body, so we can't actually upload bytes — but inserting the absolute
-  // path is enough for the agent to use its Read tool on the file
-  // (works for code, text, JSON, images Claude can see, etc).
+  // Append "[attached: <abs path>]" lines to the reply text. The
+  // daemon's /reply endpoint accepts only a string body, so we can't
+  // upload bytes directly — but inserting the absolute path is enough
+  // for the agent to use its Read tool on the file (works for code,
+  // text, JSON, images Claude can see — on a *local* helm where the
+  // path resolves on the agent side).
+  const appendAttachments = (paths: string[]): void => {
+    if (paths.length === 0) return;
+    const lines = paths.map((p) => `[attached: ${p}]`).join("\n");
+    setReply((prev) => (prev.trim() ? `${prev}\n${lines}\n` : `${lines}\n`));
+  };
+
+  // Open the system file picker and append the chosen file paths.
   const attachFiles = async () => {
     let picked: string | string[] | null = null;
     try {
@@ -860,10 +869,76 @@ export function AgentDetailPane({
       return;
     }
     if (!picked) return;
-    const paths = Array.isArray(picked) ? picked : [picked];
-    if (paths.length === 0) return;
-    const lines = paths.map((p) => `[attached: ${p}]`).join("\n");
-    setReply((prev) => (prev.trim() ? `${prev}\n${lines}\n` : `${lines}\n`));
+    appendAttachments(Array.isArray(picked) ? picked : [picked]);
+  };
+
+  // Save a Blob (from clipboard paste or file drop) to a Tauri temp
+  // file and return its absolute path so it can be attached. Reuses
+  // the existing `save_dropped_image` command (terminal/drop_image.rs).
+  const saveBlobAsTemp = async (blob: Blob, ext: string): Promise<string> => {
+    const buf = new Uint8Array(await blob.arrayBuffer());
+    return await invoke<string>("save_dropped_image", {
+      data: Array.from(buf),
+      extension: ext,
+    });
+  };
+
+  // Pulls image bytes off the clipboard. When the clipboard has at
+  // least one image, we handle it ourselves and prevent the textarea's
+  // default text-paste so the user doesn't get a stray data-URL line.
+  const handlePaste = async (
+    e: React.ClipboardEvent<HTMLTextAreaElement>,
+  ): Promise<void> => {
+    const items = e.clipboardData?.items;
+    if (!items) return;
+    const imageItems = Array.from(items).filter((it) =>
+      it.type.startsWith("image/"),
+    );
+    if (imageItems.length === 0) return;
+    e.preventDefault();
+    const paths: string[] = [];
+    for (const it of imageItems) {
+      const blob = it.getAsFile();
+      if (!blob) continue;
+      const ext = it.type.split("/")[1] || "png";
+      try {
+        paths.push(await saveBlobAsTemp(blob, ext));
+      } catch (err) {
+        setActionError(`Paste failed: ${err}`);
+        return;
+      }
+    }
+    appendAttachments(paths);
+  };
+
+  // Drag-drop handler. Uses the path directly when the OS exposes one
+  // (typical for files dragged from Finder/Explorer); falls back to
+  // saving the bytes for synthetic drops (e.g. dragging an image out
+  // of a browser tab, where File.path is empty).
+  const handleDrop = async (
+    e: React.DragEvent<HTMLDivElement>,
+  ): Promise<void> => {
+    if (!e.dataTransfer || e.dataTransfer.files.length === 0) return;
+    e.preventDefault();
+    const paths: string[] = [];
+    for (const file of Array.from(e.dataTransfer.files)) {
+      // Tauri exposes File.path for OS-level drops. When present, use
+      // it directly — no need to copy bytes through a temp file.
+      const filePath = (file as File & { path?: string }).path;
+      if (filePath) {
+        paths.push(filePath);
+        continue;
+      }
+      const ext =
+        file.name.split(".").pop() || file.type.split("/")[1] || "bin";
+      try {
+        paths.push(await saveBlobAsTemp(file, ext));
+      } catch (err) {
+        setActionError(`Drop failed: ${err}`);
+        return;
+      }
+    }
+    appendAttachments(paths);
   };
 
   const sendReply = async () => {
@@ -1292,12 +1367,22 @@ export function AgentDetailPane({
         })()}
 
       {canReply && (
-        <div className="agent-detail__reply">
+        <div
+          className="agent-detail__reply"
+          onDragOver={(e) => {
+            // Required for onDrop to fire on a div.
+            if (e.dataTransfer?.types.includes("Files")) {
+              e.preventDefault();
+            }
+          }}
+          onDrop={(e) => void handleDrop(e)}
+        >
           <textarea
             ref={replyRef}
             value={reply}
             rows={1}
             onChange={(e) => setReply(e.target.value)}
+            onPaste={(e) => void handlePaste(e)}
             onKeyDown={(e) => {
               if (
                 (e.metaKey || e.ctrlKey) &&


### PR DESCRIPTION
Partial pickoff from #489 (frontend portion).

## Summary
The reply textarea now handles three attach paths instead of one:

1. **⌘V with an image on the clipboard** → bytes saved to a Tauri temp file (reuses the existing \`save_dropped_image\` command), \`[attached: <path>]\` inserted into the reply
2. **Drag-drop a file** onto the reply area → uses \`File.path\` when the OS exposes one (Finder/Explorer drops, no temp copy needed), otherwise saves bytes to temp
3. The existing **+ button** still works

Works on **local helm** where the file path resolves on the agent side. For **remote helm**, the daemon's \`/reply\` endpoint still needs to accept image content blocks — tracking that on #489.

## Test plan
- [ ] Take a screenshot, ⌘V into the reply textarea → \`[attached: /tmp/workroot-drops/drop-XXXX.png]\` appears
- [ ] Drag a file from Finder onto the reply area → \`[attached: /Users/.../foo.txt]\` appears (real path, no temp copy)
- [ ] Drag an image from a browser tab → bytes saved to temp, attached
- [ ] Send the reply → on local helm, the agent uses Read on the path and sees the file