### PR TITLE
feat: tray badge with Needs You count (#436 partial, v0.4.19)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.4.18",
+  "version": "0.4.19",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "workroot"
-version = "0.4.18"
+version = "0.4.19"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.4.18"
+version = "0.4.19"
 edition = "2021"
 authors = ["Saurav Panda <saurav@workroot.dev>"]
 description = "A local-first developer workspace for managing projects, terminals, and Git workflows."

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -348,6 +348,7 @@ pub fn run() {
             agents::pipeline::run_agent_task,
             agents::pipeline::run_agent_task_streaming,
             agents::pipeline::save_text_file,
+            tray::update_tray_badge,
         ])
         .setup(|app| {
             let app_handle = app.handle().clone();

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -1,8 +1,14 @@
 use tauri::{
     menu::{Menu, MenuItem},
-    tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
-    Manager,
+    tray::{MouseButton, MouseButtonState, TrayIcon, TrayIconBuilder, TrayIconEvent},
+    Manager, State,
 };
+
+/// Wrapper so we can `app.manage()` the tray handle and update its
+/// title/tooltip from a Tauri command. The constant id ("main") lets
+/// us look it up later via `app.tray_by_id` as a fallback, but holding
+/// the handle directly is more reliable.
+pub struct TrayHandle(pub TrayIcon);
 
 /// Sets up the system tray icon with a context menu.
 ///
@@ -19,7 +25,7 @@ pub fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
 
     let menu = Menu::with_items(app, &[&show_i, &separator, &quit_i])?;
 
-    let _tray = TrayIconBuilder::new()
+    let tray = TrayIconBuilder::new()
         .icon(app.default_window_icon().unwrap().clone())
         .icon_as_template(true)
         .menu(&menu)
@@ -46,6 +52,36 @@ pub fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
         })
         .build(app)?;
 
+    app.manage(TrayHandle(tray));
+    Ok(())
+}
+
+/// Update the tray badge from the frontend's fleet snapshot.
+/// `needs_you` is the number of agents in `waiting_input` state.
+///
+/// macOS shows the title text next to the tray icon — natural badge.
+/// Linux/Windows update the tooltip only (no inline badge support).
+#[tauri::command]
+pub fn update_tray_badge(needs_you: u32, tray: State<'_, TrayHandle>) -> Result<(), String> {
+    let title = if needs_you > 0 {
+        Some(format!("{needs_you}"))
+    } else {
+        None
+    };
+    let tooltip = if needs_you > 0 {
+        format!(
+            "Workroot — {needs_you} agent{} need you",
+            if needs_you == 1 { "" } else { "s" }
+        )
+    } else {
+        "Workroot".to_string()
+    };
+    tray.0
+        .set_title(title)
+        .map_err(|e| format!("set_title failed: {e}"))?;
+    tray.0
+        .set_tooltip(Some(&tooltip))
+        .map_err(|e| format!("set_tooltip failed: {e}"))?;
     Ok(())
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/hooks/useAllAgents.ts
+++ b/src/hooks/useAllAgents.ts
@@ -69,9 +69,22 @@ let cachedFleet: AllAgentsResult = {
   refresh: () => {},
 };
 
+// Last value we pushed to the tray, so we don't IPC every poll when
+// the count hasn't changed. Module-scoped: matches cachedFleet.
+let lastTrayCount = -1;
+
 function publishFleet(next: Omit<AllAgentsResult, "refresh">): void {
   cachedFleet = { ...next, refresh: cachedFleet.refresh };
   window.dispatchEvent(new CustomEvent("workroot:fleet"));
+  const needsYou = next.agents.filter(
+    (a) => a.state === "waiting_input",
+  ).length;
+  if (needsYou !== lastTrayCount) {
+    lastTrayCount = needsYou;
+    void invoke("update_tray_badge", { needsYou }).catch(() => {
+      // Older builds before #436 don't have this command — ignore.
+    });
+  }
 }
 
 /** Read-only view of the latest fleet snapshot. Subscribes to the


### PR DESCRIPTION
Partial of #436. The "Needs You popover" piece is left open on that ticket.

## Summary
The system tray icon now reflects how many agents are in \`waiting_input\` state across the helm fleet:

- **macOS**: shows the count as a title next to the tray icon (the natural macOS menu-bar badge UX)
- **All platforms**: updated tooltip — \"Workroot — N agents need you\" / \"Workroot\"

The count updates whenever the fleet snapshot updates (5 s poll), dedup'd against the last-known value so we don't IPC on no-op polls.

## Wiring
- \`src-tauri/src/tray.rs\` — holds the \`TrayIcon\` handle in app state, exposes \`update_tray_badge(needs_you)\`
- \`src-tauri/src/lib.rs\` — registers the new command
- \`src/hooks/useAllAgents.ts\` — pushes the count on every fleet poll (in \`publishFleet\`), dedup'd

## Test plan
- [ ] Start with no waiting agents → tray shows just the icon, tooltip \"Workroot\"
- [ ] Spawn an agent that asks a question → tray shows \"1\" + tooltip \"Workroot — 1 agent need you\"
- [ ] Reply to it → tray returns to just the icon
- [ ] Multiple agents asking → tray shows the total