### PR TITLE
feat: state-filter chips in the agents list (#467 partial, v0.4.20)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.4.19",
+  "version": "0.4.20",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "workroot"
-version = "0.4.19"
+version = "0.4.20"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.4.19"
+version = "0.4.20"
 edition = "2021"
 authors = ["Saurav Panda <saurav@workroot.dev>"]
 description = "A local-first developer workspace for managing projects, terminals, and Git workflows."

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/components/AgentsTab.tsx
+++ b/src/components/AgentsTab.tsx
@@ -9,6 +9,7 @@ import {
 import { invoke } from "@tauri-apps/api/core";
 import { open as openShell } from "@tauri-apps/plugin-shell";
 import { useAllAgents, type MachineStatus } from "../hooks/useAllAgents";
+import type { AgentState } from "../lib/helm-api";
 import { AgentDetailPane } from "./AgentDetailPane";
 import { consumePendingOpen } from "../lib/openAgent";
 import "../styles/agents-tab.css";
@@ -175,10 +176,39 @@ function OfflineBanner({
   );
 }
 
+type StateFilter = "all" | AgentState;
+
+// Order the filter chips appear in. "all" first, then by attention
+// priority (waiting_input → ... → failed). Matches the same ranking
+// the list uses internally.
+const FILTER_ORDER: StateFilter[] = [
+  "all",
+  "waiting_input",
+  "working",
+  "planning",
+  "queued",
+  "done",
+  "failed",
+];
+
+const FILTER_LABELS: Record<StateFilter, string> = {
+  all: "All",
+  waiting_input: "Needs you",
+  working: "Working",
+  planning: "Planning",
+  queued: "Queued",
+  done: "Done",
+  failed: "Failed",
+};
+
 export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
   const { agents, machines, loading, refresh } = useAllAgents();
   const [panes, setPanes] = useState<Pane[]>([]);
   const [focusedPaneId, setFocusedPaneId] = useState<number | null>(null);
+  // Active state filter for the list. "all" passes everything through.
+  // Counts per chip are computed from the unfiltered list so the user
+  // can see "Done 12" even when looking at "Needs you 2".
+  const [stateFilter, setStateFilter] = useState<StateFilter>("all");
   // Zed-style "zoom the focused pane" — when set, only this pane is
   // visible inside the panes container (others stay mounted so polls
   // and scroll positions survive). The list pane stays put; only the
@@ -434,6 +464,25 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
     return s;
   }, [panes]);
 
+  // Per-state counts for the filter chips, computed once from the
+  // unfiltered list so a chip's number stays meaningful even when the
+  // filter narrows what the user sees.
+  const stateCounts = useMemo(() => {
+    const counts: Record<string, number> = { all: agents.length };
+    for (const a of agents) {
+      counts[a.state] = (counts[a.state] ?? 0) + 1;
+    }
+    return counts;
+  }, [agents]);
+
+  const filteredAgents = useMemo(
+    () =>
+      stateFilter === "all"
+        ? agents
+        : agents.filter((a) => a.state === stateFilter),
+    [agents, stateFilter],
+  );
+
   const list = (
     <>
       <div className="agents-tab__header">
@@ -462,6 +511,38 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
             Manage machines
           </button>
         </div>
+        {agents.length > 0 && (
+          <div
+            className="agents-tab__filters"
+            role="tablist"
+            aria-label="Filter by state"
+          >
+            {FILTER_ORDER.map((f) => {
+              const count = stateCounts[f] ?? 0;
+              // Hide state chips that have zero matches so we don't
+              // show "Failed 0 · Queued 0" noise. "All" is always
+              // visible.
+              if (f !== "all" && count === 0) return null;
+              const active = stateFilter === f;
+              return (
+                <button
+                  key={f}
+                  type="button"
+                  role="tab"
+                  aria-selected={active}
+                  className={
+                    active
+                      ? "agents-tab__filter-chip agents-tab__filter-chip--active"
+                      : "agents-tab__filter-chip"
+                  }
+                  onClick={() => setStateFilter(f)}
+                >
+                  {FILTER_LABELS[f]} {count}
+                </button>
+              );
+            })}
+          </div>
+        )}
       </div>
 
       {offlineMachines.map((m) => (
@@ -534,7 +615,19 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
             </span>
           </div>
           <div className="agents-tab__tbody">
-            {agents.map((a) => {
+            {filteredAgents.length === 0 && stateFilter !== "all" && (
+              <div className="agents-tab__filter-empty">
+                No agents in <strong>{FILTER_LABELS[stateFilter]}</strong>.{" "}
+                <button
+                  type="button"
+                  className="agents-tab__filter-reset"
+                  onClick={() => setStateFilter("all")}
+                >
+                  Show all
+                </button>
+              </div>
+            )}
+            {filteredAgents.map((a) => {
               const isOpen = openSet.has(`${a.machine_id}:${a.id}`);
               const stateLabel = STATE_LABELS[a.state] ?? a.state;
               const activity = a.last_activity ?? a.task;

--- a/src/styles/agents-tab.css
+++ b/src/styles/agents-tab.css
@@ -288,6 +288,65 @@
   background: var(--color-danger, #f87171);
 }
 
+/* ---- state-filter chips (row below the machines bar) ---- */
+
+.agents-tab__filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+  margin-top: 8px;
+}
+
+.agents-tab__filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 10px;
+  font-size: 12px;
+  font-family: inherit;
+  color: var(--color-text-secondary, #aaa);
+  background: transparent;
+  border: 1px solid var(--color-border, #2a2a2a);
+  border-radius: 999px;
+  cursor: pointer;
+  line-height: 1.5;
+}
+
+.agents-tab__filter-chip:hover {
+  color: var(--color-text, #e4e4e4);
+  border-color: var(--color-text-secondary, #aaa);
+}
+
+.agents-tab__filter-chip--active {
+  color: var(--color-bg, #0d0d0d);
+  background: var(--color-accent, #88b4ff);
+  border-color: var(--color-accent, #88b4ff);
+}
+
+.agents-tab__filter-chip--active:hover {
+  color: var(--color-bg, #0d0d0d);
+  background: var(--color-accent-hover, #a5c4ff);
+  border-color: var(--color-accent-hover, #a5c4ff);
+}
+
+.agents-tab__filter-empty {
+  padding: 16px 12px;
+  text-align: center;
+  font-size: 13px;
+  color: var(--color-text-secondary, #aaa);
+}
+
+.agents-tab__filter-reset {
+  background: transparent;
+  border: none;
+  color: var(--color-accent, #88b4ff);
+  text-decoration: underline;
+  cursor: pointer;
+  font: inherit;
+  padding: 0;
+}
+
 /* ---- offline machine banner ---- */
 
 .agents-tab__banner {


### PR DESCRIPTION
Partial of #467 — the data piece (clickable counts that filter the list). The StatusBar's left zone driving the same filter intent is left for a follow-up.

## Summary
A chip row appears below the machines bar in \`AgentsTab\` when there are any agents. Each chip is **label + count**:

\`All 12 · Needs you 2 · Working 5 · Planning 1 · Done 4\`

- Clicking a chip filters the list to that state. Active chip is accent-filled.
- Chips for states with zero matches are hidden so the row stays compact.
- Counts are computed from the **unfiltered** list — \"Done 12\" still reads accurate while looking at \"Needs you 2\".
- Empty filter result shows a \"No agents in <State>. Show all\" reset row.

## Test plan
- [ ] Open Agents → chip row appears with one chip per non-empty state
- [ ] Click \"Working\" → list narrows to working agents; \"Working\" chip turns accent
- [ ] Click \"Needs you\" → list narrows to waiting_input agents
- [ ] Click \"All\" → returns to full list
- [ ] If a filter has zero matches → empty message with \"Show all\" reset link