### PR TITLE
feat: clickable "N need you" → list filter (#467 final, v0.4.21)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.4.20",
+  "version": "0.4.21",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "workroot"
-version = "0.4.20"
+version = "0.4.21"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.4.20"
+version = "0.4.21"
 edition = "2021"
 authors = ["Saurav Panda <saurav@workroot.dev>"]
 description = "A local-first developer workspace for managing projects, terminals, and Git workflows."

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.4.20",
+  "version": "0.4.21",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/components/AgentsTab.tsx
+++ b/src/components/AgentsTab.tsx
@@ -12,6 +12,7 @@ import { useAllAgents, type MachineStatus } from "../hooks/useAllAgents";
 import type { AgentState } from "../lib/helm-api";
 import { AgentDetailPane } from "./AgentDetailPane";
 import { consumePendingOpen } from "../lib/openAgent";
+import { consumePendingFilter } from "../lib/agentFilter";
 import "../styles/agents-tab.css";
 
 interface AgentsTabProps {
@@ -324,6 +325,20 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
     window.addEventListener("workroot:open-agent", onOpen);
     return () => window.removeEventListener("workroot:open-agent", onOpen);
   }, [openAgent]);
+
+  // Same pattern for the StatusBar's clickable "N need you" → filter
+  // the list. AgentsTab is the source of truth for `stateFilter`, so
+  // we let other surfaces broadcast intents through this latch.
+  useEffect(() => {
+    const pending = consumePendingFilter();
+    if (pending) setStateFilter(pending);
+    const onFilter = () => {
+      const p = consumePendingFilter();
+      if (p) setStateFilter(p);
+    };
+    window.addEventListener("workroot:agent-filter", onFilter);
+    return () => window.removeEventListener("workroot:agent-filter", onFilter);
+  }, []);
 
   // Switch to a different layout size. Marks the user as having picked
   // explicitly (locks auto-grow). If the new size is smaller than the

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo } from "react";
 import { useFleetSnapshot } from "../hooks/useAllAgents";
+import { requestAgentFilter } from "../lib/agentFilter";
 import "../styles/status-bar.css";
 
 /* ------------------------------------------------------------------ */
@@ -58,7 +59,20 @@ function FleetSummary() {
       }
     >
       {machineLabel} · {agentLabel}
-      {summary.needsYou > 0 && ` (${summary.needsYou} need you)`}
+      {summary.needsYou > 0 && (
+        <>
+          {" ("}
+          <button
+            type="button"
+            className="status-bar-fleet-link"
+            onClick={() => requestAgentFilter("waiting_input")}
+            title="Filter agents to waiting-on-you"
+          >
+            {summary.needsYou} need you
+          </button>
+          {")"}
+        </>
+      )}
     </span>
   );
 }

--- a/src/lib/agentFilter.ts
+++ b/src/lib/agentFilter.ts
@@ -1,0 +1,23 @@
+// Cross-component "filter the agents list" channel. The StatusBar
+// (rendered at App level) wants to nudge AgentsTab (rendered as a
+// child view) to switch its state filter — same problem the openAgent
+// channel solves for opening a pane. Module-level latch + CustomEvent
+// broadcast.
+
+import type { AgentState } from "./helm-api";
+
+export type AgentFilter = "all" | AgentState;
+
+let pendingFilter: AgentFilter | null = null;
+
+export function requestAgentFilter(filter: AgentFilter): void {
+  pendingFilter = filter;
+  window.dispatchEvent(new CustomEvent("workroot:agent-filter"));
+}
+
+/** Returns and clears the latched pending filter, if any. */
+export function consumePendingFilter(): AgentFilter | null {
+  const v = pendingFilter;
+  pendingFilter = null;
+  return v;
+}

--- a/src/styles/status-bar.css
+++ b/src/styles/status-bar.css
@@ -69,6 +69,25 @@
   color: var(--warning, #d4a76a);
 }
 
+/* Inline link inside the fleet summary — "N need you" turns into a
+ * filter shortcut. Inherits color from the parent (.fleet or .alert
+ * variant) so the amber state stays amber while clickable. */
+.status-bar-fleet-link {
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+.status-bar-fleet-link:hover {
+  text-decoration-style: solid;
+}
+
 .status-bar-right .status-bar-item:first-child {
   border-left: 1px solid
     color-mix(in srgb, var(--border-subtle) 70%, transparent);


### PR DESCRIPTION
Closes the last piece of #467 — the StatusBar → AgentsTab list filter wire-up.

## Summary
The amber \`(N need you)\` segment in the StatusBar's fleet summary is now a clickable underline. Clicking it sets the AgentsTab state filter to \`waiting_input\`, so the user can jump from "something's blocking" to "show me what's blocking" in one click.

## Wiring
- New \`src/lib/agentFilter.ts\` — module-level latch + \`workroot:agent-filter\` CustomEvent, mirrors the \`openAgent\` pattern
- \`StatusBar\` — calls \`requestAgentFilter("waiting_input")\` from the inline button
- \`AgentsTab\` — owns \`stateFilter\` state; drains the latch on mount + listens for the event

With this in, #467's whole scope (left-zone clickable counts + filter wiring) is shipped. The original right-zone rotating hint is still tied to the keyboard layer (#466) and stays deferred.

## Test plan
- [ ] An agent goes into \`waiting_input\` → StatusBar shows amber "(N need you)" as underlined
- [ ] Click the link → AgentsTab list narrows to \"Needs you\" filter
- [ ] Click the chip on the filter row → can re-select \"All\"