### PR TITLE
feat: live tmux pane mode (mirrors helm phone, v0.4.22)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.4.21",
+  "version": "0.4.22",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "workroot"
-version = "0.4.21"
+version = "0.4.22"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.4.21"
+version = "0.4.22"
 edition = "2021"
 authors = ["Saurav Panda <saurav@workroot.dev>"]
 description = "A local-first developer workspace for managing projects, terminals, and Git workflows."

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.4.21",
+  "version": "0.4.22",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/components/AgentDetailPane.tsx
+++ b/src/components/AgentDetailPane.tsx
@@ -13,6 +13,7 @@ import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { open as openShell } from "@tauri-apps/plugin-shell";
 import AnsiConvert from "ansi-to-html";
 import { useAgentDetail } from "../hooks/useAgentDetail";
+import { useAgentPane } from "../hooks/useAgentPane";
 import {
   clientFor,
   type HelmMachine,
@@ -404,6 +405,84 @@ function MessageItem({
   );
 }
 
+// Live tmux capture — renders the raw `tmux capture-pane` output so
+// users can see and respond to TUI modals the cleaned chat thread
+// strips (Claude's /monitor, /resume picker, bash-tool approval).
+function PaneView({
+  text,
+  loading,
+  error,
+}: {
+  text: string;
+  loading: boolean;
+  error: string | null;
+}) {
+  if (error) {
+    return <p className="agent-detail__error">Pane fetch failed: {error}</p>;
+  }
+  return (
+    <div className="agent-detail__pane">
+      <div className="agent-detail__pane-header">
+        <span className="agent-detail__pane-dot" />
+        LIVE PANE
+      </div>
+      <pre className="agent-detail__pane-body">
+        {loading && !text ? "Loading pane…" : text || "(empty)"}
+      </pre>
+    </div>
+  );
+}
+
+// Keypad row shown below the events container when pane mode is on.
+// Sends literal tmux send-keys tokens — see helm-daemon's /keys
+// handler.
+function PaneKeypad({
+  onSend,
+  disabled,
+}: {
+  onSend: (keys: string) => void;
+  disabled: boolean;
+}) {
+  const keys: Array<{ label: string; keys: string; title?: string }> = [
+    { label: "Esc", keys: "Escape" },
+    { label: "↑", keys: "Up" },
+    { label: "↓", keys: "Down" },
+    { label: "←", keys: "Left" },
+    { label: "→", keys: "Right" },
+    { label: "↵", keys: "Enter" },
+    { label: "Tab", keys: "Tab" },
+    { label: "⇧Tab", keys: "BTab" },
+    { label: "y", keys: "y", title: "Yes (approve)" },
+    { label: "n", keys: "n", title: "No (deny)" },
+    {
+      label: "Clear",
+      keys: "Escape Escape",
+      title: "Two Escapes — dismiss modals",
+    },
+    {
+      label: "Ctrl+C",
+      keys: "C-c",
+      title: "Send Ctrl-C to the foreground job",
+    },
+  ];
+  return (
+    <div className="agent-detail__keypad" role="toolbar" aria-label="Keypad">
+      {keys.map((k) => (
+        <button
+          key={k.label}
+          type="button"
+          className="agent-detail__keypad-key"
+          onClick={() => onSend(k.keys)}
+          disabled={disabled}
+          title={k.title ?? `Send ${k.label}`}
+        >
+          {k.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
 // Highlighted code block — used for Write content, Read result body,
 // and the generic tool args/result panes. `language` from the file
 // path when known, else highlight.js auto-detect.
@@ -685,6 +764,13 @@ export function AgentDetailPane({
   const [reply, setReply] = useState("");
   const [busy, setBusy] = useState<"reply" | "kill" | "delete" | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
+  // Pane mode toggle — when on, the right side of the pane swaps the
+  // cleaned chat thread for the raw tmux capture (live terminal).
+  // Lets the user see + interact with TUI modals the chat view
+  // strips: Claude's /monitor, the /resume picker, the bash-tool
+  // approval prompt.
+  const [paneMode, setPaneMode] = useState(false);
+  const paneFetch = useAgentPane(machine, agentId, paneMode);
 
   // Auto-grow the reply textarea: starts at one line, grows to fit
   // content up to a 160 px ceiling, then scrolls inside. Avoids the
@@ -971,6 +1057,19 @@ export function AgentDetailPane({
     }
   };
 
+  // Send a tmux send-keys token (e.g. "Escape", "Up", "C-c") to the
+  // agent's pane. Fire-and-forget — the pane poll picks up the result
+  // within ~500 ms so visual feedback is automatic. Errors land in the
+  // action-error banner.
+  const sendKeysToPane = async (keys: string): Promise<void> => {
+    if (!machine || !detail) return;
+    try {
+      await clientFor(machine).sendKeys(detail.id, keys);
+    } catch (e) {
+      setActionError(`sendKeys failed: ${e}`);
+    }
+  };
+
   const copyText = async (text: string) => {
     try {
       await navigator.clipboard.writeText(text);
@@ -1200,6 +1299,23 @@ export function AgentDetailPane({
             </Popover.Portal>
           </Popover.Root>
         )}
+        <button
+          className={
+            paneMode
+              ? "agent-detail__icon-btn agent-detail__icon-btn--zoomed"
+              : "agent-detail__icon-btn"
+          }
+          onClick={() => setPaneMode((v) => !v)}
+          aria-label={paneMode ? "Hide live tmux pane" : "Show live tmux pane"}
+          aria-pressed={paneMode}
+          title={
+            paneMode
+              ? "Hide live tmux pane — back to the chat thread"
+              : "Show live tmux pane — what `tmux attach` would show"
+          }
+        >
+          ▥
+        </button>
         {onToggleZoom && (
           <button
             className={
@@ -1269,7 +1385,13 @@ export function AgentDetailPane({
             }
           }}
         >
-          {loading && !detail ? (
+          {paneMode ? (
+            <PaneView
+              text={paneFetch.text}
+              loading={paneFetch.loading}
+              error={paneFetch.error}
+            />
+          ) : loading && !detail ? (
             <p className="agent-detail__loading">Loading…</p>
           ) : !hasTranscript && detail ? (
             <p className="agent-detail__empty">
@@ -1302,7 +1424,7 @@ export function AgentDetailPane({
               );
             })
           )}
-          {isActive && detail && (
+          {!paneMode && isActive && detail && (
             <div
               className="agent-detail__working"
               aria-live="polite"
@@ -1320,7 +1442,7 @@ export function AgentDetailPane({
           )}
         </div>
 
-        {unseen > 0 && (
+        {unseen > 0 && !paneMode && (
           <button
             type="button"
             className="agent-detail__new-pill"
@@ -1331,6 +1453,10 @@ export function AgentDetailPane({
           </button>
         )}
       </div>
+
+      {paneMode && (
+        <PaneKeypad onSend={(k) => void sendKeysToPane(k)} disabled={!detail} />
+      )}
 
       {detail?.usage &&
         (() => {

--- a/src/hooks/useAgentPane.ts
+++ b/src/hooks/useAgentPane.ts
@@ -1,0 +1,97 @@
+// Live tmux-pane fetch for an agent. Polls /v1/agents/:id/pane while
+// `enabled` is true; stops when toggled off. Used by AgentDetailPane
+// to render the raw terminal — what `tmux attach` would show — so the
+// user can see and interact with TUI modals the cleaned chat view
+// strips (Claude's /monitor, /resume picker, bash-tool approval).
+//
+// Mirrors the helm phone app's pattern: tight 500 ms cadence while
+// pane mode is active, paused while document.hidden.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { clientFor, type HelmMachine } from "../lib/helm-api";
+
+const POLL_INTERVAL_MS = 500;
+
+export interface AgentPaneResult {
+  text: string;
+  loading: boolean;
+  error: string | null;
+}
+
+export function useAgentPane(
+  machine: HelmMachine | null,
+  agentId: string | null,
+  enabled: boolean,
+): AgentPaneResult {
+  const [text, setText] = useState<string>("");
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  const cancelledRef = useRef(false);
+  const machineRef = useRef(machine);
+  machineRef.current = machine;
+
+  const fetchOnce = useCallback(async () => {
+    const m = machineRef.current;
+    if (!m || !agentId) return;
+    try {
+      const t = await clientFor(m).agentPane(agentId);
+      if (!cancelledRef.current) {
+        setText(t);
+        setError(null);
+      }
+    } catch (e) {
+      if (!cancelledRef.current) setError(String(e));
+    } finally {
+      if (!cancelledRef.current) setLoading(false);
+    }
+  }, [agentId]);
+
+  useEffect(() => {
+    cancelledRef.current = false;
+    if (!enabled || !machine || !agentId) {
+      // Clear stale content when pane mode is off — next toggle-on
+      // should show a clean "loading" state, not the last frame.
+      setText("");
+      setError(null);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    void fetchOnce();
+
+    let interval: number | null = null;
+    const start = () => {
+      if (interval !== null) return;
+      interval = window.setInterval(() => void fetchOnce(), POLL_INTERVAL_MS);
+    };
+    const stop = () => {
+      if (interval !== null) {
+        window.clearInterval(interval);
+        interval = null;
+      }
+    };
+    if (!document.hidden) start();
+
+    const onVisibility = () => {
+      if (document.hidden) {
+        stop();
+      } else {
+        void fetchOnce();
+        start();
+      }
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+
+    return () => {
+      cancelledRef.current = true;
+      stop();
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+    // machine.id rather than `machine` so identity changes (a fresh
+    // object with the same id from each useAllAgents poll) don't tear
+    // down the interval.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fetchOnce, machine?.id, agentId, enabled]);
+
+  return { text, loading, error };
+}

--- a/src/lib/helm-api.ts
+++ b/src/lib/helm-api.ts
@@ -167,6 +167,25 @@ export class DaemonClient {
   deleteAgent(id: string): Promise<{ ok: boolean }> {
     return this.request<{ ok: boolean }>("DELETE", `/agents/${id}`);
   }
+
+  /** Raw current tmux pane — what `tmux attach` would show. The
+   *  daemon returns plain text; the Tauri proxy wraps it as
+   *  `{ text: "..." }` (see helm/mod.rs::helm_proxy_request). */
+  async agentPane(id: string): Promise<string> {
+    const v = await this.request<{ text?: string } | null>(
+      "GET",
+      `/agents/${id}/pane`,
+    );
+    return v && typeof v.text === "string" ? v.text : "";
+  }
+
+  /** Forward a key sequence into the agent's tmux pane. Used to
+   *  navigate TUI modals (Esc / arrows / Enter / Tab / Ctrl-C). */
+  sendKeys(id: string, keys: string): Promise<{ ok: boolean }> {
+    return this.request<{ ok: boolean }>("POST", `/agents/${id}/keys`, {
+      keys,
+    });
+  }
 }
 
 export function clientFor(m: HelmMachine): DaemonClient {

--- a/src/styles/agent-detail.css
+++ b/src/styles/agent-detail.css
@@ -864,3 +864,95 @@
   color: var(--color-danger, #f87171);
   flex: 0 0 auto;
 }
+
+/* ---- live tmux pane mode (v0.4.22) ---- */
+
+.agent-detail__pane {
+  display: flex;
+  flex-direction: column;
+  background: var(--color-bg-secondary, #181818);
+  border: 1px solid var(--color-border, #2a2a2a);
+  border-radius: 4px;
+  margin: 6px 0;
+  overflow: hidden;
+}
+
+.agent-detail__pane-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  color: var(--color-text-secondary, #888);
+  background: rgba(255, 255, 255, 0.02);
+  border-bottom: 1px solid var(--color-border, #2a2a2a);
+  text-transform: uppercase;
+}
+
+.agent-detail__pane-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--color-success, #7ec699);
+  /* Subtle pulse so the user sees the pane is live, not a snapshot. */
+  animation: agent-detail__pane-pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes agent-detail__pane-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+}
+
+.agent-detail__pane-body {
+  margin: 0;
+  padding: 8px 10px;
+  font-family: var(--font-mono, monospace);
+  font-size: var(--app-msg-size, 13px);
+  line-height: 1.4;
+  color: var(--color-text, #d4d8de);
+  /* tmux capture lines are typically 80-200 chars and rely on a
+   * fixed-width font with no wrapping (otherwise box-drawing breaks).
+   * Horizontal scroll instead of word-wrap. */
+  white-space: pre;
+  overflow-x: auto;
+}
+
+/* ---- keypad row (visible only while in pane mode) ---- */
+
+.agent-detail__keypad {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 6px 0;
+  flex: 0 0 auto;
+  border-top: 1px solid var(--color-border, #2a2a2a);
+}
+
+.agent-detail__keypad-key {
+  padding: 4px 10px;
+  font-family: var(--font-mono, monospace);
+  font-size: 12px;
+  background: var(--color-bg-secondary, #181818);
+  color: var(--color-text, #e4e4e4);
+  border: 1px solid var(--color-border, #2a2a2a);
+  border-radius: 4px;
+  cursor: pointer;
+}
+.agent-detail__keypad-key:hover:not(:disabled) {
+  background: var(--color-bg-hover, #222);
+  border-color: var(--color-accent-muted, rgba(136, 180, 255, 0.4));
+}
+.agent-detail__keypad-key:active:not(:disabled) {
+  background: var(--color-accent-muted, rgba(136, 180, 255, 0.18));
+}
+.agent-detail__keypad-key:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}


### PR DESCRIPTION
Brings the phone app's "Pane mode" feature to the desktop console.

## Summary
A new **▥ toggle** in the agent pane header swaps the cleaned chat thread for the raw \`tmux capture-pane\` output — what \`tmux attach\` would show. Lets users see + respond to TUI modals the chat view strips:

- Claude's \`/monitor\` overlay
- The \`/resume\` session picker
- The bash-tool approval prompt

While pane mode is on, a 500 ms poll fetches \`/v1/agents/:id/pane\` (daemon endpoint exists in helm v4.0.6+). A **keypad row** below the events container is the navigation surface — Esc, ↑↓←→, Enter, Tab, ⇧Tab, y, n, Clear (Escape Escape), Ctrl-C — and POSTs to \`/v1/agents/:id/keys\`.

## Wiring
- \`src/lib/helm-api.ts\` — \`agentPane()\` + \`sendKeys()\` on \`DaemonClient\`. \`agentPane\` unwraps the \`{text}\` shape that the Tauri proxy uses for non-JSON daemon responses (\`helm/mod.rs::helm_proxy_request\`).
- \`src/hooks/useAgentPane.ts\` — 500 ms poll while enabled, paused on \`document.hidden\`. Same shape as \`useAgentDetail\`.
- \`src/components/AgentDetailPane.tsx\` — \`paneMode\` state, ▥ header toggle, new \`PaneView\` + \`PaneKeypad\` subcomponents, \`sendKeysToPane\` action.
- \`src/styles/agent-detail.css\` — pane container, pulsing LIVE dot, keypad row.

## Test plan
- [ ] Open an agent with Claude — click ▥ → chat thread is replaced by the raw tmux output, "LIVE PANE" badge with a pulsing dot
- [ ] Send keys via the keypad — pane updates within ~500 ms
- [ ] Toggle ▥ off → returns to chat view, polling stops
- [ ] Trigger a bash-tool approval prompt → pane mode + 'y' key approves it