### PR TITLE
feat: j/k list navigation + Enter to open (#466 first slice, v0.4.23)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.4.22",
+  "version": "0.4.23",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "workroot"
-version = "0.4.22"
+version = "0.4.23"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.4.22"
+version = "0.4.23"
 edition = "2021"
 authors = ["Saurav Panda <saurav@workroot.dev>"]
 description = "A local-first developer workspace for managing projects, terminals, and Git workflows."

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.4.22",
+  "version": "0.4.23",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/components/AgentsTab.tsx
+++ b/src/components/AgentsTab.tsx
@@ -210,6 +210,10 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
   // Counts per chip are computed from the unfiltered list so the user
   // can see "Done 12" even when looking at "Needs you 2".
   const [stateFilter, setStateFilter] = useState<StateFilter>("all");
+  // Keyboard cursor into the filtered agents list — j/k move it,
+  // Enter opens the agent under the cursor. -1 means "no cursor"
+  // (the user hasn't pressed j/k yet, or the list is empty). #466.
+  const [listCursor, setListCursor] = useState<number>(-1);
   // Zed-style "zoom the focused pane" — when set, only this pane is
   // visible inside the panes container (others stay mounted so polls
   // and scroll positions survive). The list pane stays put; only the
@@ -498,6 +502,69 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
     [agents, stateFilter],
   );
 
+  // List navigation: j/k move the cursor through filteredAgents,
+  // Enter opens the agent under the cursor. Skipped when the user is
+  // typing in an input/textarea so it doesn't fight reply composition.
+  // #466 first slice.
+  useEffect(() => {
+    if (filteredAgents.length === 0) return;
+    const onKey = (e: KeyboardEvent) => {
+      const t = e.target as HTMLElement | null;
+      if (
+        t &&
+        (t.tagName === "TEXTAREA" ||
+          t.tagName === "INPUT" ||
+          t.isContentEditable)
+      ) {
+        return;
+      }
+      // Ignore modifier-key combinations — those are reserved for
+      // ⌘P / ⌘⇧Z / ⌘W etc., not for list navigation.
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      if (e.key === "j" || e.key === "ArrowDown") {
+        e.preventDefault();
+        setListCursor((cur) =>
+          Math.min(filteredAgents.length - 1, (cur < 0 ? -1 : cur) + 1),
+        );
+      } else if (e.key === "k" || e.key === "ArrowUp") {
+        e.preventDefault();
+        setListCursor((cur) =>
+          cur < 0 ? filteredAgents.length - 1 : Math.max(0, cur - 1),
+        );
+      } else if (e.key === "Enter" && listCursor >= 0) {
+        const a = filteredAgents[listCursor];
+        if (a) {
+          e.preventDefault();
+          openAgent(a.machine_id, a.id);
+        }
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [filteredAgents, listCursor, openAgent]);
+
+  // Keep the cursor in range as the filtered list churns (poll updates,
+  // filter changes). Clamp rather than reset so the cursor sticks
+  // visually near where the user left it.
+  useEffect(() => {
+    if (filteredAgents.length === 0) {
+      if (listCursor !== -1) setListCursor(-1);
+      return;
+    }
+    if (listCursor >= filteredAgents.length) {
+      setListCursor(filteredAgents.length - 1);
+    }
+  }, [filteredAgents, listCursor]);
+
+  // Scroll the cursor row into view whenever it moves.
+  useEffect(() => {
+    if (listCursor < 0) return;
+    const el = document.querySelector(".agents-tab__row--cursor");
+    if (el && typeof el.scrollIntoView === "function") {
+      el.scrollIntoView({ block: "nearest" });
+    }
+  }, [listCursor]);
+
   const list = (
     <>
       <div className="agents-tab__header">
@@ -642,8 +709,9 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
                 </button>
               </div>
             )}
-            {filteredAgents.map((a) => {
+            {filteredAgents.map((a, idx) => {
               const isOpen = openSet.has(`${a.machine_id}:${a.id}`);
+              const isCursor = idx === listCursor;
               const stateLabel = STATE_LABELS[a.state] ?? a.state;
               const activity = a.last_activity ?? a.task;
               const machineShort = shortMachineLabel(a.machine_label);
@@ -651,11 +719,13 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
               return (
                 <div
                   key={`${a.machine_id}:${a.id}`}
-                  className={
-                    isOpen
-                      ? "agents-tab__row agents-tab__row--selected"
-                      : "agents-tab__row"
-                  }
+                  className={[
+                    "agents-tab__row",
+                    isOpen ? "agents-tab__row--selected" : "",
+                    isCursor ? "agents-tab__row--cursor" : "",
+                  ]
+                    .filter(Boolean)
+                    .join(" ")}
                   onClick={() => openAgent(a.machine_id, a.id)}
                   role="row"
                   tabIndex={0}

--- a/src/styles/agents-tab.css
+++ b/src/styles/agents-tab.css
@@ -464,6 +464,15 @@
   background: rgba(96, 165, 250, 0.1);
 }
 
+/* Keyboard cursor (j/k navigation, #466). Distinct from --selected
+ * (which means "open in a pane"): the cursor is the *focus*, the
+ * thing Enter will open. Outline-style so it can stack on top of
+ * --selected without fighting backgrounds. */
+.agents-tab__row--cursor {
+  outline: 1px solid var(--color-accent, #88b4ff);
+  outline-offset: -1px;
+}
+
 /* state pill — mirrors detail-pane treatment */
 .agents-tab__state-pill {
   display: inline-block;


### PR DESCRIPTION
First slice of #466 — the most-requested keyboard piece.

## Summary
- **j / ↓** move a cursor down through the filtered agents list
- **k / ↑** move it up (from "no cursor", k jumps to the last row)
- **Enter** opens the agent under the cursor in a pane
- Cursor (outline, accent color) is distinct from "selected" (background fill, marks agents already in a pane) — both visuals can stack on the same row
- Skipped inside text inputs/textareas/contentEditable so it doesn't fight the reply composer
- Modifier-key combos (⌘/Ctrl/Alt + j/k/Enter) are ignored — slots stay free for ⌘P / ⌘⇧Z / ⌘W
- Cursor clamps to the current filtered list as polls churn it, and scrolls into view when it moves

Rest of #466 — \`⌘W\` close pane, \`⌘1..4\` layout switch, fuller keymap — stays open.

## Test plan
- [ ] Press \`j\` in the list → first row gets accent outline; \`j\` again moves down
- [ ] Press \`k\` from "no cursor" → cursor lands on the last row
- [ ] Press \`Enter\` with cursor on a row → that agent opens in a pane
- [ ] Type in the reply textarea → j/k stay literal (no nav)
- [ ] Use the filter chips → cursor stays in range (clamps if it would fall off)
- [ ] Scroll a long list, press k repeatedly → cursor row scrolls back into view