### PR TITLE
feat: ⌘1..⌘4 set Agents layout size (#466 cont., v0.4.24)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.4.23",
+  "version": "0.4.24",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "workroot"
-version = "0.4.23"
+version = "0.4.24"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.4.23"
+version = "0.4.24"
 edition = "2021"
 authors = ["Saurav Panda <saurav@workroot.dev>"]
 description = "A local-first developer workspace for managing projects, terminals, and Git workflows."

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.4.23",
+  "version": "0.4.24",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/components/AgentsTab.tsx
+++ b/src/components/AgentsTab.tsx
@@ -410,20 +410,37 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
   // Keyboard:
   //   Esc       — unzoom if zoomed, else close the focused pane
   //   ⌘⇧Z       — toggle zoom on the focused pane (Zed parity)
-  // Both no-op inside text inputs so they don't fight Cancel/blur.
+  //   ⌘1..⌘4    — switch layout to N panes (#466)
+  // All no-op inside text inputs so they don't fight Cancel/blur or
+  // the user's reply composition.
   useEffect(() => {
-    if (panes.length === 0) return;
     const onKey = (e: KeyboardEvent) => {
       const target = e.target as HTMLElement | null;
       const inInput =
         target && (target.tagName === "TEXTAREA" || target.tagName === "INPUT");
+      if (inInput) return;
+
+      // ⌘1..⌘4 → setLayout(N). Works with 0 panes too — the user can
+      // pre-set the layout before opening agents. Shift required by
+      // ⌘⇧Z below is excluded here so the two don't collide.
+      if (
+        (e.metaKey || e.ctrlKey) &&
+        !e.shiftKey &&
+        !e.altKey &&
+        ["1", "2", "3", "4"].includes(e.key)
+      ) {
+        e.preventDefault();
+        setLayout(parseInt(e.key, 10) as LayoutSize);
+        return;
+      }
+
+      if (panes.length === 0) return;
 
       // ⌘⇧Z toggles zoom on the focused pane.
       if (
         e.key.toLowerCase() === "z" &&
         (e.metaKey || e.ctrlKey) &&
-        e.shiftKey &&
-        !inInput
+        e.shiftKey
       ) {
         e.preventDefault();
         setZoomedPaneId((cur) => {
@@ -434,7 +451,6 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
       }
 
       if (e.key !== "Escape") return;
-      if (inInput) return;
       // Esc unzooms first (don't close the pane while we're zoomed —
       // the user expects "back to multi-pane view").
       if (zoomedPaneId !== null) {
@@ -448,7 +464,7 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [panes, focusedPaneId, zoomedPaneId, closePane]);
+  }, [panes, focusedPaneId, zoomedPaneId, closePane, setLayout]);
 
   // If the zoomed pane goes away (closed elsewhere, agent deleted),
   // unzoom so the layout doesn't end up stuck on a phantom pane.


### PR DESCRIPTION
Continues #466 — adds the layout-size shortcut from the spec.

## Summary
- **⌘1 / ⌘2 / ⌘3 / ⌘4** switch the Agents pane layout to 1/2/3/4 cells — same effect as clicking the existing layout picker
- Marks \`userPickedLayout=true\` so auto-grow doesn't fight the explicit choice on the next open
- Works with 0 panes too — the user can pre-set the layout before opening agents
- Skipped inside text inputs / textareas, same as the other shortcuts

⌘W is deferred — it collides with the macOS window-close binding and needs separate plumbing (or a different glyph like ⌘⇧W). Esc already closes the focused pane today, so this isn't blocking.

## Test plan
- [ ] Open the Agents tab, no panes — press ⌘2 → layout picker highlights 2; opening agents will fill 2 cells
- [ ] Press ⌘4 with 1 pane → layout grows to 4
- [ ] Press ⌘1 with 3 panes → trims down (drops unpinned first)
- [ ] Type in the reply textarea — ⌘1..⌘4 are inert (don't fire)