### PR TITLE
fix: live-pane view fills available height (v0.4.25)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.4.24",
+  "version": "0.4.25",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "workroot"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.4.24"
+version = "0.4.25"
 edition = "2021"
 authors = ["Saurav Panda <saurav@workroot.dev>"]
 description = "A local-first developer workspace for managing projects, terminals, and Git workflows."

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.4.24",
+  "version": "0.4.25",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/styles/agent-detail.css
+++ b/src/styles/agent-detail.css
@@ -875,6 +875,11 @@
   border-radius: 4px;
   margin: 6px 0;
   overflow: hidden;
+  /* Fill the available height of the events container — without this
+   * the pane sits at content height and leaves a big empty band
+   * between the LIVE PANE and the keypad. */
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 .agent-detail__pane-header {
@@ -921,7 +926,11 @@
    * fixed-width font with no wrapping (otherwise box-drawing breaks).
    * Horizontal scroll instead of word-wrap. */
   white-space: pre;
-  overflow-x: auto;
+  /* Fills the rest of the pane vertically; scroll inside both axes
+   * so a tall capture or long lines don't push the keypad away. */
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
 }
 
 /* ---- keypad row (visible only while in pane mode) ---- */


### PR DESCRIPTION
Fix for the layout bug in v0.4.22's live-pane mode shown in the user screenshot — the LIVE PANE box was content-height with a big empty band between it and the keypad.

## Summary
- \`.agent-detail__pane\` is now \`flex: 1 1 auto; min-height: 0\` — fills the events scroll area like the chat thread does when paneMode is off
- \`.agent-detail__pane-body\` is \`flex: 1 1 auto; min-height: 0; overflow: auto\` — tall captures or 200+ col lines scroll inside the pane instead of pushing the keypad off screen

## Test plan
- [ ] Toggle ▥ on → LIVE PANE box fills the available height; no empty band between pane and keypad row
- [ ] On a wide tmux session (200-col output) → horizontal scroll inside the pane
- [ ] On a very tall capture → vertical scroll inside the pane, keypad stays visible at the bottom

(Side note from the same screenshot — \`ctx 99%\` even though Claude's own status line shows 24% — that's the known approximation limit. The daemon would need to expose Claude Code's real session token state for a true number, tracked in #489 territory.)