### PR TITLE
fix: status bar polish + friendly invoke errors (v0.4.26)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.4.25",
+  "version": "0.4.26",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "workroot"
-version = "0.4.25"
+version = "0.4.26"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.4.25"
+version = "0.4.26"
 edition = "2021"
 authors = ["Saurav Panda <saurav@workroot.dev>"]
 description = "A local-first developer workspace for managing projects, terminals, and Git workflows."

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/components/AgentsTab.tsx
+++ b/src/components/AgentsTab.tsx
@@ -13,6 +13,7 @@ import type { AgentState } from "../lib/helm-api";
 import { AgentDetailPane } from "./AgentDetailPane";
 import { consumePendingOpen } from "../lib/openAgent";
 import { consumePendingFilter } from "../lib/agentFilter";
+import { publishAgentsView } from "../lib/agentsViewSnapshot";
 import "../styles/agents-tab.css";
 
 interface AgentsTabProps {
@@ -474,6 +475,17 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
       setZoomedPaneId(null);
     }
   }, [panes, zoomedPaneId]);
+
+  // Publish pane/zoom state for the StatusBar so its keyboard hints
+  // stay honest — show "⌘⇧Z zoom" only when there's a pane to zoom,
+  // "Esc unzoom" only when something is currently zoomed. #501.
+  useEffect(() => {
+    publishAgentsView({
+      paneCount: panes.length,
+      zoomed: zoomedPaneId !== null,
+    });
+    return () => publishAgentsView({ paneCount: 0, zoomed: false });
+  }, [panes.length, zoomedPaneId]);
 
   const offlineMachines = useMemo(
     () => machines.filter((m) => m.error !== null),

--- a/src/components/HelmMachinesPanel.tsx
+++ b/src/components/HelmMachinesPanel.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { Dialog, DialogContent } from "./ui/dialog";
+import { friendlyError } from "../lib/tauriErrors";
 import "../styles/helm-machines.css";
 
 interface HelmMachine {
@@ -56,7 +57,7 @@ export function HelmMachinesPanel({ onClose }: HelmMachinesPanelProps) {
       const list = await invoke<HelmMachine[]>("list_helm_machines");
       setMachines(list);
     } catch (e) {
-      setError(String(e));
+      setError(friendlyError(e));
     } finally {
       setLoading(false);
     }
@@ -84,7 +85,7 @@ export function HelmMachinesPanel({ onClose }: HelmMachinesPanelProps) {
       setNewToken("");
       await refresh();
     } catch (e) {
-      setError(String(e));
+      setError(friendlyError(e));
     } finally {
       setAdding(false);
     }
@@ -103,7 +104,7 @@ export function HelmMachinesPanel({ onClose }: HelmMachinesPanelProps) {
         });
         await refresh();
       } catch (e) {
-        setError(String(e));
+        setError(friendlyError(e));
       }
     },
     [refresh],
@@ -115,7 +116,7 @@ export function HelmMachinesPanel({ onClose }: HelmMachinesPanelProps) {
         await invoke<boolean>("remove_helm_machine", { id: m.id });
         await refresh();
       } catch (e) {
-        setError(String(e));
+        setError(friendlyError(e));
       }
     },
     [refresh],
@@ -130,7 +131,7 @@ export function HelmMachinesPanel({ onClose }: HelmMachinesPanelProps) {
       );
       setDiscovered(list);
     } catch (e) {
-      setDiscoverError(String(e));
+      setDiscoverError(friendlyError(e));
       setDiscovered([]);
     } finally {
       setDiscovering(false);
@@ -158,7 +159,7 @@ export function HelmMachinesPanel({ onClose }: HelmMachinesPanelProps) {
         );
         await refresh();
       } catch (e) {
-        setError(String(e));
+        setError(friendlyError(e));
       }
     },
     [refresh],

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo } from "react";
 import { useFleetSnapshot } from "../hooks/useAllAgents";
 import { requestAgentFilter } from "../lib/agentFilter";
+import { useAgentsViewSnapshot } from "../lib/agentsViewSnapshot";
 import "../styles/status-bar.css";
 
 /* ------------------------------------------------------------------ */
@@ -87,6 +88,8 @@ export function StatusBar({
   isGitHubConnected,
 }: StatusBarProps) {
   const [time, setTime] = useState(() => formatTime(new Date()));
+  const agentsView = useAgentsViewSnapshot();
+  const { agents, machines } = useFleetSnapshot();
 
   useEffect(() => {
     const update = () => setTime(formatTime(new Date()));
@@ -112,9 +115,16 @@ export function StatusBar({
       {/* -- Left side -- */}
       <div className="status-bar-left">
         <FleetSummary />
-        <span className="status-bar-item">
-          {projectName ?? "No project selected"}
-        </span>
+        {projectName ? (
+          <span className="status-bar-item">{projectName}</span>
+        ) : machines.length > 0 ? (
+          // On the Agents view (no worktree selected), "No project
+          // selected" is stale/confusing. Show agent context instead.
+          // #503.
+          <span className="status-bar-item">
+            {agents.length} agent{agents.length === 1 ? "" : "s"}
+          </span>
+        ) : null}
         {branchName && (
           <span className="status-bar-item">
             <span className="status-bar-branch-icon">
@@ -150,28 +160,40 @@ export function StatusBar({
                 : "status-bar-dot--disconnected"
             }`}
           />
-          <span className="status-bar-connection">
-            {isGitHubConnected ? "Connected" : "Disconnected"}
+          <span
+            className="status-bar-connection"
+            title="GitHub authentication status"
+          >
+            GitHub: {isGitHubConnected ? "Connected" : "Disconnected"}
           </span>
         </span>
         <span className="status-bar-item">
           <span className="status-bar-time">{time}</span>
         </span>
         {/* Honest keymap hint \u2014 only the shortcuts that are actually
-         *  wired today (#467). Once the keyboard layer (#466) lands,
-         *  this becomes context-aware (list / pane / zoomed). */}
+         *  wired today (#467) AND apply to the current context (#501).
+         *  \u2318K palette is always shown; the rest are gated on whether
+         *  there's a pane to act on. */}
         <span
           className="status-bar-item status-bar-hints"
           title="Keyboard shortcuts"
         >
           <kbd className="status-bar-kbd">{"\u2318K"}</kbd>
           <span className="status-bar-hint-label">palette</span>
-          <span className="status-bar-hint-sep">\u00b7</span>
-          <kbd className="status-bar-kbd">{"\u2318\u21e7Z"}</kbd>
-          <span className="status-bar-hint-label">zoom</span>
-          <span className="status-bar-hint-sep">\u00b7</span>
-          <kbd className="status-bar-kbd">Esc</kbd>
-          <span className="status-bar-hint-label">unzoom</span>
+          {agentsView.paneCount > 0 && (
+            <>
+              <span className="status-bar-hint-sep">{"\u00b7"}</span>
+              <kbd className="status-bar-kbd">{"\u2318\u21e7Z"}</kbd>
+              <span className="status-bar-hint-label">zoom</span>
+            </>
+          )}
+          {agentsView.zoomed && (
+            <>
+              <span className="status-bar-hint-sep">{"\u00b7"}</span>
+              <kbd className="status-bar-kbd">Esc</kbd>
+              <span className="status-bar-hint-label">unzoom</span>
+            </>
+          )}
         </span>
       </div>
     </div>

--- a/src/lib/agentsViewSnapshot.ts
+++ b/src/lib/agentsViewSnapshot.ts
@@ -1,0 +1,34 @@
+// Cross-component read-only view of AgentsTab's pane state, so the
+// StatusBar (rendered at App level) can give honest keyboard hints
+// ("⌘⇧Z zoom" only when a pane exists, "Esc unzoom" only when one
+// is currently zoomed). Mirrors the openAgent / agentFilter / fleet
+// snapshot patterns: module-level cache + CustomEvent broadcast.
+
+import { useEffect, useState } from "react";
+
+export interface AgentsViewSnapshot {
+  paneCount: number;
+  zoomed: boolean;
+}
+
+let cached: AgentsViewSnapshot = { paneCount: 0, zoomed: false };
+
+export function publishAgentsView(next: AgentsViewSnapshot): void {
+  // Only fire if something changed — saves React work in StatusBar.
+  if (cached.paneCount === next.paneCount && cached.zoomed === next.zoomed) {
+    return;
+  }
+  cached = next;
+  window.dispatchEvent(new CustomEvent("workroot:agents-view"));
+}
+
+export function useAgentsViewSnapshot(): AgentsViewSnapshot {
+  const [snap, setSnap] = useState<AgentsViewSnapshot>(cached);
+  useEffect(() => {
+    const sync = () => setSnap(cached);
+    window.addEventListener("workroot:agents-view", sync);
+    sync();
+    return () => window.removeEventListener("workroot:agents-view", sync);
+  }, []);
+  return snap;
+}

--- a/src/lib/tauriErrors.ts
+++ b/src/lib/tauriErrors.ts
@@ -1,0 +1,28 @@
+// Helpers for surfacing Tauri-IPC errors to the user. The most common
+// confusing case is when the frontend is loaded outside the Tauri
+// runtime (browser preview, Vite dev with no Tauri bundle): every
+// invoke() rejects with a JS-runtime TypeError about reading 'invoke'
+// on undefined, which is total noise to a user.
+
+const TAURI_MISSING_SENTINELS = [
+  "Cannot read properties of undefined",
+  "is not a function",
+  "__TAURI_INTERNALS__",
+  "window.__TAURI_IPC__",
+];
+
+/** True when the error string clearly comes from the Tauri runtime
+ *  not being loaded (vs. a genuine command failure). */
+export function isTauriMissingError(e: unknown): boolean {
+  const msg = String(e);
+  return TAURI_MISSING_SENTINELS.some((s) => msg.includes(s));
+}
+
+/** Convert any thrown value to a user-facing string. Hides the
+ *  TypeError noise when Tauri isn't loaded. */
+export function friendlyError(e: unknown): string {
+  if (isTauriMissingError(e)) {
+    return "This screen needs the desktop app — Tauri commands aren't available here.";
+  }
+  return String(e);
+}


### PR DESCRIPTION
Bundles five small UX fixes surfaced by a codex-assisted review of running the app in browser preview.

Closes #500, #501, #502, #503, #504.

## Summary
- **#500** Status bar showed literal \`·\` instead of \`·\` (JSX text nodes don't interpret escapes; needs \`{\"·\"}\` form).
- **#501** Keyboard hints are now **conditional** via a new \`lib/agentsViewSnapshot\` pub/sub: \`⌘⇧Z zoom\` only shows when at least one pane is open; \`Esc unzoom\` only when a pane is zoomed.
- **#502** Connection label gains a noun: \`GitHub: Connected\` / \`GitHub: Disconnected\`.
- **#503** \`No project selected\` on the Agents view is replaced with fleet context (\`N agents\`) when no worktree is selected. Worktree/terminal views keep the project name.
- **#504** \`HelmMachinesPanel\` catches Tauri-IPC-missing failures and shows \`This screen needs the desktop app — Tauri commands aren't available here.\` instead of a raw TypeError string. New \`src/lib/tauriErrors.ts\` helper.

## Test plan
- [ ] Status bar bottom right shows real \`·\` dots (no \`\\u00b7\`)
- [ ] No panes → only \`⌘K palette\` hint
- [ ] Pane open → adds \`⌘⇧Z zoom\`
- [ ] Pane zoomed → adds \`Esc unzoom\`
- [ ] Right side reads \`GitHub: Disconnected\` (or Connected)
- [ ] On Agents view with no machines → status bar left zone has no \`No project selected\`
- [ ] Running via \`pnpm dev\` (no Tauri) → Manage Machines shows the friendly fallback