### PR TITLE
feat: empty-state onboarding + machine wording dedup (v0.4.27)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.4.26",
+  "version": "0.4.27",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "workroot"
-version = "0.4.26"
+version = "0.4.27"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.4.26"
+version = "0.4.27"
 edition = "2021"
 authors = ["Saurav Panda <saurav@workroot.dev>"]
 description = "A local-first developer workspace for managing projects, terminals, and Git workflows."

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.4.26",
+  "version": "0.4.27",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -256,7 +256,7 @@ function AppContent({
       },
       {
         id: "settings:helm-machines",
-        label: "Helm Machines",
+        label: "Machines",
         category: "Navigation",
         icon: "\u2756",
         action: () => openPanel("helmMachines"),

--- a/src/components/AgentsTab.tsx
+++ b/src/components/AgentsTab.tsx
@@ -503,6 +503,30 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
     [refresh],
   );
 
+  // Primary onboarding action from the empty state: register a machine
+  // at the conventional localhost helm-daemon address. If the daemon is
+  // running, polling kicks in within a cycle; if not, the user sees the
+  // offline-machine banner and can debug. #505.
+  const [connectingLocal, setConnectingLocal] = useState(false);
+  const connectLocal = useCallback(async () => {
+    setConnectingLocal(true);
+    try {
+      await invoke("add_helm_machine", {
+        label: "Local",
+        baseUrl: "http://127.0.0.1:8421",
+        apiToken: null,
+      });
+      refresh();
+    } catch {
+      // Likely a duplicate label or the IPC isn't available — fall
+      // back to opening the full Machines panel so the user can
+      // diagnose.
+      onOpenMachines();
+    } finally {
+      setConnectingLocal(false);
+    }
+  }, [refresh, onOpenMachines]);
+
   // Build a Set of "open" machineId:agentId so list rows can show whether
   // they're already in a pane.
   const openSet = useMemo(() => {
@@ -675,14 +699,24 @@ export function AgentsTab({ onOpenMachines }: AgentsTabProps) {
           </p>
           <div className="agents-tab__empty-actions">
             <button
+              type="button"
               className="agents-tab__empty-cta agents-tab__empty-cta--primary"
-              onClick={onOpenMachines}
+              onClick={() => void connectLocal()}
+              disabled={connectingLocal}
+              title="Register http://127.0.0.1:8421 — start helm-daemon locally first"
             >
-              Add a machine
+              {connectingLocal ? "Connecting…" : "Connect local helm-daemon"}
             </button>
             <button
               type="button"
               className="agents-tab__empty-cta"
+              onClick={onOpenMachines}
+            >
+              Add machine…
+            </button>
+            <button
+              type="button"
+              className="agents-tab__empty-cta agents-tab__empty-cta--link"
               onClick={() => {
                 void openShell(
                   "https://github.com/sauravpanda/workroot#readme",

--- a/src/components/HelmMachinesPanel.tsx
+++ b/src/components/HelmMachinesPanel.tsx
@@ -172,9 +172,9 @@ export function HelmMachinesPanel({ onClose }: HelmMachinesPanelProps) {
         if (!open) onClose();
       }}
     >
-      <DialogContent className="helm-machines" aria-label="Helm Machines">
+      <DialogContent className="helm-machines" aria-label="Machines">
         <div className="helm-machines__header">
-          <h3 className="helm-machines__title">Helm Machines</h3>
+          <h3 className="helm-machines__title">Machines</h3>
           <p className="helm-machines__hint">
             Each row is one helm-daemon. Disabled rows are skipped when fetching
             agents.

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -435,7 +435,7 @@ export function SettingsTab({
       <hr className="settings-divider" />
 
       <section className="settings-section">
-        <h3 className="settings-section-title">Helm Machines</h3>
+        <h3 className="settings-section-title">Machines</h3>
         <p className="settings-section-desc">
           Workroot connects to one or more helm-daemon machines (local or
           tailnet) to spawn and watch agents. Add, remove, or rotate tokens
@@ -447,7 +447,7 @@ export function SettingsTab({
           onClick={() => onOpenHelmMachines?.()}
           disabled={!onOpenHelmMachines}
         >
-          Manage helm machines
+          Manage machines
         </button>
       </section>
 

--- a/src/styles/agents-tab.css
+++ b/src/styles/agents-tab.css
@@ -684,6 +684,28 @@
   background: var(--color-accent-muted, rgba(136, 180, 255, 0.14));
 }
 
+.agents-tab__empty-cta--primary:disabled {
+  opacity: 0.55;
+  cursor: progress;
+}
+
+/* Tertiary "Read docs" — looks like a link, not a button, so the
+ * primary "Connect" reads as the clear next step (#505). */
+.agents-tab__empty-cta--link {
+  border-color: transparent;
+  background: transparent;
+  color: var(--color-text-secondary, #888);
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-underline-offset: 3px;
+  padding: 6px 8px;
+}
+.agents-tab__empty-cta--link:hover {
+  background: transparent;
+  color: var(--color-text, #e4e4e4);
+  text-decoration-style: solid;
+}
+
 /* "helm spawn …" code line — copyable look. Inherits the mono +
  * surface bg from the rest of the design. */
 .agents-tab__empty-code {


### PR DESCRIPTION
Closes #505, #508.

## Summary
- **#505** Agents empty state's primary CTA is now **\`Connect local helm-daemon\`** — registers a Machine at \`http://127.0.0.1:8421\`. If the daemon is up the agents list starts polling within a cycle; if not, the user gets the offline-machine banner and can diagnose. \`Add machine…\` stays as a secondary path for non-local setups; \`Read the setup docs\` becomes a tertiary link-style action.
- **#508** Wording dedup. \`Helm Machines\` / \`Manage helm machines\` / \`Add a machine\` are normalized to \`Machines\` / \`Manage machines\` / \`Add machine\`. The \"helm\" framing is implied by the app's context — repeating it in user-facing strings was noise.

## Test plan
- [ ] Empty Agents view shows 3-tier CTA: Connect local helm-daemon (primary, accent) / Add machine… (secondary) / Read the setup docs (link)
- [ ] Click \"Connect local helm-daemon\" with daemon running → machine added, agents list starts polling
- [ ] Click \"Connect local helm-daemon\" with daemon down → offline-machine banner appears
- [ ] Status bar, palette, settings, machines panel all say \`Machines\` (not \`Helm Machines\`)