### PR TITLE
feat: Settings centered column + card-panel sections (v0.4.31)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.4.29",
+  "version": "0.4.31",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "workroot"
-version = "0.4.29"
+version = "0.4.31"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.4.29"
+version = "0.4.31"
 edition = "2021"
 authors = ["Saurav Panda <saurav@workroot.dev>"]
 description = "A local-first developer workspace for managing projects, terminals, and Git workflows."

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.4.29",
+  "version": "0.4.31",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -3,11 +3,15 @@
    ========================================================== */
 
 .settings-tab {
-  padding: 2em;
-  max-width: 560px;
+  padding: 2.5em 2em 4em;
+  /* Centered content column — was max-width: 560px without margin:auto
+   * so the page hugged the left edge of a wide window. #506. */
+  max-width: 760px;
+  margin: 0 auto;
   overflow-y: auto;
   height: 100%;
   position: relative;
+  box-sizing: border-box;
 }
 
 /* Top-left so it reads as "back to where I came from" rather than
@@ -60,16 +64,23 @@
   font-size: 0.8em;
 }
 
-/* ── Sections ── */
+/* ── Sections ── #507 — each section is a card-ish panel with its
+ *   own border + background, so the page reads as grouped blocks
+ *   instead of one continuous form. The old <hr>-between-sections
+ *   pattern is gone (the dividers are now de-emphasized to 0). */
 
 .settings-section {
-  margin-bottom: 1.5em;
+  margin-bottom: 1.25em;
+  padding: 1.25em 1.5em;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle, var(--border));
+  border-radius: var(--radius-md, 6px);
 }
 
 .settings-section-title {
   font-size: 0.82em;
   font-weight: 600;
-  margin: 0 0 0.35em;
+  margin: 0 0 0.65em;
   color: var(--text-primary);
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -207,10 +218,10 @@
 
 /* ── Divider ── */
 
+/* Dividers are now redundant — sections are their own cards (#507).
+ * Keep the class so existing <hr>s don't 404, but render nothing. */
 .settings-divider {
-  border: none;
-  border-top: 1px solid var(--border);
-  margin: 1.5em 0;
+  display: none;
 }
 
 /* ── Update Status ── */


### PR DESCRIPTION
Closes #506, #507. Settings redesign pass.

## Summary
- **#506** \`.settings-tab\` gets \`margin: 0 auto\` + bumps \`max-width\` to 760px. Previously hugged the left edge on a wide window because the max-width existed without margin: auto.
- **#507** Each \`.settings-section\` becomes a card: border, padded background, radius. The page reads as discrete grouped panels (Integration, Appearance, Machines, Updates, About) instead of one continuous form. \`.settings-divider\` stays in markup but renders as \`display: none\` — the panels themselves provide the visual separation.

Before / after screenshots in the issue threads (#506, #507).

## Test plan
- [ ] On a wide window, Settings sits in a centered ~760px column with whitespace on both sides
- [ ] Each section reads as its own card (border, slightly darker bg)
- [ ] No more horizontal-rule lines between sections
- [ ] Section spacing is consistent top-to-bottom