### PR TITLE
feat: palette polish — ranking, fuzzy, contrast (v0.4.29)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.4.27",
+  "version": "0.4.29",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "workroot"
-version = "0.4.27"
+version = "0.4.29"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.4.27"
+version = "0.4.29"
 edition = "2021"
 authors = ["Saurav Panda <saurav@workroot.dev>"]
 description = "A local-first developer workspace for managing projects, terminals, and Git workflows."

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.4.27",
+  "version": "0.4.29",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -228,12 +228,20 @@ function AppContent({
 
   // Build commands from current app state
   const commands: Command[] = useMemo(() => {
+    // True when the user is currently on the Agents view (no project
+    // selected and not in settings). Used to demote "Go Home" since
+    // it's a no-op there. #509.
+    const onHome = !showSettings && !selectedWorktreePath;
+
     const cmds: Command[] = [
       {
         id: "nav:home",
         label: "Go Home",
         category: "Navigation",
         icon: "\u2302",
+        // Sink "Go Home" below other commands when already home \u2014
+        // priority 100 puts it past every default-0 command.
+        priority: onHome ? 100 : 0,
         action: () => {
           setShowSettings(false);
           setSelectedWorktreeId(null);

--- a/src/hooks/useCommandRegistry.ts
+++ b/src/hooks/useCommandRegistry.ts
@@ -8,6 +8,10 @@ export interface Command {
   icon?: string;
   action: () => void;
   enabled?: () => boolean;
+  /** Lower = ranks higher in empty-query results + ties. Defaults
+   *  to 0. Used by the App to demote commands that don't apply to
+   *  the current view (e.g. "Go Home" while already home). #509. */
+  priority?: number;
 }
 
 interface CommandRegistryState {
@@ -66,44 +70,63 @@ export function useCommandRegistry() {
     (query: string): Command[] => {
       const q = query.toLowerCase().trim();
       if (!q) {
-        // Return recent commands first, then all
+        // Return recent commands first, then all, sorted by priority
+        // (lower = higher) within each group.
+        const byPrio = (a: Command, b: Command) =>
+          (a.priority ?? 0) - (b.priority ?? 0);
         const recentCmds = state.recentIds
           .map((id) => state.commands.find((c) => c.id === id))
-          .filter((c): c is Command => c !== undefined);
-        const rest = state.commands.filter(
-          (c) => !state.recentIds.includes(c.id),
-        );
+          .filter((c): c is Command => c !== undefined)
+          .sort(byPrio);
+        const rest = state.commands
+          .filter((c) => !state.recentIds.includes(c.id))
+          .sort(byPrio);
         return [...recentCmds, ...rest].filter(
           (c) => !c.enabled || c.enabled(),
         );
       }
 
-      return state.commands
-        .filter((c) => {
-          if (c.enabled && !c.enabled()) return false;
-          const haystack = `${c.label} ${c.category} ${c.id}`.toLowerCase();
-          // Fuzzy: all query chars appear in order
-          let hi = 0;
-          for (const ch of q) {
-            const idx = haystack.indexOf(ch, hi);
-            if (idx === -1) return false;
-            hi = idx + 1;
-          }
-          return true;
-        })
-        .sort((a, b) => {
-          const aLabel = a.label.toLowerCase();
-          const bLabel = b.label.toLowerCase();
-          // Prefer starts-with matches
-          const aStarts = aLabel.startsWith(q) ? 0 : 1;
-          const bStarts = bLabel.startsWith(q) ? 0 : 1;
-          if (aStarts !== bStarts) return aStarts - bStarts;
-          // Then prefer contains
-          const aContains = aLabel.includes(q) ? 0 : 1;
-          const bContains = bLabel.includes(q) ? 0 : 1;
-          if (aContains !== bContains) return aContains - bContains;
-          return aLabel.localeCompare(bLabel);
-        });
+      // Pass 1: collect substring-only matches (label or category
+      // contains the query). These are unambiguous and stand alone.
+      // Pass 2: only fall back to scattered-fuzzy matches when pass 1
+      // returned nothing — keeps "Settings" from dragging in commands
+      // that only match because the letters appear in any order. #510.
+      const enabled = state.commands.filter((c) => !c.enabled || c.enabled());
+      const sub = enabled.filter((c) => {
+        const hay = `${c.label} ${c.category}`.toLowerCase();
+        return hay.includes(q);
+      });
+      const pool =
+        sub.length > 0
+          ? sub
+          : enabled.filter((c) => {
+              const haystack = `${c.label} ${c.category} ${c.id}`.toLowerCase();
+              let hi = 0;
+              for (const ch of q) {
+                const idx = haystack.indexOf(ch, hi);
+                if (idx === -1) return false;
+                hi = idx + 1;
+              }
+              return true;
+            });
+
+      return pool.sort((a, b) => {
+        const aLabel = a.label.toLowerCase();
+        const bLabel = b.label.toLowerCase();
+        // Prefer starts-with matches
+        const aStarts = aLabel.startsWith(q) ? 0 : 1;
+        const bStarts = bLabel.startsWith(q) ? 0 : 1;
+        if (aStarts !== bStarts) return aStarts - bStarts;
+        // Then prefer label-contains over category-only contains
+        const aContains = aLabel.includes(q) ? 0 : 1;
+        const bContains = bLabel.includes(q) ? 0 : 1;
+        if (aContains !== bContains) return aContains - bContains;
+        // Then priority (lower wins)
+        const aPrio = a.priority ?? 0;
+        const bPrio = b.priority ?? 0;
+        if (aPrio !== bPrio) return aPrio - bPrio;
+        return aLabel.localeCompare(bLabel);
+      });
     },
     [state.commands, state.recentIds],
   );

--- a/src/styles/command-palette.css
+++ b/src/styles/command-palette.css
@@ -155,10 +155,20 @@
   outline: none;
 }
 
-.cmd-palette-item:hover,
-.cmd-palette-item-active {
+/* Hover gets a subtle muted background — non-committal preview that
+ * a click here will fire something. */
+.cmd-palette-item:hover {
   background-color: var(--accent-muted);
   color: var(--text-primary);
+}
+
+/* Active (keyboard cursor / will-fire-on-Enter) is unmistakable:
+ * solid accent fill with high-contrast text. Codex flagged the old
+ * muted-green treatment as reading like "disabled". #511. */
+.cmd-palette-item-active,
+.cmd-palette-item-active:hover {
+  background-color: var(--color-accent, var(--accent));
+  color: var(--color-bg, var(--bg-base));
 }
 
 .cmd-palette-item-icon {


### PR DESCRIPTION
Closes #509, #510, #511.

## Summary
- **#509** Commands gain an optional \`priority?: number\`. When the user is already on the Agents view, \`Go Home\` is bumped to priority 100 so it sinks below the actually-useful commands in the empty palette and in tied search results.
- **#510** Search no longer mixes substring and scattered-fuzzy matches. If at least one command's label/category contains the query as a substring, only substring matches show. Fuzzy is the fallback when nothing else matches. Typing \`Settings\` no longer drags in commands whose letters appear in random order.
- **#511** Selected palette row uses the solid accent color with high-contrast text instead of the old muted-green fill (codex flagged it as reading like \"disabled\"). Hover keeps the soft \`accent-muted\` treatment so hover ≠ active.

## Test plan
- [ ] Open Cmd+P on the Agents view with no query → \`Go Home\` is not the first result
- [ ] Type \`Settings\` → results contain \`Open Settings\` and don't include unrelated commands
- [ ] Type \`mach\` → \`Machines\` still appears (substring intact)
- [ ] Arrow keys → the highlighted row is unambiguously the active one