### PR TITLE
feat: Machines panel polish — lighter empty state + clearer form (v0.4.32)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workroot",
   "private": true,
-  "version": "0.4.31",
+  "version": "0.4.32",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "workroot"
-version = "0.4.31"
+version = "0.4.32"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workroot"
-version = "0.4.31"
+version = "0.4.32"
 edition = "2021"
 authors = ["Saurav Panda <saurav@workroot.dev>"]
 description = "A local-first developer workspace for managing projects, terminals, and Git workflows."

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui/nicegui/main/.nicegui/schema/tauri-conf.json",
   "productName": "Workroot",
-  "version": "0.4.31",
+  "version": "0.4.32",
   "identifier": "com.workroot.dev",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/components/HelmMachinesPanel.tsx
+++ b/src/components/HelmMachinesPanel.tsx
@@ -187,9 +187,35 @@ export function HelmMachinesPanel({ onClose }: HelmMachinesPanelProps) {
           {loading ? (
             <p className="helm-machines__empty">Loading…</p>
           ) : machines.length === 0 ? (
-            <p className="helm-machines__empty">
-              No machines yet. Add one below or discover via Tailscale.
-            </p>
+            // Lighter empty row + inline quick actions instead of the
+            // big dashed block (#512).
+            <div className="helm-machines__empty-row">
+              <span className="helm-machines__empty-label">
+                No machines configured
+              </span>
+              <div className="helm-machines__empty-actions">
+                <button
+                  type="button"
+                  className="helm-machines__btn"
+                  onClick={() => {
+                    setNewLabel("Local");
+                    setNewBaseUrl("http://127.0.0.1:8421");
+                    setNewToken("");
+                  }}
+                  title="Pre-fill the form with the conventional local daemon address"
+                >
+                  Add local
+                </button>
+                <button
+                  type="button"
+                  className="helm-machines__btn"
+                  onClick={() => void discover()}
+                  disabled={discovering}
+                >
+                  {discovering ? "Probing…" : "Discover Tailscale"}
+                </button>
+              </div>
+            </div>
           ) : (
             machines.map((m) => (
               <div
@@ -285,21 +311,22 @@ export function HelmMachinesPanel({ onClose }: HelmMachinesPanelProps) {
         <div className="helm-machines__form">
           <input
             type="text"
-            placeholder="Label (e.g. Work MBP)"
+            placeholder="Label (e.g. Local, Work MBP)"
             value={newLabel}
             onChange={(e) => setNewLabel(e.target.value)}
           />
           <input
             type="text"
-            placeholder="Base URL (e.g. http://10.0.0.1:8421)"
+            placeholder="http://127.0.0.1:8421 (or http://10.0.0.1:8421)"
             value={newBaseUrl}
             onChange={(e) => setNewBaseUrl(e.target.value)}
           />
           <input
             type="password"
-            placeholder="Bearer token (optional)"
+            placeholder="Bearer token — optional, leave blank for unauthenticated daemons"
             value={newToken}
             onChange={(e) => setNewToken(e.target.value)}
+            className="helm-machines__form-optional"
             style={{ gridColumn: "1 / -1" }}
           />
           <div className="helm-machines__form-row">

--- a/src/styles/helm-machines.css
+++ b/src/styles/helm-machines.css
@@ -199,3 +199,44 @@
   border: 1px dashed var(--color-border, #2a2a2a);
   border-radius: 6px;
 }
+
+/* Lighter empty state — one row, label on the left, quick actions
+ * on the right. Replaces the dashed-border block for the
+ * no-machines-yet case (#512). */
+.helm-machines__empty-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  font-size: 13px;
+  color: var(--color-text-secondary, #888);
+  border: 1px solid var(--color-border, #2a2a2a);
+  border-radius: 6px;
+}
+
+.helm-machines__empty-label {
+  flex: 1 1 auto;
+}
+
+.helm-machines__empty-actions {
+  display: flex;
+  gap: 6px;
+  flex: 0 0 auto;
+}
+
+/* Bearer-token row reads as optional rather than required: muted
+ * border, slightly faded background. The "optional" placeholder
+ * carries the same message. */
+.helm-machines__form-optional {
+  border-color: var(--color-border-subtle, #1f252c) !important;
+  background: transparent !important;
+  color: var(--color-text-secondary, #888) !important;
+}
+.helm-machines__form-optional::placeholder {
+  color: var(--color-text-muted, #5c5c66);
+}
+.helm-machines__form-optional:focus {
+  border-color: var(--color-accent, #88b4ff) !important;
+  color: var(--color-text, #e4e4e4) !important;
+}


### PR DESCRIPTION
Closes #512. Final issue from the codex review batch.

## Summary
- **Empty state** drops the heavy dashed-border block in favor of a single compact row: \"No machines configured\" on the left, \`Add local\` (pre-fills the form with \`http://127.0.0.1:8421\`) and \`Discover Tailscale\` (kicks the existing probe) on the right.
- **Add-machine form**:
  - Base URL placeholder defaults to \`http://127.0.0.1:8421\` (with a remote example in the hint), instead of the previous random 10.x.
  - Bearer Token field gets visual demotion: muted border, transparent background, faded placeholder, and a verbose \`optional, leave blank for unauthenticated daemons\` hint so it stops reading as required.

## Test plan
- [ ] Open Machines panel with no machines configured → compact one-line row, not the dashed block
- [ ] Click \"Add local\" → form fields prefill with Label=Local, URL=127.0.0.1:8421
- [ ] Click \"Discover Tailscale\" → invokes the same probe as the standalone Discover button
- [ ] Form: URL field's placeholder reads localhost; Bearer Token reads as clearly optional